### PR TITLE
refactor: consolidate public error unions, standardize @throws TSDoc, and remove CancelError

### DIFF
--- a/packages/client/src/actions/account.ts
+++ b/packages/client/src/actions/account.ts
@@ -282,7 +282,7 @@ export type DropNotificationsError =
  * Drops notifications for the authenticated account.
  *
  * @throws {@link DropNotificationsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, cannot be signed, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -335,7 +335,7 @@ export type FetchBalanceAllowanceError =
  * This is a low-level action that most SDK consumers will not need.
  *
  * @throws {@link FetchBalanceAllowanceError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, cannot be signed, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/activity.ts
+++ b/packages/client/src/actions/activity.ts
@@ -82,7 +82,7 @@ export type ListTradesError =
  * Lists trades for a wallet, market, or event.
  *
  * @throws {@link ListTradesError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -120,7 +120,7 @@ export type ListActivityError =
  * Lists wallet activity.
  *
  * @throws {@link ListActivityError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -62,7 +62,7 @@ export type PrepareErc20ApprovalError = UserInputError;
  * ```
  *
  * @throws {@link PrepareErc20ApprovalError}
- * Thrown when the request is invalid.
+ * Thrown on failure.
  */
 export async function prepareErc20Approval(
   client: SecureClient,
@@ -131,7 +131,7 @@ export type PrepareErc1155ApprovalForAllError = UserInputError;
  * ```
  *
  * @throws {@link PrepareErc1155ApprovalForAllError}
- * Thrown when the request is invalid.
+ * Thrown on failure.
  */
 export async function prepareErc1155ApprovalForAll(
   client: SecureClient,
@@ -197,7 +197,7 @@ export type PrepareTradingApprovalsError = UserInputError;
  * ```
  *
  * @throws {@link PrepareTradingApprovalsError}
- * Thrown when the request is invalid.
+ * Thrown on failure.
  */
 export async function prepareTradingApprovals(
   client: SecureClient,

--- a/packages/client/src/actions/auth.ts
+++ b/packages/client/src/actions/auth.ts
@@ -45,7 +45,7 @@ export type CreateApiKeyError =
  * ```
  *
  * @throws {@link CreateApiKeyError}
- * Thrown when the request is rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function createApiKey(
   client: Client,
@@ -78,7 +78,7 @@ export type DeriveApiKeyError =
  * ```
  *
  * @throws {@link DeriveApiKeyError}
- * Thrown when the request is rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function deriveApiKey(
   client: Client,
@@ -111,7 +111,7 @@ export type CreateOrDeriveApiKeyError =
  * ```
  *
  * @throws {@link CreateOrDeriveApiKeyError}
- * Thrown when the request is rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function createOrDeriveApiKey(
   client: Client,
@@ -147,7 +147,7 @@ export type FetchApiKeysError =
  * ```
  *
  * @throws {@link FetchApiKeysError}
- * Thrown when request signing fails, or the request is rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function fetchApiKeys(client: SecureClient): Promise<ApiKey[]> {
   const response = await unwrap(

--- a/packages/client/src/actions/builders.ts
+++ b/packages/client/src/actions/builders.ts
@@ -40,7 +40,7 @@ export type ListBuilderTradesError =
  * Lists builder-attributed trades.
  *
  * @throws {@link ListBuilderTradesError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -57,7 +57,7 @@ export type FetchMidpointError =
  * Fetches the midpoint price for a token.
  *
  * @throws {@link FetchMidpointError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -107,7 +107,7 @@ export type FetchMidpointsError =
  * Fetches midpoint prices for multiple tokens.
  *
  * @throws {@link FetchMidpointsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -154,7 +154,7 @@ export type FetchTickSizeError =
  * Fetches the minimum price tick size for a token's order book.
  *
  * @throws {@link FetchTickSizeError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -199,7 +199,7 @@ export type FetchNegRiskError =
  * Fetches whether a token is in a negative-risk market.
  *
  * @throws {@link FetchNegRiskError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -244,7 +244,7 @@ export type FetchFeeRateError =
  * Fetches the base fee rate, in basis points, for a token's order book.
  *
  * @throws {@link FetchFeeRateError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -290,7 +290,7 @@ export type FetchPriceError =
  * Fetches the current quoted price for a token and side.
  *
  * @throws {@link FetchPriceError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -342,7 +342,7 @@ export type FetchPricesError =
  * Fetches quoted prices for multiple tokens.
  *
  * @throws {@link FetchPricesError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -390,7 +390,7 @@ export type FetchOrderBookError =
  * Fetches the current order book for a token.
  *
  * @throws {@link FetchOrderBookError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -440,7 +440,7 @@ export type FetchOrderBooksError =
  * Fetches order books for multiple tokens.
  *
  * @throws {@link FetchOrderBooksError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -486,7 +486,7 @@ export type FetchSpreadError =
  * Fetches the spread for a token.
  *
  * @throws {@link FetchSpreadError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -536,7 +536,7 @@ export type FetchSpreadsError =
  * Fetches spreads for multiple tokens.
  *
  * @throws {@link FetchSpreadsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -585,7 +585,7 @@ export type FetchLastTradePriceError =
  * Fetches the last traded price for a token.
  *
  * @throws {@link FetchLastTradePriceError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -636,7 +636,7 @@ export type FetchLastTradePricesError =
  * Fetches last traded prices for multiple tokens.
  *
  * @throws {@link FetchLastTradePricesError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -689,7 +689,7 @@ export type ListPriceHistoryError =
  * Lists historical price points for a token.
  *
  * @throws {@link ListPriceHistoryError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -747,7 +747,7 @@ export type ListCurrentRewardsError =
  * Lists current active market rewards.
  *
  * @throws {@link ListCurrentRewardsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -799,7 +799,7 @@ export type FetchMarketRewardsError =
  * Fetches reward configurations for a market.
  *
  * @throws {@link FetchMarketRewardsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/comments.ts
+++ b/packages/client/src/actions/comments.ts
@@ -59,7 +59,7 @@ export type ListCommentsError =
  * Lists comments for an event or series.
  *
  * @throws {@link ListCommentsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -98,7 +98,7 @@ export type FetchCommentsByIdError =
  * Fetches a comment thread by comment id.
  *
  * @throws {@link FetchCommentsByIdError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -141,7 +141,7 @@ export type FetchCommentsByUserAddressError =
  * Fetches comments written by a wallet address.
  *
  * @throws {@link FetchCommentsByUserAddressError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/events.ts
+++ b/packages/client/src/actions/events.ts
@@ -118,7 +118,7 @@ export type ListEventsError =
  * Lists events.
  *
  * @throws {@link ListEventsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -156,7 +156,7 @@ export type FetchEventError =
  * Fetches an event.
  *
  * @throws {@link FetchEventError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -203,7 +203,7 @@ export type FetchEventTagsError =
  * Fetches an event's tags.
  *
  * @throws {@link FetchEventTagsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -238,7 +238,7 @@ export type FetchEventLiveVolumeError =
  * Fetches live volume for an event.
  *
  * @throws {@link FetchEventLiveVolumeError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -102,7 +102,7 @@ export type FetchExecuteParamsError =
  * This is a low-level action that most SDK consumers will not need.
  *
  * @throws {@link FetchExecuteParamsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function fetchExecuteParams(
   client: Client,
@@ -147,7 +147,7 @@ export type IsGaslessReadyError =
  * Checks whether a wallet is ready for gasless transactions.
  *
  * @throws {@link IsGaslessReadyError}
- * Thrown when the readiness check is rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function isGaslessReady(
   client: Client,
@@ -191,7 +191,7 @@ export type PrepareGaslessWalletError =
  * Starts preparing the wallet for gasless transactions.
  *
  * @throws {@link PrepareGaslessWalletError}
- * Thrown when the wallet is already ready, cannot be prepared through this flow, or the request is rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function prepareGaslessWallet(
   client: Client,
@@ -256,7 +256,7 @@ export async function prepareGaslessWallet(
  * This is a low-level action that most SDK consumers will not need.
  *
  * @throws {@link FetchGaslessTransactionError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function fetchTransaction(
   client: Client,
@@ -318,7 +318,7 @@ export type PrepareGaslessTransactionError =
  * This is a low-level action that most SDK consumers will not need.
  *
  * @throws {@link PrepareGaslessTransactionError}
- * Thrown when the request is invalid, unsupported for the current account, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  */
 export async function prepareGaslessTransaction(
   client: SecureClient,

--- a/packages/client/src/actions/leaderboards.ts
+++ b/packages/client/src/actions/leaderboards.ts
@@ -64,7 +64,7 @@ export type ListBuilderLeaderboardError =
  * Lists builder leaderboard rankings.
  *
  * @throws {@link ListBuilderLeaderboardError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -102,7 +102,7 @@ export type ListBuilderVolumeError =
  * Lists daily builder volume entries.
  *
  * @throws {@link ListBuilderVolumeError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -139,7 +139,7 @@ export type ListTraderLeaderboardError =
  * Lists trader leaderboard rankings.
  *
  * @throws {@link ListTraderLeaderboardError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -144,7 +144,7 @@ export type ListMarketsError =
  * Lists markets.
  *
  * @throws {@link ListMarketsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -182,7 +182,7 @@ export type FetchMarketError =
  * Fetches a market.
  *
  * @throws {@link FetchMarketError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -217,7 +217,7 @@ export type FetchMarketTagsError =
  * Fetches a market's tags.
  *
  * @throws {@link FetchMarketTagsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -252,7 +252,7 @@ export type ListMarketHoldersError =
  * Lists the top holders for one or more markets.
  *
  * @throws {@link ListMarketHoldersError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -290,7 +290,7 @@ export type ListOpenInterestError =
  * Lists open interest for one or more markets.
  *
  * @throws {@link ListOpenInterestError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -327,7 +327,7 @@ export type ListMarketPositionsError =
  * Lists positions for a market.
  *
  * @throws {@link ListMarketPositionsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/orders/cancel.ts
+++ b/packages/client/src/actions/orders/cancel.ts
@@ -5,14 +5,13 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { SecureClient } from '../../clients';
-import {
-  CancelError,
-  type RateLimitError,
+import type {
+  RateLimitError,
   RequestRejectedError,
-  type SigningError,
-  type TransportError,
-  type UnexpectedResponseError,
-  type UserInputError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
 } from '../../errors';
 import { parseUserInput } from '../../input';
 import { validateWith } from '../../response';
@@ -41,7 +40,7 @@ const CancelMarketOrdersRequestSchema = z
 export type CancelOrderRequest = z.input<typeof CancelOrderRequestSchema>;
 
 export type CancelOrderError =
-  | CancelError
+  | RequestRejectedError
   | RateLimitError
   | SigningError
   | TransportError
@@ -67,7 +66,7 @@ export async function cancelOrder(
 
 export type CancelOrdersRequest = z.input<typeof CancelOrdersRequestSchema>;
 export type CancelOrdersError =
-  | CancelError
+  | RequestRejectedError
   | RateLimitError
   | SigningError
   | TransportError
@@ -90,7 +89,7 @@ export async function cancelOrders(
 }
 
 export type CancelAllError =
-  | CancelError
+  | RequestRejectedError
   | RateLimitError
   | SigningError
   | TransportError
@@ -112,7 +111,7 @@ export type CancelMarketOrdersRequest = z.input<
   typeof CancelMarketOrdersRequestSchema
 >;
 export type CancelMarketOrdersError =
-  | CancelError
+  | RequestRejectedError
   | RateLimitError
   | SigningError
   | TransportError
@@ -147,15 +146,6 @@ async function cancel(
     client.secureClob
       .del(path, {
         json: payload,
-      })
-      .mapErr((error) => {
-        if (!(error instanceof RequestRejectedError)) {
-          return error;
-        }
-
-        return new CancelError(error.message, {
-          cause: error,
-        });
       })
       .andThen(validateWith(CancelOrdersResponseSchema)),
   );

--- a/packages/client/src/actions/orders/cancel.ts
+++ b/packages/client/src/actions/orders/cancel.ts
@@ -40,21 +40,19 @@ const CancelMarketOrdersRequestSchema = z
 
 export type CancelOrderRequest = z.input<typeof CancelOrderRequestSchema>;
 
-type CancelRequestError =
+export type CancelOrderError =
+  | CancelError
   | RateLimitError
   | SigningError
   | TransportError
-  | UnexpectedResponseError;
-
-export type CancelOrderError =
-  | CancelError
-  | CancelRequestError
+  | UnexpectedResponseError
   | UserInputError;
 
 /**
  * Cancels a single open order for the authenticated account.
  *
  * @throws {@link CancelOrderError}
+ * Thrown on failure.
  */
 export async function cancelOrder(
   client: SecureClient,
@@ -70,13 +68,17 @@ export async function cancelOrder(
 export type CancelOrdersRequest = z.input<typeof CancelOrdersRequestSchema>;
 export type CancelOrdersError =
   | CancelError
-  | CancelRequestError
+  | RateLimitError
+  | SigningError
+  | TransportError
+  | UnexpectedResponseError
   | UserInputError;
 
 /**
  * Cancels multiple open orders for the authenticated account.
  *
  * @throws {@link CancelOrdersError}
+ * Thrown on failure.
  */
 export async function cancelOrders(
   client: SecureClient,
@@ -87,12 +89,18 @@ export async function cancelOrders(
   return cancel(client, '/orders', params.orderIds);
 }
 
-export type CancelAllError = CancelError | CancelRequestError;
+export type CancelAllError =
+  | CancelError
+  | RateLimitError
+  | SigningError
+  | TransportError
+  | UnexpectedResponseError;
 
 /**
  * Cancels all open orders for the authenticated account.
  *
  * @throws {@link CancelAllError}
+ * Thrown on failure.
  */
 export async function cancelAll(
   client: SecureClient,
@@ -105,7 +113,10 @@ export type CancelMarketOrdersRequest = z.input<
 >;
 export type CancelMarketOrdersError =
   | CancelError
-  | CancelRequestError
+  | RateLimitError
+  | SigningError
+  | TransportError
+  | UnexpectedResponseError
   | UserInputError;
 
 /**
@@ -113,6 +124,7 @@ export type CancelMarketOrdersError =
  * or asset filter.
  *
  * @throws {@link CancelMarketOrdersError}
+ * Thrown on failure.
  */
 export async function cancelMarketOrders(
   client: SecureClient,

--- a/packages/client/src/actions/orders/estimate.ts
+++ b/packages/client/src/actions/orders/estimate.ts
@@ -66,9 +66,7 @@ export type EstimateMarketPriceError =
  * ```
  *
  * @throws {@link EstimateMarketPriceError}
- * Thrown when the request is invalid, market data cannot be fetched or
- * validated, or the current order book cannot satisfy the requested execution
- * semantics.
+ * Thrown on failure.
  */
 export async function estimateMarketPrice(
   client: Client,

--- a/packages/client/src/actions/orders/post.ts
+++ b/packages/client/src/actions/orders/post.ts
@@ -30,7 +30,13 @@ export type PostOrderError =
   | TransportError
   | UnexpectedResponseError;
 
-export type PostOrdersError = PostOrderError | UserInputError;
+export type PostOrdersError =
+  | RateLimitError
+  | RequestRejectedError
+  | SigningError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
 
 /**
  * Posts a signed order for the authenticated account.
@@ -41,6 +47,7 @@ export type PostOrdersError = PostOrderError | UserInputError;
  * ```
  *
  * @throws {@link PostOrderError}
+ * Thrown on failure.
  */
 export function postOrder(
   client: SecureClient,
@@ -79,6 +86,7 @@ export function postOrder(client: SecureClient, order?: SignedOrder) {
  * ```
  *
  * @throws {@link PostOrdersError}
+ * Thrown on failure.
  */
 export function postOrders(
   client: SecureClient,

--- a/packages/client/src/actions/orders/prepare.ts
+++ b/packages/client/src/actions/orders/prepare.ts
@@ -51,8 +51,7 @@ export type PrepareMarketOrderError =
  * Starts the market-order workflow.
  *
  * @throws {@link PrepareMarketOrderError}
- * Thrown when the request is invalid, required market or allowance data cannot
- * be fetched, or the current order book cannot satisfy the requested fill.
+ * Thrown on failure.
  */
 export async function prepareMarketOrder(
   client: SecureClient,
@@ -87,8 +86,7 @@ export type PrepareLimitOrderError =
  * Starts the limit-order workflow.
  *
  * @throws {@link PrepareLimitOrderError}
- * Thrown when the request is invalid, required market or allowance data cannot
- * be fetched, or signing prerequisites cannot be resolved.
+ * Thrown on failure.
  */
 export async function prepareLimitOrder(
   client: SecureClient,

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -117,7 +117,7 @@ export type ListPositionsError =
  * Lists current positions for a wallet.
  *
  * @throws {@link ListPositionsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -155,7 +155,7 @@ export type ListClosedPositionsError =
  * Lists closed positions for a wallet.
  *
  * @throws {@link ListClosedPositionsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -193,7 +193,7 @@ export type FetchPortfolioValueError =
  * Fetches the total value for a wallet's positions.
  *
  * @throws {@link FetchPortfolioValueError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -230,7 +230,7 @@ export type FetchTradedMarketCountError =
  * Fetches the total number of markets a wallet has traded.
  *
  * @throws {@link FetchTradedMarketCountError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -267,7 +267,7 @@ export type DownloadAccountingSnapshotError =
  * Downloads an accounting snapshot archive for a wallet.
  *
  * @throws {@link DownloadAccountingSnapshotError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -17,7 +17,13 @@ import {
   splitPositionCall,
 } from '../abis';
 import type { SecureClient } from '../clients';
-import { UserInputError } from '../errors';
+import {
+  type RateLimitError,
+  type RequestRejectedError,
+  type TransportError,
+  type UnexpectedResponseError,
+  UserInputError,
+} from '../errors';
 import { parseUserInput } from '../input';
 import {
   expectTransactionHandle,
@@ -30,7 +36,7 @@ import {
   prepareGaslessTransaction,
 } from './gasless';
 import { listMarkets } from './markets';
-import { type ListPositionsError, listPositions } from './portfolio';
+import { listPositions } from './portfolio';
 
 type BinaryPositions = readonly [
   yes: Position | undefined,
@@ -114,8 +120,18 @@ export type PrepareRedeemPositionsRequest = z.input<
 >;
 
 export type PrepareSplitPositionError = UserInputError;
-export type PrepareMergePositionsError = ListPositionsError;
-export type PrepareRedeemPositionsError = ListPositionsError;
+export type PrepareMergePositionsError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export type PrepareRedeemPositionsError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
 
 /**
  * Starts a split workflow for a market condition.
@@ -130,7 +146,7 @@ export type PrepareRedeemPositionsError = ListPositionsError;
  * ```
  *
  * @throws {@link PrepareSplitPositionError}
- * Thrown when the request is invalid or the environment does not support the requested split flow.
+ * Thrown on failure.
  */
 export async function prepareSplitPosition(
   client: SecureClient,
@@ -176,7 +192,7 @@ export async function prepareSplitPosition(
  * ```
  *
  * @throws {@link PrepareMergePositionsError}
- * Thrown when the request is invalid, when the market positions cannot satisfy the requested merge amount, or when the workflow cannot be prepared.
+ * Thrown on failure.
  */
 export async function prepareMergePositions(
   client: SecureClient,
@@ -232,7 +248,7 @@ export async function prepareMergePositions(
  * ```
  *
  * @throws {@link PrepareRedeemPositionsError}
- * Thrown when the request is invalid or the environment does not support the requested redemption flow.
+ * Thrown on failure.
  */
 export async function prepareRedeemPositions(
   client: SecureClient,

--- a/packages/client/src/actions/profiles.ts
+++ b/packages/client/src/actions/profiles.ts
@@ -35,7 +35,7 @@ export type FetchPublicProfileError =
  * Fetches a public profile by wallet address.
  *
  * @throws {@link FetchPublicProfileError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/search.ts
+++ b/packages/client/src/actions/search.ts
@@ -49,7 +49,7 @@ export type SearchError =
  * Runs a public full-text search.
  *
  * @throws {@link SearchError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/series.ts
+++ b/packages/client/src/actions/series.ts
@@ -53,7 +53,7 @@ export type ListSeriesError =
  * Lists series.
  *
  * @throws {@link ListSeriesError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -97,7 +97,7 @@ export type FetchSeriesError =
  * Fetches a series.
  *
  * @throws {@link FetchSeriesError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/sports.ts
+++ b/packages/client/src/actions/sports.ts
@@ -24,7 +24,7 @@ export type ListSportsError =
  * Lists available sports metadata.
  *
  * @throws {@link ListSportsError}
- * Thrown when the request is rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -51,7 +51,7 @@ export type FetchSportsMarketTypesError =
  * Fetches the available market types grouped by sport.
  *
  * @throws {@link FetchSportsMarketTypesError}
- * Thrown when the request is rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/tags.ts
+++ b/packages/client/src/actions/tags.ts
@@ -88,7 +88,7 @@ export type ListTagsError =
  * Lists tags.
  *
  * @throws {@link ListTagsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -126,7 +126,7 @@ export type FetchTagError =
  * Fetches a tag by id or slug.
  *
  * @throws {@link FetchTagError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -186,7 +186,7 @@ export type FetchRelatedTagsError =
  * Fetches related tag relationships by id or slug.
  *
  * @throws {@link FetchRelatedTagsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts
@@ -241,7 +241,7 @@ export type FetchRelatedTagResourcesError =
  * Fetches resources linked from related tag relationships by id or slug.
  *
  * @throws {@link FetchRelatedTagResourcesError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/teams.ts
+++ b/packages/client/src/actions/teams.ts
@@ -37,7 +37,7 @@ export type ListTeamsError =
  * Lists teams.
  *
  * @throws {@link ListTeamsError}
- * Thrown when the request is invalid, rejected, rate limited, interrupted by transport issues, or returns an unexpected response.
+ * Thrown on failure.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/transfers.ts
+++ b/packages/client/src/actions/transfers.ts
@@ -58,7 +58,7 @@ export type PrepareErc20TransferError = UserInputError;
  * ```
  *
  * @throws {@link PrepareErc20TransferError}
- * Thrown when the request is invalid.
+ * Thrown on failure.
  */
 export async function prepareErc20Transfer(
   client: SecureClient,

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -119,23 +119,6 @@ export class TransactionFailedError extends PolymarketError {
 }
 
 /**
- * Error thrown when the SDK cannot complete a cancel request.
- */
-export class CancelError extends PolymarketError {
-  override name = 'CancelError' as const;
-
-  constructor(message: string, options: ErrorOptions = {}) {
-    super(message, options);
-  }
-
-  static fromError(error: Error): CancelError {
-    return new CancelError(error.message, {
-      cause: error,
-    });
-  }
-}
-
-/**
  * Error thrown when the user cancels a required wallet signing action.
  */
 export class CancelledSigningError extends PolymarketError {


### PR DESCRIPTION
## Summary

- **Flatten intermediate alias unions** in exported action-level error types:
  - `CancelRequestError` (non-exported internal alias) removed from `cancel.ts`; `CancelOrderError`, `CancelOrdersError`, `CancelAllError`, and `CancelMarketOrdersError` now list concrete types directly
  - `PostOrdersError` no longer references `PostOrderError`; concrete types listed
  - `PrepareMergePositionsError` and `PrepareRedeemPositionsError` no longer alias `ListPositionsError`; concrete types imported from `errors.ts` directly
- **Standardize `@throws` sentences** across all `@polymarket/client` actions to the short generic form `Thrown on failure.` — replacing verbose per-action enumerations and filling in missing sentences
- **Remove `CancelError`** from `errors.ts` and expose `RequestRejectedError` directly from cancel actions — `CancelError` wrapped `RequestRejectedError` but stripped the `status` code, making it strictly less useful for consumer control flow

## Why

Public `*Error` exports built from intermediate alias unions are harder to read in generated docs and IDE hovers. `@throws` sentences were inconsistent across actions. `CancelError` added no value over `RequestRejectedError` and dropped useful information.

No runtime behavior changes beyond removing the `CancelError` → `RequestRejectedError` remapping in cancel actions.

Closes DEV-15.

## Reviewer notes

- 24 files changed; all type-level and documentation cleanup
- `CancelError` was never exported from the public index, so this is not a breaking change for external consumers
- `pnpm typecheck` and `pnpm lint` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)