### PR TITLE
feat: refresh balance allowance cache after order approvals settle

### DIFF
--- a/packages/client/src/actions/orders/prepare.ts
+++ b/packages/client/src/actions/orders/prepare.ts
@@ -1,4 +1,4 @@
-import { OrderSide } from '@polymarket/bindings/clob';
+import { AssetType, OrderSide } from '@polymarket/bindings/clob';
 import {
   type EvmAddress,
   type EvmSignature,
@@ -16,6 +16,7 @@ import type {
 } from '../../errors';
 import { parseUserInput } from '../../input';
 import type { TransactionHandle } from '../../types';
+import { updateBalanceAllowance } from '../account';
 import {
   type Erc20ApprovalWorkflowRequest,
   type Erc1155ApprovalForAllWorkflowRequest,
@@ -140,4 +141,12 @@ async function* ensureOrderApproval(
         });
 
   await handle.wait();
+
+  await updateBalanceAllowance(client, {
+    assetType:
+      draft.side === OrderSide.BUY
+        ? AssetType.COLLATERAL
+        : AssetType.CONDITIONAL,
+    tokenId: draft.side === OrderSide.SELL ? draft.tokenId : undefined,
+  });
 }


### PR DESCRIPTION
## Summary

- Cherry-picks `updateBalanceAllowance()` from `main` (`0281f46`) into this branch so the action is available
- Wires it into `ensureOrderApproval()` in `prepare.ts` — called after `handle.wait()` confirms the approval transaction settled
- Refreshes `COLLATERAL` for buy orders; `CONDITIONAL` (with `tokenId`) for sell orders
- No-ops entirely when existing allowance is already sufficient (early return path is unchanged)

## Test plan

- [ ] Verify typecheck passes: `pnpm typecheck`
- [ ] Verify lint passes: `pnpm lint`
- [ ] Manual: place an order from a wallet with no prior approval and confirm the cache refresh fires after the approval tx confirms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the order-approval workflow and post-transaction behavior; a wrong asset type/tokenId mapping or extra network call could cause stale allowance handling or minor latency during order preparation.
> 
> **Overview**
> Ensures allowance state is refreshed immediately after an order approval transaction settles by calling `updateBalanceAllowance()` after `handle.wait()` in `ensureOrderApproval()`.
> 
> The refresh targets **collateral** for buy-side approvals and **conditional tokens** (including `tokenId`) for sell-side approvals, without changing the early-return path when allowance is already sufficient.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2096d003ed3a57dbd25bbbf0867d3eb748f2c3b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->