### PR TITLE
fix: remove flaky 400 assertion in dropNotifications test

### DIFF
--- a/packages/client/src/actions/account.test.ts
+++ b/packages/client/src/actions/account.test.ts
@@ -52,14 +52,6 @@ describe('Account', () => {
       const notifications = await fetchNotifications(secureClient);
 
       if (notifications.length === 0) {
-        await expect(
-          dropNotifications(secureClient, {
-            ids: ['0'],
-          }),
-        ).rejects.toMatchObject({
-          status: 400,
-        });
-
         return;
       }
 


### PR DESCRIPTION
## Summary

- The `dropNotifications` test expected a 400 when passing a bogus notification ID (`'0'`) with an empty account
- Investigation of the CLOB repo confirms the DELETE `/notifications` endpoint **always returns 200 OK** for non-existent IDs — it uses `INSERT INTO fe_notifications_read ... ON CONFLICT DO NOTHING`, so unknown IDs silently no-op
- A 400 is only returned when `ids` is missing or empty, not when IDs don't exist
- Fix skips the test when there are no notifications to drop rather than asserting an unreliable API behavior

## Test plan

- [ ] Run `pnpm test:client` — `dropNotifications` test should no longer flake

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only a client test to avoid asserting an API error status that may legitimately not occur, reducing flakiness without affecting runtime behavior.
> 
> **Overview**
> Removes the `dropNotifications` test assertion that a bogus notification ID returns `400` when the account has no notifications; the test now simply returns early in that situation.
> 
> This reduces flakiness by only exercising the happy path where real notification IDs exist and are verified to clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e352b0e590155de80974d7a38742d7e777ce0cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->