### PR TITLE
feat(client): add runtime isError guards to all public ...Error unions

### DIFF
--- a/packages/client/src/abis.ts
+++ b/packages/client/src/abis.ts
@@ -1,7 +1,7 @@
 import type { ConditionId } from '@polymarket/bindings';
 import { type EvmAddress, type HexString, invariant } from '@polymarket/types';
 import { AbiFunction, AbiParameters } from 'ox';
-import { UserInputError } from './errors';
+import { makeErrorGuard, UserInputError } from './errors';
 import type { TransactionCall } from './types';
 
 const ZERO_BYTES32 =
@@ -35,6 +35,7 @@ const BINARY_OUTCOME_INDEX_SETS = [1n, 2n] as const;
 export const MAX_UINT256 = (1n << 256n) - 1n;
 
 export type Erc20ApprovalCallError = UserInputError;
+export const Erc20ApprovalCallError = makeErrorGuard(UserInputError);
 
 /**
  * Creates a transaction call for `approve(address,uint256)` on an ERC-20 token.
@@ -76,6 +77,7 @@ export function erc1155ApprovalForAllCall(
 }
 
 export type Erc20TransferCallError = UserInputError;
+export const Erc20TransferCallError = makeErrorGuard(UserInputError);
 
 /**
  * Creates a transaction call for `transfer(address,uint256)` on an ERC-20 token.
@@ -103,8 +105,10 @@ export function erc20TransferCall(
 }
 
 export type CtfRedeemPositionsCallError = UserInputError;
+export const CtfRedeemPositionsCallError = makeErrorGuard(UserInputError);
 
 export type SplitPositionCallError = UserInputError;
+export const SplitPositionCallError = makeErrorGuard(UserInputError);
 
 /**
  * Creates a transaction call for `splitPosition(address,bytes32,bytes32,uint256[],uint256)`.
@@ -135,6 +139,7 @@ export function splitPositionCall(
 }
 
 export type MergePositionsCallError = UserInputError;
+export const MergePositionsCallError = makeErrorGuard(UserInputError);
 
 /**
  * Creates a transaction call for `mergePositions(address,bytes32,bytes32,uint256[],uint256)`.
@@ -186,6 +191,7 @@ export function ctfRedeemPositionsCall(
 }
 
 export type NegRiskRedeemPositionsCallError = UserInputError;
+export const NegRiskRedeemPositionsCallError = makeErrorGuard(UserInputError);
 
 /**
  * Creates a transaction call for `redeemPositions(bytes32,uint256[])` on the

--- a/packages/client/src/actions/account.ts
+++ b/packages/client/src/actions/account.ts
@@ -31,7 +31,8 @@ import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import { toSignatureType } from '../account';
 import type { BaseSecureClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   SigningError,
@@ -50,6 +51,13 @@ export type FetchClosedOnlyModeError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const FetchClosedOnlyModeError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Fetches whether the account is restricted to closed-only trading.
@@ -90,6 +98,14 @@ export type ListOpenOrdersError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListOpenOrdersError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists open orders for the authenticated account across all pages.
@@ -164,6 +180,14 @@ export type FetchOrderError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchOrderError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches a single order for the authenticated account.
@@ -214,6 +238,14 @@ export type ListAccountTradesError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListAccountTradesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists trades for the authenticated account across all pages.
@@ -282,6 +314,13 @@ export type FetchNotificationsError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const FetchNotificationsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 const DropNotificationsRequestSchema = z.object({
   ids: z.array(z.string()).min(1),
@@ -322,6 +361,14 @@ export type DropNotificationsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const DropNotificationsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Drops notifications for the authenticated account.
@@ -373,6 +420,14 @@ export type FetchBalanceAllowanceError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchBalanceAllowanceError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches balance and allowance for the authenticated account.
@@ -428,6 +483,14 @@ export type UpdateBalanceAllowanceError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const UpdateBalanceAllowanceError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Refreshes balance and allowance for the authenticated account.
@@ -482,6 +545,14 @@ export type FetchOrderScoringError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchOrderScoringError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches whether a single order is currently scoring.
@@ -525,6 +596,14 @@ export type FetchOrdersScoringError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchOrdersScoringError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches scoring state for multiple orders.
@@ -569,6 +648,14 @@ export type ListUserEarningsForDayError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListUserEarningsForDayError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists per-market earnings for the authenticated account on a given day.
@@ -649,6 +736,14 @@ export type FetchTotalEarningsForUserForDayError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchTotalEarningsForUserForDayError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches total earnings for the authenticated account on a given day.
@@ -703,6 +798,14 @@ export type ListUserEarningsAndMarketsConfigError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListUserEarningsAndMarketsConfigError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists market reward configuration and earnings for the authenticated account on a given day.
@@ -779,6 +882,13 @@ export type FetchRewardPercentagesError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const FetchRewardPercentagesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Fetches reward percentages for the authenticated account.

--- a/packages/client/src/actions/activity.ts
+++ b/packages/client/src/actions/activity.ts
@@ -9,7 +9,8 @@ import {
 } from '@polymarket/bindings/data';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -84,6 +85,13 @@ export type ListTradesError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListTradesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists trades for a wallet, market, or event.
@@ -164,6 +172,13 @@ export type ListActivityError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListActivityError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists wallet activity.

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -8,7 +8,7 @@ import {
   MAX_UINT256,
 } from '../abis';
 import type { BaseSecureClient } from '../clients';
-import type { UserInputError } from '../errors';
+import { makeErrorGuard, UserInputError } from '../errors';
 import { parseUserInput } from '../input';
 import { expectTransactionHandle, type TransactionHandle } from '../types';
 import type { SignerTransactionRequest } from '../workflow';
@@ -45,6 +45,7 @@ export type PrepareErc20ApprovalRequest = z.input<
 >;
 
 export type PrepareErc20ApprovalError = UserInputError;
+export const PrepareErc20ApprovalError = makeErrorGuard(UserInputError);
 
 /**
  * Starts an ERC-20 approval workflow.
@@ -121,6 +122,7 @@ export type PrepareErc1155ApprovalForAllRequest = z.input<
 >;
 
 export type PrepareErc1155ApprovalForAllError = UserInputError;
+export const PrepareErc1155ApprovalForAllError = makeErrorGuard(UserInputError);
 
 /**
  * Starts an ERC-1155 approval-for-all workflow.
@@ -192,6 +194,7 @@ export type TradingApprovalsWorkflow = AsyncGenerator<
 >;
 
 export type PrepareTradingApprovalsError = UserInputError;
+export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
 
 /**
  * Starts a trading-setup approval workflow.

--- a/packages/client/src/actions/auth.ts
+++ b/packages/client/src/actions/auth.ts
@@ -12,11 +12,12 @@ import { type EvmAddress, type EvmSignature, unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient, BaseSecureClient } from '../clients';
 import {
-  type RateLimitError,
+  makeErrorGuard,
+  RateLimitError,
   RequestRejectedError,
-  type SigningError,
-  type TransportError,
-  type UnexpectedResponseError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
 } from '../errors';
 import { validateWith } from '../response';
 
@@ -32,6 +33,12 @@ export type CreateApiKeyError =
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError;
+export const CreateApiKeyError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Creates a new API key from a signed L1 auth payload.
@@ -65,6 +72,12 @@ export type DeriveApiKeyError =
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError;
+export const DeriveApiKeyError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Derives an existing API key from a signed L1 auth payload.
@@ -98,6 +111,12 @@ export type CreateOrDeriveApiKeyError =
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError;
+export const CreateOrDeriveApiKeyError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Creates an API key and falls back to derivation when it already exists.
@@ -134,6 +153,13 @@ export type FetchApiKeysError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const FetchApiKeysError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Fetches all API keys associated with the authenticated client.
@@ -167,6 +193,13 @@ export type DeleteApiKeyError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const DeleteApiKeyError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Deletes the authenticated API key.
@@ -197,6 +230,13 @@ export type CreateBuilderApiKeyError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const CreateBuilderApiKeyError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Creates a new builder API key for the authenticated client.
@@ -229,6 +269,13 @@ export type FetchBuilderApiKeysError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const FetchBuilderApiKeysError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Fetches builder API keys associated with the authenticated client.
@@ -261,6 +308,13 @@ export type RevokeBuilderApiKeyError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const RevokeBuilderApiKeyError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Revokes a builder API key.

--- a/packages/client/src/actions/builders.ts
+++ b/packages/client/src/actions/builders.ts
@@ -9,7 +9,8 @@ import {
 } from '@polymarket/bindings/clob';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -41,6 +42,13 @@ export type ListBuilderTradesError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListBuilderTradesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists builder-attributed trades.

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -35,7 +35,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -59,6 +60,13 @@ export type FetchMidpointError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchMidpointError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the midpoint price for a token.
@@ -109,6 +117,13 @@ export type FetchMidpointsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchMidpointsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches midpoint prices for multiple tokens.
@@ -156,6 +171,13 @@ export type FetchTickSizeError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchTickSizeError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the minimum price tick size for a token's order book.
@@ -204,6 +226,13 @@ export type FetchNegRiskError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchNegRiskError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches whether a token is in a negative-risk market.
@@ -252,6 +281,13 @@ export type FetchFeeRateError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchFeeRateError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the base fee rate, in basis points, for a token's order book.
@@ -301,6 +337,13 @@ export type FetchPriceError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchPriceError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the current quoted price for a token and side.
@@ -353,6 +396,13 @@ export type FetchPricesError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchPricesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches quoted prices for multiple tokens.
@@ -401,6 +451,13 @@ export type FetchOrderBookError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchOrderBookError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the current order book for a token.
@@ -451,6 +508,13 @@ export type FetchOrderBooksError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchOrderBooksError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches order books for multiple tokens.
@@ -497,6 +561,13 @@ export type FetchSpreadError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchSpreadError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the spread for a token.
@@ -547,6 +618,13 @@ export type FetchSpreadsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchSpreadsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches spreads for multiple tokens.
@@ -596,6 +674,13 @@ export type FetchLastTradePriceError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchLastTradePriceError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the last traded price for a token.
@@ -647,6 +732,13 @@ export type FetchLastTradePricesError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchLastTradePricesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches last traded prices for multiple tokens.
@@ -700,6 +792,13 @@ export type FetchPriceHistoryError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchPriceHistoryError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches historical price points for a token.
@@ -759,6 +858,13 @@ export type ListCurrentRewardsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListCurrentRewardsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists current active market rewards.
@@ -840,6 +946,13 @@ export type ListMarketRewardsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListMarketRewardsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists reward configurations for a market.

--- a/packages/client/src/actions/comments.ts
+++ b/packages/client/src/actions/comments.ts
@@ -11,7 +11,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -67,6 +68,13 @@ export type ListCommentsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListCommentsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists comments for an event or series.
@@ -157,6 +165,13 @@ export type FetchCommentsByIdError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchCommentsByIdError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches a comment thread by comment id.
@@ -200,6 +215,13 @@ export type ListCommentsByUserAddressError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListCommentsByUserAddressError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists comments written by a wallet address.

--- a/packages/client/src/actions/events.ts
+++ b/packages/client/src/actions/events.ts
@@ -17,7 +17,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -115,6 +116,13 @@ export type ListEventsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListEventsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists events.
@@ -182,6 +190,13 @@ export type FetchEventError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchEventError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches an event.
@@ -229,6 +244,13 @@ export type FetchEventTagsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchEventTagsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches an event's tags.
@@ -264,6 +286,13 @@ export type FetchEventLiveVolumeError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchEventLiveVolumeError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches live volume for an event.

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -33,11 +33,12 @@ import { encodeSafeMultisendCall } from '../abis';
 import { deriveSafeWalletAddress } from '../account';
 import type { BaseClient, BaseSecureClient } from '../clients';
 import {
-  type RateLimitError,
-  type RequestRejectedError,
+  makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
   TimeoutError,
   TransactionFailedError,
-  type TransportError,
+  TransportError,
   UnexpectedResponseError,
   UserInputError,
 } from '../errors';
@@ -99,6 +100,13 @@ export type FetchExecuteParamsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchExecuteParamsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the parameters needed to prepare a low-level transaction submission.
@@ -147,6 +155,13 @@ export type IsGaslessReadyError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const IsGaslessReadyError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Checks whether a wallet is ready for gasless transactions.
@@ -193,6 +208,13 @@ export type PrepareGaslessWalletError =
   | ExecuteGaslessError
   | IsGaslessReadyError
   | UserInputError;
+export const PrepareGaslessWalletError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Starts preparing the wallet for gasless transactions.
@@ -321,6 +343,13 @@ export type PrepareGaslessTransactionError =
   | ExecuteGaslessError
   | FetchExecuteParamsError
   | UserInputError;
+export const PrepareGaslessTransactionError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Starts preparing a low-level transaction workflow from one or more calls.
@@ -564,6 +593,15 @@ export type WaitForGaslessTransactionError =
   | UserInputError
   | TimeoutError
   | TransactionFailedError;
+export const WaitForGaslessTransactionError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+  TimeoutError,
+  TransactionFailedError,
+);
 
 class GaslessTransactionHandle implements TransactionHandle {
   readonly #client: BaseClient;

--- a/packages/client/src/actions/leaderboards.ts
+++ b/packages/client/src/actions/leaderboards.ts
@@ -13,7 +13,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -67,6 +68,13 @@ export type ListBuilderLeaderboardError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListBuilderLeaderboardError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists builder leaderboard rankings.
@@ -147,6 +155,13 @@ export type ListBuilderVolumeError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListBuilderVolumeError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists daily builder volume entries.
@@ -184,6 +199,13 @@ export type ListTraderLeaderboardError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListTraderLeaderboardError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists trader leaderboard rankings.

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -20,7 +20,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -149,6 +150,13 @@ export type ListMarketsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListMarketsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists markets.
@@ -216,6 +224,13 @@ export type FetchMarketError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchMarketError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches a market.
@@ -251,6 +266,13 @@ export type FetchMarketTagsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchMarketTagsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches a market's tags.
@@ -286,6 +308,13 @@ export type ListMarketHoldersError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListMarketHoldersError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists the top holders for one or more markets.
@@ -324,6 +353,13 @@ export type ListOpenInterestError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListOpenInterestError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists open interest for one or more markets.
@@ -361,6 +397,13 @@ export type ListMarketPositionsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListMarketPositionsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists positions for a market.

--- a/packages/client/src/actions/orders/cancel.ts
+++ b/packages/client/src/actions/orders/cancel.ts
@@ -5,7 +5,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseSecureClient } from '../../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   SigningError,
@@ -46,6 +47,14 @@ export type CancelOrderError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const CancelOrderError = makeErrorGuard(
+  RequestRejectedError,
+  RateLimitError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Cancels a single open order for the authenticated account.
@@ -81,6 +90,14 @@ export type CancelOrdersError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const CancelOrdersError = makeErrorGuard(
+  RequestRejectedError,
+  RateLimitError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Cancels multiple open orders for the authenticated account.
@@ -112,6 +129,13 @@ export type CancelAllError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const CancelAllError = makeErrorGuard(
+  RequestRejectedError,
+  RateLimitError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Cancels all open orders for the authenticated account.
@@ -142,6 +166,14 @@ export type CancelMarketOrdersError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const CancelMarketOrdersError = makeErrorGuard(
+  RequestRejectedError,
+  RateLimitError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Cancels all open orders for the authenticated account that match the market

--- a/packages/client/src/actions/orders/estimate.ts
+++ b/packages/client/src/actions/orders/estimate.ts
@@ -10,11 +10,12 @@ import { z } from 'zod';
 import type { BaseClient } from '../../clients';
 import {
   InsufficientLiquidityError,
-  type RateLimitError,
-  type RequestRejectedError,
-  type TransportError,
-  type UnexpectedResponseError,
-  type UserInputError,
+  makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
 } from '../../errors';
 import { parseUserInput } from '../../input';
 import { fetchOrderBook, fetchTickSize } from '../clob';
@@ -39,6 +40,14 @@ export type EstimateMarketPriceError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const EstimateMarketPriceError = makeErrorGuard(
+  InsufficientLiquidityError,
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Estimates the price level a market order would cross at current book depth.

--- a/packages/client/src/actions/orders/post.ts
+++ b/packages/client/src/actions/orders/post.ts
@@ -8,7 +8,8 @@ import {
 import { invariant, unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseSecureClient } from '../../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   SigningError,
@@ -30,6 +31,13 @@ export type PostOrderError =
   | SigningError
   | TransportError
   | UnexpectedResponseError;
+export const PostOrderError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 export type PostOrdersError =
   | RateLimitError
@@ -38,6 +46,14 @@ export type PostOrdersError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const PostOrdersError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Posts a signed order for the authenticated account.

--- a/packages/client/src/actions/orders/prepare.ts
+++ b/packages/client/src/actions/orders/prepare.ts
@@ -5,8 +5,9 @@ import {
   expectEvmSignature,
 } from '@polymarket/types';
 import type { BaseSecureClient } from '../../clients';
-import type {
+import {
   InsufficientLiquidityError,
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   SigningError,
@@ -49,6 +50,15 @@ export type PrepareMarketOrderError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const PrepareMarketOrderError = makeErrorGuard(
+  InsufficientLiquidityError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Starts the market-order workflow.
@@ -97,6 +107,14 @@ export type PrepareLimitOrderError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const PrepareLimitOrderError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Starts the limit-order workflow.
@@ -142,6 +160,7 @@ export async function prepareLimitOrder(
 }
 
 export type PrepareMarketOrderPostingError = PrepareMarketOrderError;
+export const PrepareMarketOrderPostingError = PrepareMarketOrderError;
 
 /**
  * Starts and posts a market-order workflow.
@@ -171,6 +190,7 @@ export async function prepareMarketOrderPosting(
 }
 
 export type PrepareLimitOrderPostingError = PrepareLimitOrderError;
+export const PrepareLimitOrderPostingError = PrepareLimitOrderError;
 
 /**
  * Starts and posts a limit-order workflow.

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -12,7 +12,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -120,6 +121,13 @@ export type ListPositionsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListPositionsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists current positions for a wallet.
@@ -200,6 +208,13 @@ export type ListClosedPositionsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListClosedPositionsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists closed positions for a wallet.
@@ -280,6 +295,13 @@ export type FetchPortfolioValueError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchPortfolioValueError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the total value for a wallet's positions.
@@ -317,6 +339,13 @@ export type FetchTradedMarketCountError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchTradedMarketCountError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches the total number of markets a wallet has traded.
@@ -354,6 +383,13 @@ export type DownloadAccountingSnapshotError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const DownloadAccountingSnapshotError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Downloads an accounting snapshot archive for a wallet.

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -18,10 +18,11 @@ import {
 } from '../abis';
 import type { BaseSecureClient } from '../clients';
 import {
-  type RateLimitError,
-  type RequestRejectedError,
-  type TransportError,
-  type UnexpectedResponseError,
+  makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
   UserInputError,
 } from '../errors';
 import { parseUserInput } from '../input';
@@ -108,18 +109,33 @@ export type PrepareRedeemPositionsRequest = z.input<
 >;
 
 export type PrepareSplitPositionError = UserInputError;
+export const PrepareSplitPositionError = makeErrorGuard(UserInputError);
 export type PrepareMergePositionsError =
   | RateLimitError
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const PrepareMergePositionsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 export type PrepareRedeemPositionsError =
   | RateLimitError
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const PrepareRedeemPositionsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Starts a split workflow for a market condition.

--- a/packages/client/src/actions/profiles.ts
+++ b/packages/client/src/actions/profiles.ts
@@ -6,11 +6,12 @@ import { err, ok, unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
 import {
-  type RateLimitError,
+  makeErrorGuard,
+  RateLimitError,
   RequestRejectedError,
-  type TransportError,
-  type UnexpectedResponseError,
-  type UserInputError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
 } from '../errors';
 import { parseUserInput } from '../input';
 import { validateWith } from '../response';
@@ -30,6 +31,13 @@ export type FetchPublicProfileError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchPublicProfileError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches a public profile by wallet address.

--- a/packages/client/src/actions/search.ts
+++ b/packages/client/src/actions/search.ts
@@ -5,7 +5,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -44,6 +45,13 @@ export type SearchError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const SearchError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Runs a public full-text search.

--- a/packages/client/src/actions/series.ts
+++ b/packages/client/src/actions/series.ts
@@ -7,7 +7,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -56,6 +57,13 @@ export type ListSeriesError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListSeriesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists series.
@@ -142,6 +150,13 @@ export type FetchSeriesError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchSeriesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches a series.

--- a/packages/client/src/actions/sports.ts
+++ b/packages/client/src/actions/sports.ts
@@ -6,7 +6,8 @@ import {
 } from '@polymarket/bindings/gamma';
 import { unwrap } from '@polymarket/types';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -19,6 +20,12 @@ export type ListSportsError =
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError;
+export const ListSportsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Lists available sports metadata.
@@ -48,6 +55,12 @@ export type FetchSportsMarketTypesError =
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError;
+export const FetchSportsMarketTypesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+);
 
 /**
  * Fetches the available market types grouped by sport.

--- a/packages/client/src/actions/tags.ts
+++ b/packages/client/src/actions/tags.ts
@@ -10,7 +10,8 @@ import {
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -91,6 +92,13 @@ export type ListTagsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListTagsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists tags.
@@ -174,6 +182,13 @@ export type FetchTagError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchTagError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches a tag by id or slug.
@@ -234,6 +249,13 @@ export type FetchRelatedTagsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchRelatedTagsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches related tag relationships by id or slug.
@@ -289,6 +311,13 @@ export type FetchRelatedTagResourcesError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const FetchRelatedTagResourcesError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Fetches resources linked from related tag relationships by id or slug.

--- a/packages/client/src/actions/teams.ts
+++ b/packages/client/src/actions/teams.ts
@@ -2,7 +2,8 @@ import { PaginationCursorSchema } from '@polymarket/bindings';
 import { ListTeamsResponseSchema, type Team } from '@polymarket/bindings/gamma';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
-import type {
+import {
+  makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -39,6 +40,13 @@ export type ListTeamsError =
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
+export const ListTeamsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Lists teams.

--- a/packages/client/src/actions/transfers.ts
+++ b/packages/client/src/actions/transfers.ts
@@ -4,7 +4,7 @@ import type { EvmSignature } from '@polymarket/types';
 import { z } from 'zod';
 import { erc20TransferCall } from '../abis';
 import type { BaseSecureClient } from '../clients';
-import type { UserInputError } from '../errors';
+import { makeErrorGuard, UserInputError } from '../errors';
 import { parseUserInput } from '../input';
 import { expectTransactionHandle, type TransactionHandle } from '../types';
 import type { SignerTransactionRequest } from '../workflow';
@@ -40,6 +40,7 @@ export type PrepareErc20TransferRequest = z.input<
 >;
 
 export type PrepareErc20TransferError = UserInputError;
+export const PrepareErc20TransferError = makeErrorGuard(UserInputError);
 
 /**
  * Starts an ERC-20 transfer workflow.

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -345,3 +345,20 @@ export function accountActions(
     fetchClosedOnlyMode: fetchClosedOnlyMode.bind(null, client),
   };
 }
+
+// Error unions and runtime `isError` guards for every action bound above.
+// Surfaced at the root entry point through `export * from './decorators'`.
+// Keep this list in sync with the methods on AccountPublicActions / AccountActions.
+export {
+  DownloadAccountingSnapshotError,
+  DropNotificationsError,
+  FetchClosedOnlyModeError,
+  FetchNotificationsError,
+  FetchPortfolioValueError,
+  FetchTradedMarketCountError,
+  ListAccountTradesError,
+  ListActivityError,
+  ListClosedPositionsError,
+  ListMarketPositionsError,
+  ListPositionsError,
+} from '../actions';

--- a/packages/client/src/decorators/analytics.ts
+++ b/packages/client/src/decorators/analytics.ts
@@ -167,3 +167,13 @@ export function analyticsActions(client: BaseClient): AnalyticsActions {
     listTraderLeaderboard: listTraderLeaderboard.bind(null, client),
   };
 }
+
+// Error unions and runtime `isError` guards for every action bound above.
+// Surfaced at the root entry point through `export * from './decorators'`.
+// Keep this list in sync with the methods on AnalyticsActions.
+export {
+  ListBuilderLeaderboardError,
+  ListBuilderTradesError,
+  ListBuilderVolumeError,
+  ListTraderLeaderboardError,
+} from '../actions';

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -315,3 +315,25 @@ export function dataActions(client: BaseClient): DataActions {
     listTrades: listTrades.bind(null, client),
   };
 }
+
+// Error unions and runtime `isError` guards for every action bound above.
+// Surfaced at the root entry point through `export * from './decorators'`.
+// Keep this list in sync with the methods on DataActions.
+export {
+  EstimateMarketPriceError,
+  FetchEventLiveVolumeError,
+  FetchLastTradePriceError,
+  FetchLastTradePricesError,
+  FetchMidpointError,
+  FetchMidpointsError,
+  FetchOrderBookError,
+  FetchOrderBooksError,
+  FetchPriceError,
+  FetchPriceHistoryError,
+  FetchPricesError,
+  FetchSpreadError,
+  FetchSpreadsError,
+  ListMarketHoldersError,
+  ListOpenInterestError,
+  ListTradesError,
+} from '../actions';

--- a/packages/client/src/decorators/discovery.ts
+++ b/packages/client/src/decorators/discovery.ts
@@ -540,3 +540,29 @@ export function discoveryActions(client: BaseClient): DiscoveryActions {
     listCommentsByUserAddress: listCommentsByUserAddress.bind(null, client),
   };
 }
+
+// Error unions and runtime `isError` guards for every action bound above.
+// Surfaced at the root entry point through `export * from './decorators'`.
+// Keep this list in sync with the methods on DiscoveryActions.
+export {
+  FetchCommentsByIdError,
+  FetchEventError,
+  FetchEventTagsError,
+  FetchMarketError,
+  FetchMarketTagsError,
+  FetchPublicProfileError,
+  FetchRelatedTagResourcesError,
+  FetchRelatedTagsError,
+  FetchSeriesError,
+  FetchSportsMarketTypesError,
+  FetchTagError,
+  ListCommentsByUserAddressError,
+  ListCommentsError,
+  ListEventsError,
+  ListMarketsError,
+  ListSeriesError,
+  ListSportsError,
+  ListTagsError,
+  ListTeamsError,
+  SearchError,
+} from '../actions';

--- a/packages/client/src/decorators/rewards.ts
+++ b/packages/client/src/decorators/rewards.ts
@@ -272,3 +272,17 @@ export function rewardsActions(
     fetchRewardPercentages: fetchRewardPercentages.bind(null, client),
   };
 }
+
+// Error unions and runtime `isError` guards for every action bound above.
+// Surfaced at the root entry point through `export * from './decorators'`.
+// Keep this list in sync with the methods on RewardsPublicActions / RewardsActions.
+export {
+  FetchOrderScoringError,
+  FetchOrdersScoringError,
+  FetchRewardPercentagesError,
+  FetchTotalEarningsForUserForDayError,
+  ListCurrentRewardsError,
+  ListMarketRewardsError,
+  ListUserEarningsAndMarketsConfigError,
+  ListUserEarningsForDayError,
+} from '../actions';

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -271,3 +271,21 @@ export function tradingActions(client: BaseSecureClient): TradingActions {
     fetchOrder: fetchOrder.bind(null, client),
   };
 }
+
+// Error unions and runtime `isError` guards for every action bound above.
+// Surfaced at the root entry point through `export * from './decorators'`.
+// Keep this list in sync with the methods on TradingActions.
+export {
+  CancelAllError,
+  CancelMarketOrdersError,
+  CancelOrderError,
+  CancelOrdersError,
+  FetchOrderError,
+  ListOpenOrdersError,
+  PostOrderError,
+  PostOrdersError,
+  PrepareLimitOrderError,
+  PrepareLimitOrderPostingError,
+  PrepareMarketOrderError,
+  PrepareMarketOrderPostingError,
+} from '../actions';

--- a/packages/client/src/decorators/wallet.ts
+++ b/packages/client/src/decorators/wallet.ts
@@ -247,3 +247,18 @@ export function walletActions(
     prepareRedeemPositions: prepareRedeemPositions.bind(null, client),
   };
 }
+
+// Error unions and runtime `isError` guards for every action bound above.
+// Surfaced at the root entry point through `export * from './decorators'`.
+// Keep this list in sync with the methods on PublicWalletActions / SecureWalletActions.
+export {
+  IsGaslessReadyError,
+  PrepareErc20ApprovalError,
+  PrepareErc20TransferError,
+  PrepareErc1155ApprovalForAllError,
+  PrepareGaslessWalletError,
+  PrepareMergePositionsError,
+  PrepareRedeemPositionsError,
+  PrepareSplitPositionError,
+  PrepareTradingApprovalsError,
+} from '../actions';

--- a/packages/client/src/errors.test.ts
+++ b/packages/client/src/errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { ListMarketsError } from './actions';
+import {
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+} from './errors';
+
+describe('error guards', () => {
+  it('isError returns true for each member of the union', () => {
+    expect(ListMarketsError.isError(new RateLimitError('rate limited'))).toBe(
+      true,
+    );
+    expect(
+      ListMarketsError.isError(
+        new RequestRejectedError('rejected', { status: 400 }),
+      ),
+    ).toBe(true);
+    expect(
+      ListMarketsError.isError(new TransportError('transport failed')),
+    ).toBe(true);
+    expect(
+      ListMarketsError.isError(new UnexpectedResponseError('unexpected')),
+    ).toBe(true);
+    expect(ListMarketsError.isError(new UserInputError('bad input'))).toBe(
+      true,
+    );
+  });
+
+  it('isError returns false for non-SDK errors', () => {
+    expect(ListMarketsError.isError(new Error('plain error'))).toBe(false);
+    expect(ListMarketsError.isError('string error')).toBe(false);
+    expect(ListMarketsError.isError(null)).toBe(false);
+    expect(ListMarketsError.isError(undefined)).toBe(false);
+  });
+
+  it('narrows to union type enabling switch on name', () => {
+    const error: unknown = new RateLimitError('rate limited');
+    if (ListMarketsError.isError(error)) {
+      // TypeScript should allow switch on error.name here
+      // This verifies type narrowing works at compile time
+      const name = error.name;
+      expect([
+        'RateLimitError',
+        'RequestRejectedError',
+        'TransportError',
+        'UnexpectedResponseError',
+        'UserInputError',
+      ]).toContain(name);
+    }
+  });
+});

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -164,3 +164,16 @@ export class SigningError extends PolymarketError {
     return new SigningError(msg, { cause: error });
   }
 }
+
+export function makeErrorGuard<
+  // biome-ignore lint/suspicious/noExplicitAny: constructor rest args require any[]
+  TClasses extends ReadonlyArray<new (...args: any[]) => unknown>,
+>(
+  ...classes: TClasses
+): { isError(error: unknown): error is InstanceType<TClasses[number]> } {
+  return {
+    isError(error: unknown): error is InstanceType<TClasses[number]> {
+      return classes.some((c) => error instanceof c);
+    },
+  };
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -7,7 +7,6 @@ export { WalletType } from '@polymarket/bindings/gamma';
 export type * from '@polymarket/bindings/relayer';
 export * from './abis';
 export type { AccountIdentity } from './account';
-export * from './actions';
 export type {
   RelayerApiKeyConfig,
   RemoteBuilderSigningConfig,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -7,6 +7,7 @@ export { WalletType } from '@polymarket/bindings/gamma';
 export type * from '@polymarket/bindings/relayer';
 export * from './abis';
 export type { AccountIdentity } from './account';
+export * from './actions';
 export type {
   RelayerApiKeyConfig,
   RemoteBuilderSigningConfig,
@@ -21,8 +22,7 @@ export * from './hmac';
 export type * from './pagination';
 export * from './types';
 export type {
-  AuthenticateWithError,
   AuthenticationWorkflow,
   AuthenticationWorkflowRequest,
-  CompleteWithError,
 } from './workflow';
+export { AuthenticateWithError, CompleteWithError } from './workflow';

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -6,6 +6,16 @@ import {
   type TxHash,
 } from '@polymarket/types';
 import type { WaitForGaslessTransactionError } from './actions';
+import {
+  makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
+  TimeoutError,
+  TransactionFailedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+} from './errors';
 
 export type TypedDataField = {
   name: string;
@@ -66,6 +76,15 @@ export type TransactionOutcome = {
 };
 
 export type WaitForTransactionError = WaitForGaslessTransactionError;
+export const WaitForTransactionError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TimeoutError,
+  TransactionFailedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 export interface TransactionHandle {
   /**

--- a/packages/client/src/workflow.ts
+++ b/packages/client/src/workflow.ts
@@ -1,5 +1,5 @@
 import type { EvmAddress, EvmSignature, HexString } from '@polymarket/types';
-import type { CancelledSigningError, SigningError } from './errors';
+import { CancelledSigningError, makeErrorGuard, SigningError } from './errors';
 import type {
   TransactionCall,
   TransactionHandle,
@@ -82,7 +82,15 @@ export type AuthenticateWith = <TReturn>(
 ) => Promise<TReturn>;
 
 export type AuthenticateWithError = CancelledSigningError | SigningError;
+export const AuthenticateWithError = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+);
 export type CompleteWithError = CancelledSigningError | SigningError;
+export const CompleteWithError = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+);
 
 export type CompleteWorkflowRequest =
   | RequestAddressRequest


### PR DESCRIPTION
## Summary

- Adds a `makeErrorGuard(...classes)` helper in `errors.ts` that takes concrete error constructors and returns `{ isError(error: unknown): error is Union }` via `instanceof` checks — the union type is inferred from the constructor tuple
- Adds a same-named `export const FooError = makeErrorGuard(...)` alongside every `export type FooError` union across 27 source files (all action files, `abis.ts`, `types.ts`, `workflow.ts`)
- Re-exports `./actions` from the root `index.ts` so guards are accessible from `@polymarket/client` without a sub-path import
- Adds `errors.test.ts` with 3 tests covering positive hits, non-SDK rejection, and type-narrowing

## Consumer ergonomics

```ts
try {
  await client.listMarkets();
} catch (error) {
  if (ListMarketsError.isError(error)) {
    switch (error.name) {
      case 'RateLimitError':
        // retry...
        break;
      case 'RequestRejectedError':
        // handle 4xx...
        break;
    }
  }
}
```

Both the existing `import type { ListMarketsError }` (union type) and the new `import { ListMarketsError }` (guard object) are exported under the same name, using TypeScript's separate type/value namespaces — no breaking change.

## Design notes

- Guard uses `instanceof`, not `error.name` string matching, so subclasses are handled correctly
- For alias unions (`PrepareMarketOrderPostingError = PrepareMarketOrderError`), the const is a direct reference to the parent guard — no duplication
- For composed unions in `gasless.ts` where the inner type is module-private (`ExecuteGaslessError`), the classes are flattened at the call site
- `WaitForTransactionError` in `types.ts` imports classes directly from `./errors` to avoid a circular value dependency through `./actions`

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm vitest run --project client packages/client/src/errors.test.ts` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new `makeErrorGuard` helper and exported guard values) and don’t alter request/transaction behavior, but they do expand the public API surface via additional exports.
> 
> **Overview**
> Adds a generic `makeErrorGuard(...classes)` helper and, alongside each existing `...Error` *type* union, exports a same-named `const` with an `isError(error)` runtime type guard inferred from the provided error constructors.
> 
> Updates decorators to re-export these error guards/unions per action group, adjusts root exports (including `AuthenticateWithError`/`CompleteWithError`) so consumers can import guards from the package entrypoint, and adds a small `vitest` suite validating guard behavior and TypeScript narrowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af2b1f5e960294099fbd60f9d0486b0782a8a42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->