### PR TITLE
feat: include negRiskAdapter in prepareTradingApprovals

### DIFF
--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -186,6 +186,11 @@ export type PrepareTradingApprovalsError = UserInputError;
 /**
  * Starts a trading-setup approval workflow.
  *
+ * Prepares all approvals required for trading, including collateral and
+ * position token approvals for both standard and neg-risk market flows.
+ * The neg-risk adapter approvals cover split, merge, and redemption workflows
+ * on neg-risk markets.
+ *
  * @example
  * ```ts
  * const result = await prepareTradingApprovals(client).then(completeWith(walletClient));
@@ -208,6 +213,11 @@ export async function prepareTradingApprovals(
       client.environment.negRiskExchange,
       MAX_UINT256,
     ),
+    erc20ApprovalCall(
+      client.environment.collateralToken,
+      client.environment.negRiskAdapter,
+      MAX_UINT256,
+    ),
     erc1155ApprovalForAllCall(
       client.environment.conditionalTokens,
       client.environment.standardExchange,
@@ -216,6 +226,11 @@ export async function prepareTradingApprovals(
     erc1155ApprovalForAllCall(
       client.environment.conditionalTokens,
       client.environment.negRiskExchange,
+      true,
+    ),
+    erc1155ApprovalForAllCall(
+      client.environment.conditionalTokens,
+      client.environment.negRiskAdapter,
       true,
     ),
   ] as const;
@@ -232,13 +247,23 @@ export async function prepareTradingApprovals(
       );
       await collateralNegRiskApproval.wait();
 
+      const collateralNegRiskAdapterApproval = expectTransactionHandle(
+        yield sendErc20ApprovalTransaction(calls[2]),
+      );
+      await collateralNegRiskAdapterApproval.wait();
+
       const conditionalStandardApproval = expectTransactionHandle(
-        yield sendErc1155ApprovalForAllTransaction(calls[2]),
+        yield sendErc1155ApprovalForAllTransaction(calls[3]),
       );
       await conditionalStandardApproval.wait();
 
+      const conditionalNegRiskApproval = expectTransactionHandle(
+        yield sendErc1155ApprovalForAllTransaction(calls[4]),
+      );
+      await conditionalNegRiskApproval.wait();
+
       return expectTransactionHandle(
-        yield sendErc1155ApprovalForAllTransaction(calls[3]),
+        yield sendErc1155ApprovalForAllTransaction(calls[5]),
       );
     }
 


### PR DESCRIPTION
## Summary

- Adds ERC-20 collateral approval for `negRiskAdapter` (needed for split workflows, where the user pays collateral in)
- Adds ERC-1155 `setApprovalForAll` for `negRiskAdapter` on the conditional tokens contract (needed for merge and redeem workflows, where the adapter pulls conditional tokens from the user)
- Updates TSDoc on `prepareTradingApprovals` to document the full approval surface including neg-risk adapter flows

## Why

`prepareTradingApprovals` is the single setup call consumers run before trading. Without `negRiskAdapter` approvals, split/merge/redeem on neg-risk markets would silently fail due to missing allowances, requiring ad hoc out-of-band approval handling.

Closes DEV-31.

## Reviewer notes

- Both EOA and gasless paths are covered: the gasless path picks up the new calls automatically via `[...calls]`; the EOA path gets two new sequential `yield`/`wait` steps
- The `negRiskAdapter` address is already present in `EnvironmentConfig` and used by position workflows — no new addresses introduced
- `pnpm typecheck` and `pnpm lint` pass clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands unlimited token/operator approvals to an additional on-chain spender (`negRiskAdapter`) and adds extra approval transactions, which can impact user permissions and transaction flow ordering.
> 
> **Overview**
> `prepareTradingApprovals` now includes **additional approvals for `negRiskAdapter`**: an ERC-20 max allowance for the collateral token and an ERC-1155 `setApprovalForAll` for conditional tokens, so neg-risk split/merge/redeem flows are covered by the single setup call.
> 
> For EOA wallets, the workflow adds two extra sequential approval transactions (with `wait()` between steps) and adjusts the call ordering; gasless execution automatically picks up the new calls via the expanded `calls` list. Documentation on the function is updated to reflect the broader approval surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df0924f72f9a8e9be2878f53867b890d1265e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->