### PR TITLE
refactor(client): use bound methods in action tests

### DIFF
--- a/packages/client/src/actions/account.test.ts
+++ b/packages/client/src/actions/account.test.ts
@@ -1,16 +1,9 @@
 import { AssetType } from '@polymarket/bindings/clob';
 import { describe, expect, it } from 'vitest';
-import type { SecureClient } from '../clients';
+import type { AccountActions } from '../decorators';
 import { publicClient, safeWalletAddress, walletClient } from '../testing';
 import { authenticateWith } from '../viem';
-import {
-  dropNotifications,
-  fetchBalanceAllowance,
-  fetchClosedOnlyMode,
-  fetchNotifications,
-  listAccountTrades,
-  listOpenOrders,
-} from './account';
+import { fetchBalanceAllowance } from './account';
 
 describe('Account', () => {
   describe('authenticated reads', () => {
@@ -21,10 +14,10 @@ describe('Account', () => {
 
       const [closedOnly, openOrders, trades, notifications, balanceAllowance] =
         await Promise.all([
-          fetchClosedOnlyMode(secureClient),
-          listOpenOrders(secureClient).firstPage(),
-          listAccountTrades(secureClient).firstPage(),
-          fetchNotifications(secureClient),
+          secureClient.fetchClosedOnlyMode(),
+          secureClient.listOpenOrders().firstPage(),
+          secureClient.listAccountTrades().firstPage(),
+          secureClient.fetchNotifications(),
           fetchBalanceAllowance(secureClient, {
             assetType: AssetType.COLLATERAL,
           }),
@@ -49,7 +42,7 @@ describe('Account', () => {
         .beginAuthentication({ wallet: safeWalletAddress })
         .then(authenticateWith(walletClient));
 
-      const notifications = await fetchNotifications(secureClient);
+      const notifications = await secureClient.fetchNotifications();
 
       if (notifications.length === 0) {
         return;
@@ -58,7 +51,7 @@ describe('Account', () => {
       const ids = notifications.slice(0, 1).map(({ id }) => `${id}`);
 
       await expect(
-        dropNotifications(secureClient, {
+        secureClient.dropNotifications({
           ids,
         }),
       ).resolves.toBeUndefined();
@@ -76,11 +69,11 @@ describe('Account', () => {
 });
 
 async function waitForNotificationsToClear(
-  secureClient: SecureClient,
+  secureClient: Pick<AccountActions, 'fetchNotifications'>,
   ids: string[],
 ) {
   for (let attempt = 0; attempt < 10; attempt += 1) {
-    const notifications = await fetchNotifications(secureClient);
+    const notifications = await secureClient.fetchNotifications();
 
     if (!notifications.some(({ id }) => ids.includes(`${id}`))) {
       return notifications;
@@ -89,5 +82,5 @@ async function waitForNotificationsToClear(
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
 
-  return fetchNotifications(secureClient);
+  return secureClient.fetchNotifications();
 }

--- a/packages/client/src/actions/activity.test.ts
+++ b/packages/client/src/actions/activity.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import { listActivity, listTrades } from './activity';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
 
 describe('Activity', () => {
   describe('listTrades', () => {
     it('lists trades for a wallet', async () => {
-      const result = await listTrades(publicClient, {
-        user: TEST_USER,
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listTrades({
+          user: TEST_USER,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
@@ -26,10 +26,11 @@ describe('Activity', () => {
 
   describe('listActivity', () => {
     it('lists wallet activity', async () => {
-      const result = await listActivity(publicClient, {
-        user: TEST_USER,
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listActivity({
+          user: TEST_USER,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -10,11 +10,6 @@ import {
   walletClient,
 } from '../testing';
 import { authenticateWith, completeWith } from '../viem';
-import {
-  prepareErc20Approval,
-  prepareErc1155ApprovalForAll,
-  prepareTradingApprovals,
-} from './approvals';
 
 describe('Approvals', () => {
   describe('prepareErc20Approval', () => {
@@ -25,11 +20,13 @@ describe('Approvals', () => {
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      const handle = await prepareErc20Approval(secureClient, {
-        spenderAddress: secureClient.environment.standardExchange,
-        tokenAddress: secureClient.environment.collateralToken,
-        amount: 'max',
-      }).then(completeWith(walletClient));
+      const handle = await secureClient
+        .prepareErc20Approval({
+          spenderAddress: secureClient.environment.standardExchange,
+          tokenAddress: secureClient.environment.collateralToken,
+          amount: 'max',
+        })
+        .then(completeWith(walletClient));
 
       await expect(handle.wait()).resolves.toBeTruthy();
     });
@@ -46,11 +43,13 @@ describe('Approvals', () => {
       // to avoid having to fund the wallet we stop the test by proving the
       // transaction request is correctly formed, without actually sending it
       await expect(
-        prepareErc20Approval(secureClient, {
-          amount: 'max',
-          spenderAddress: ZERO_ADDRESS,
-          tokenAddress: secureClient.environment.collateralToken,
-        }).then(completeWith(walletClient)),
+        secureClient
+          .prepareErc20Approval({
+            amount: 'max',
+            spenderAddress: ZERO_ADDRESS,
+            tokenAddress: secureClient.environment.collateralToken,
+          })
+          .then(completeWith(walletClient)),
       ).rejects.toBeInstanceOf(SigningError);
     });
   });
@@ -63,10 +62,12 @@ describe('Approvals', () => {
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      const handle = await prepareErc1155ApprovalForAll(secureClient, {
-        operatorAddress: secureClient.environment.standardExchange,
-        tokenAddress: secureClient.environment.conditionalTokens,
-      }).then(completeWith(walletClient));
+      const handle = await secureClient
+        .prepareErc1155ApprovalForAll({
+          operatorAddress: secureClient.environment.standardExchange,
+          tokenAddress: secureClient.environment.conditionalTokens,
+        })
+        .then(completeWith(walletClient));
 
       await expect(handle.wait()).resolves.toBeTruthy();
     });
@@ -80,9 +81,9 @@ describe('Approvals', () => {
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      const handle = await prepareTradingApprovals(secureClient).then(
-        completeWith(walletClient),
-      );
+      const handle = await secureClient
+        .prepareTradingApprovals()
+        .then(completeWith(walletClient));
 
       await expect(handle.wait()).resolves.toBeTruthy();
     });

--- a/packages/client/src/actions/builders.test.ts
+++ b/packages/client/src/actions/builders.test.ts
@@ -1,7 +1,6 @@
 import { OrderSide } from '@polymarket/bindings';
 import { delay, expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
-import type { PublicClient } from '../clients';
 import {
   builderCredentials,
   expectNonEmptyPage,
@@ -11,15 +10,14 @@ import {
   walletClient,
 } from '../testing';
 import { authenticateWith, completeWith } from '../viem';
-import { listBuilderTrades } from './builders';
-import { postOrder, prepareMarketOrder } from './orders';
 
 const market = await findHighVolumeLowPriceMarket();
 
 describe('Builders', () => {
   describe('listBuilderTrades', () => {
     it('lists builder-attributed trades', async () => {
-      const existingTrades = await listBuilderTrades(publicClientWithBuilderKey)
+      const existingTrades = await publicClientWithBuilderKey
+        .listBuilderTrades()
         .firstPage()
         .then((page) => page.items);
 
@@ -40,13 +38,14 @@ describe('Builders', () => {
       console.log(market.slug);
       const [tokenId] = expectPresent(market.clobTokenIds);
 
-      const response = await prepareMarketOrder(secureClient, {
-        amount: expectPresent(market.orderMinSize),
-        side: OrderSide.BUY,
-        tokenId,
-      })
+      const response = await secureClient
+        .prepareMarketOrder({
+          amount: expectPresent(market.orderMinSize),
+          side: OrderSide.BUY,
+          tokenId,
+        })
         .then(completeWith(walletClient))
-        .then(postOrder(secureClient));
+        .then(secureClient.postOrder);
 
       expect(response.ok).toBe(true);
 
@@ -65,9 +64,12 @@ describe('Builders', () => {
   });
 });
 
-async function waitForBuilderTrades(client: PublicClient, tokenId: string) {
+async function waitForBuilderTrades(
+  client: typeof publicClientWithBuilderKey,
+  tokenId: string,
+) {
   for (let attempt = 0; attempt < 10; attempt += 1) {
-    const { items } = await listBuilderTrades(client, { tokenId }).firstPage();
+    const { items } = await client.listBuilderTrades({ tokenId }).firstPage();
 
     if (items.length > 0) {
       return items;
@@ -76,7 +78,8 @@ async function waitForBuilderTrades(client: PublicClient, tokenId: string) {
     await delay(500);
   }
 
-  return listBuilderTrades(client, { tokenId })
+  return client
+    .listBuilderTrades({ tokenId })
     .firstPage()
     .then(expectNonEmptyPage)
     .then((page) => page.items);

--- a/packages/client/src/actions/clob.test.ts
+++ b/packages/client/src/actions/clob.test.ts
@@ -3,25 +3,7 @@ import { PriceHistoryInterval } from '@polymarket/bindings/clob';
 import { expectPresent, never } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import { publicClient } from '../testing';
-import {
-  fetchFeeRate,
-  fetchLastTradePrice,
-  fetchLastTradePrices,
-  fetchMidpoint,
-  fetchMidpoints,
-  fetchNegRisk,
-  fetchOrderBook,
-  fetchOrderBooks,
-  fetchPrice,
-  fetchPriceHistory,
-  fetchPrices,
-  fetchSpread,
-  fetchSpreads,
-  fetchTickSize,
-  listCurrentRewards,
-  listMarketRewards,
-} from './clob';
-import { listMarkets } from './markets';
+import { fetchFeeRate, fetchNegRisk, fetchTickSize } from './clob';
 
 describe('CLOB', () => {
   describe('fetchTickSize', () => {
@@ -66,7 +48,7 @@ describe('CLOB', () => {
     it('fetches the order book for a token', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchOrderBook(publicClient, {
+      const result = await publicClient.fetchOrderBook({
         tokenId,
       });
 
@@ -84,7 +66,7 @@ describe('CLOB', () => {
     it('fetches order books for multiple tokens', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchOrderBooks(publicClient, [{ tokenId }]);
+      const result = await publicClient.fetchOrderBooks([{ tokenId }]);
 
       expect(result[0]).toEqual(
         expect.objectContaining({
@@ -100,7 +82,7 @@ describe('CLOB', () => {
     it('fetches the midpoint price for a token', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchMidpoint(publicClient, {
+      const result = await publicClient.fetchMidpoint({
         tokenId,
       });
 
@@ -112,7 +94,7 @@ describe('CLOB', () => {
     it('fetches midpoint prices for multiple tokens', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchMidpoints(publicClient, [{ tokenId }]);
+      const result = await publicClient.fetchMidpoints([{ tokenId }]);
 
       expect(result[tokenId]).toEqual(expect.any(String));
     });
@@ -122,7 +104,7 @@ describe('CLOB', () => {
     it('fetches the quoted price for a token and side', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchPrice(publicClient, {
+      const result = await publicClient.fetchPrice({
         tokenId,
         side: OrderSide.BUY,
       });
@@ -135,7 +117,7 @@ describe('CLOB', () => {
     it('fetches quoted prices for multiple tokens', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchPrices(publicClient, [
+      const result = await publicClient.fetchPrices([
         {
           tokenId,
           side: OrderSide.BUY,
@@ -150,7 +132,7 @@ describe('CLOB', () => {
     it('fetches the spread for a token', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchSpread(publicClient, {
+      const result = await publicClient.fetchSpread({
         tokenId,
       });
 
@@ -162,7 +144,7 @@ describe('CLOB', () => {
     it('fetches spreads for multiple tokens', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchSpreads(publicClient, [{ tokenId }]);
+      const result = await publicClient.fetchSpreads([{ tokenId }]);
 
       expect(result[tokenId]).toEqual(expect.any(String));
     });
@@ -172,7 +154,7 @@ describe('CLOB', () => {
     it('fetches the last traded price for a token', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchLastTradePrice(publicClient, {
+      const result = await publicClient.fetchLastTradePrice({
         tokenId,
       });
 
@@ -189,7 +171,7 @@ describe('CLOB', () => {
     it('fetches last traded prices for multiple tokens', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchLastTradePrices(publicClient, [{ tokenId }]);
+      const result = await publicClient.fetchLastTradePrices([{ tokenId }]);
 
       expect(result[0]).toEqual(
         expect.objectContaining({
@@ -205,7 +187,7 @@ describe('CLOB', () => {
     it('lists historical price points for a token', async () => {
       const tokenId = await selectLiquidClobTokenId();
 
-      const result = await fetchPriceHistory(publicClient, {
+      const result = await publicClient.fetchPriceHistory({
         tokenId,
         interval: PriceHistoryInterval.ONE_DAY,
         fidelity: 60,
@@ -224,14 +206,16 @@ describe('CLOB', () => {
   describe('listCurrentRewards', () => {
     it('lists current active market rewards', async () => {
       await expect(
-        listCurrentRewards(publicClient).firstPage(),
+        publicClient.listCurrentRewards().firstPage(),
       ).resolves.toBeDefined();
     });
   });
 
   describe('listMarketRewards', () => {
     it('fetches reward configurations for a market', async () => {
-      const currentRewards = await listCurrentRewards(publicClient).firstPage();
+      const currentRewards = await publicClient
+        .listCurrentRewards()
+        .firstPage();
 
       const currentReward = currentRewards.items[0];
 
@@ -239,9 +223,11 @@ describe('CLOB', () => {
         return;
       }
 
-      const result = await listMarketRewards(publicClient, {
-        conditionId: currentReward.conditionId,
-      }).firstPage();
+      const result = await publicClient
+        .listMarketRewards({
+          conditionId: currentReward.conditionId,
+        })
+        .firstPage();
 
       expect(result.items.length).toBeGreaterThan(0);
       expect(result.items[0]).toEqual(
@@ -256,12 +242,13 @@ describe('CLOB', () => {
 });
 
 async function selectLiquidClobTokenId(): Promise<string> {
-  const markets = await listMarkets(publicClient, {
-    closed: false,
-    pageSize: 100,
-    order: 'volume24hr',
-    ascending: false,
-  })
+  const markets = await publicClient
+    .listMarkets({
+      closed: false,
+      pageSize: 100,
+      order: 'volume24hr',
+      ascending: false,
+    })
     .firstPage()
     .then((page) => page.items);
 

--- a/packages/client/src/actions/comments.test.ts
+++ b/packages/client/src/actions/comments.test.ts
@@ -2,29 +2,26 @@ import { CommentParentEntityType } from '@polymarket/bindings';
 import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import {
-  fetchCommentsById,
-  listComments,
-  listCommentsByUserAddress,
-} from './comments';
-import { listEvents } from './events';
 
 const {
   items: [event],
-} = await listEvents(publicClient, {
-  closed: false,
-  pageSize: 1,
-})
+} = await publicClient
+  .listEvents({
+    closed: false,
+    pageSize: 1,
+  })
   .firstPage()
   .then(expectNonEmptyPage);
 
 describe('Comments', () => {
   describe('listComments', () => {
     it('fetches comments for an event', async () => {
-      const { items } = await listComments(publicClient, {
-        parentEntityId: event.id,
-        parentEntityType: CommentParentEntityType.Event,
-      }).firstPage();
+      const { items } = await publicClient
+        .listComments({
+          parentEntityId: event.id,
+          parentEntityType: CommentParentEntityType.Event,
+        })
+        .firstPage();
 
       expect(items).toEqual(expect.any(Array));
     });
@@ -34,23 +31,23 @@ describe('Comments', () => {
     it('fetches related comment threads when a comment is available', async () => {
       const {
         items: [comment],
-      } = await listComments(publicClient, {
-        parentEntityId: event.id,
-        parentEntityType: CommentParentEntityType.Event,
-      })
+      } = await publicClient
+        .listComments({
+          parentEntityId: event.id,
+          parentEntityType: CommentParentEntityType.Event,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const commentsById = await fetchCommentsById(publicClient, {
+      const commentsById = await publicClient.fetchCommentsById({
         id: comment.id,
       });
-      const commentsByUserAddress = await listCommentsByUserAddress(
-        publicClient,
-        {
+      const commentsByUserAddress = await publicClient
+        .listCommentsByUserAddress({
           address: expectPresent(comment.userAddress),
           pageSize: 1,
-        },
-      ).firstPage();
+        })
+        .firstPage();
 
       expect(commentsById).toEqual(expect.any(Array));
       expect(commentsByUserAddress.items).toEqual(expect.any(Array));

--- a/packages/client/src/actions/events.test.ts
+++ b/packages/client/src/actions/events.test.ts
@@ -1,17 +1,11 @@
 import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import {
-  fetchEvent,
-  fetchEventLiveVolume,
-  fetchEventTags,
-  listEvents,
-} from './events';
 
 describe('Events', () => {
   describe('listEvents', () => {
     it('fetches events from Gamma', async () => {
-      const paginator = listEvents(publicClient, {
+      const paginator = publicClient.listEvents({
         closed: false,
         pageSize: 1,
       });
@@ -36,18 +30,19 @@ describe('Events', () => {
     it('fetches an event by id and slug', async () => {
       const {
         items: [event],
-      } = await listEvents(publicClient, {
-        closed: false,
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listEvents({
+          closed: false,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const eventById = await fetchEvent(publicClient, {
+      const eventById = await publicClient.fetchEvent({
         id: event.id,
       });
 
-      const eventBySlug = await fetchEvent(publicClient, {
+      const eventBySlug = await publicClient.fetchEvent({
         slug: expectPresent(event.slug),
       });
 
@@ -60,14 +55,15 @@ describe('Events', () => {
     it("fetches an event's tags by id", async () => {
       const {
         items: [event],
-      } = await listEvents(publicClient, {
-        closed: false,
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listEvents({
+          closed: false,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const result = await fetchEventTags(publicClient, {
+      const result = await publicClient.fetchEventTags({
         id: event.id,
       });
 
@@ -87,14 +83,15 @@ describe('Events', () => {
     it('fetches live volume for an event', async () => {
       const {
         items: [event],
-      } = await listEvents(publicClient, {
-        closed: false,
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listEvents({
+          closed: false,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const result = await fetchEventLiveVolume(publicClient, {
+      const result = await publicClient.fetchEventLiveVolume({
         id: event.id,
       });
 

--- a/packages/client/src/actions/gasless.test.ts
+++ b/packages/client/src/actions/gasless.test.ts
@@ -14,11 +14,7 @@ import {
   walletClient,
 } from '../testing';
 import { authenticateWith, completeWith } from '../viem';
-import {
-  isGaslessReady,
-  prepareGaslessTransaction,
-  prepareGaslessWallet,
-} from './gasless';
+import { prepareGaslessTransaction } from './gasless';
 
 describe('Gasless', () => {
   describe('isGaslessReady', () => {
@@ -30,7 +26,7 @@ describe('Gasless', () => {
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
       await expect(
-        isGaslessReady(secureClient, {
+        secureClient.isGaslessReady({
           wallet: secureClient.account.wallet,
         }),
       ).resolves.toBe(true);
@@ -38,7 +34,7 @@ describe('Gasless', () => {
 
     it('supports checking readiness from a public client with a wallet address', async () => {
       await expect(
-        isGaslessReady(publicClientWithRelayerKey, {
+        publicClientWithRelayerKey.isGaslessReady({
           wallet: safeWalletAddress,
         }),
       ).resolves.toBe(true);
@@ -54,7 +50,7 @@ describe('Gasless', () => {
       expect(secureClient.account.walletType).toBe(WalletType.EOA);
 
       await expect(
-        isGaslessReady(secureClient, {
+        secureClient.isGaslessReady({
           wallet: secureClient.account.wallet,
         }),
       ).resolves.toBe(false);
@@ -65,7 +61,7 @@ describe('Gasless', () => {
       const walletClient = createRandomWalletClient();
 
       await expect(
-        isGaslessReady(publicClient, {
+        publicClient.isGaslessReady({
           wallet: walletClient.account.address,
         }),
       ).resolves.toBe(false);
@@ -230,14 +226,14 @@ describe('Gasless', () => {
         );
 
         await expect(
-          isGaslessReady(publicClientWithBuilderKey, {
+          publicClientWithBuilderKey.isGaslessReady({
             wallet: safeWallet,
           }),
         ).resolves.toBe(false);
 
-        const handle = await prepareGaslessWallet(
-          publicClientWithBuilderKey,
-        ).then(completeWith(walletClient));
+        const handle = await publicClientWithBuilderKey
+          .prepareGaslessWallet()
+          .then(completeWith(walletClient));
 
         expect(handle.wallet).toBe(safeWallet);
 
@@ -246,7 +242,7 @@ describe('Gasless', () => {
         await expect(handle.wait()).resolves.toBeTruthy();
 
         await expect(
-          isGaslessReady(publicClientWithBuilderKey, {
+          publicClientWithBuilderKey.isGaslessReady({
             wallet: safeWallet,
           }),
         ).resolves.toBe(true);

--- a/packages/client/src/actions/leaderboards.test.ts
+++ b/packages/client/src/actions/leaderboards.test.ts
@@ -1,17 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import {
-  fetchBuilderVolume,
-  listBuilderLeaderboard,
-  listTraderLeaderboard,
-} from './leaderboards';
 
 describe('Leaderboards', () => {
   describe('listTraderLeaderboard', () => {
     it('lists trader rankings', async () => {
-      const result = await listTraderLeaderboard(publicClient, {
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listTraderLeaderboard({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
@@ -27,9 +23,10 @@ describe('Leaderboards', () => {
 
   describe('listBuilderLeaderboard', () => {
     it('lists builder rankings', async () => {
-      const result = await listBuilderLeaderboard(publicClient, {
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listBuilderLeaderboard({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
@@ -45,7 +42,7 @@ describe('Leaderboards', () => {
 
   describe('fetchBuilderVolume', () => {
     it('lists builder volume entries', async () => {
-      const result = await fetchBuilderVolume(publicClient, {
+      const result = await publicClient.fetchBuilderVolume({
         timePeriod: 'DAY',
       });
 

--- a/packages/client/src/actions/markets.test.ts
+++ b/packages/client/src/actions/markets.test.ts
@@ -1,25 +1,17 @@
 import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import {
-  fetchMarket,
-  fetchMarketTags,
-  listMarketHolders,
-  listMarketPositions,
-  listMarkets,
-  listOpenInterest,
-} from './markets';
-import { listPositions } from './portfolio';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
 
 async function findPositionConditionId(): Promise<string> {
   const {
     items: [position],
-  } = await listPositions(publicClient, {
-    user: TEST_USER,
-    pageSize: 1,
-  })
+  } = await publicClient
+    .listPositions({
+      user: TEST_USER,
+      pageSize: 1,
+    })
     .firstPage()
     .then(expectNonEmptyPage);
 
@@ -29,7 +21,7 @@ async function findPositionConditionId(): Promise<string> {
 describe('Markets', () => {
   describe('listMarkets', () => {
     it('fetches markets from Gamma', async () => {
-      const paginator = listMarkets(publicClient, {
+      const paginator = publicClient.listMarkets({
         closed: false,
         pageSize: 1,
       });
@@ -54,18 +46,19 @@ describe('Markets', () => {
     it('fetches a market by id and slug', async () => {
       const {
         items: [market],
-      } = await listMarkets(publicClient, {
-        closed: false,
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listMarkets({
+          closed: false,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const marketById = await fetchMarket(publicClient, {
+      const marketById = await publicClient.fetchMarket({
         id: market.id,
       });
 
-      const marketBySlug = await fetchMarket(publicClient, {
+      const marketBySlug = await publicClient.fetchMarket({
         slug: expectPresent(market.slug),
       });
 
@@ -78,14 +71,15 @@ describe('Markets', () => {
     it("fetches a market's tags by id", async () => {
       const {
         items: [market],
-      } = await listMarkets(publicClient, {
-        closed: false,
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listMarkets({
+          closed: false,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const result = await fetchMarketTags(publicClient, {
+      const result = await publicClient.fetchMarketTags({
         id: market.id,
       });
 
@@ -105,7 +99,7 @@ describe('Markets', () => {
     it('lists top holders for a market', async () => {
       const market = await findPositionConditionId();
 
-      const result = await listMarketHolders(publicClient, {
+      const result = await publicClient.listMarketHolders({
         market: [market],
         limit: 1,
       });
@@ -124,7 +118,7 @@ describe('Markets', () => {
     it('lists open interest for a market', async () => {
       const market = await findPositionConditionId();
 
-      const result = await listOpenInterest(publicClient, {
+      const result = await publicClient.listOpenInterest({
         market: [market],
       });
 
@@ -141,10 +135,11 @@ describe('Markets', () => {
     it('lists positions for a market', async () => {
       const market = await findPositionConditionId();
 
-      const result = await listMarketPositions(publicClient, {
-        market,
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listMarketPositions({
+          market,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 

--- a/packages/client/src/actions/orders.test.ts
+++ b/packages/client/src/actions/orders.test.ts
@@ -16,7 +16,6 @@ import {
   walletClient,
 } from '../testing';
 import { authenticateWith, completeWith } from '../viem';
-import { prepareErc20Approval } from './approvals';
 import { fetchNegRisk } from './clob';
 
 const market = await findHighVolumeLowPriceMarket();
@@ -178,11 +177,12 @@ describe('Orders', () => {
         yesTokenId,
       );
 
-      await prepareErc20Approval(gaslessClient, {
-        amount: 0n,
-        spenderAddress: exchangeAddress,
-        tokenAddress: gaslessClient.environment.collateralToken,
-      })
+      await gaslessClient
+        .prepareErc20Approval({
+          amount: 0n,
+          spenderAddress: exchangeAddress,
+          tokenAddress: gaslessClient.environment.collateralToken,
+        })
         .then(completeWith(walletClient))
         .then((handle) => handle.wait());
 

--- a/packages/client/src/actions/portfolio.test.ts
+++ b/packages/client/src/actions/portfolio.test.ts
@@ -1,22 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import {
-  downloadAccountingSnapshot,
-  fetchPortfolioValue,
-  fetchTradedMarketCount,
-  listClosedPositions,
-  listPositions,
-} from './portfolio';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
 
 describe('Portfolio', () => {
   describe('listPositions', () => {
     it('lists positions for a wallet', async () => {
-      const result = await listPositions(publicClient, {
-        user: TEST_USER,
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listPositions({
+          user: TEST_USER,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
@@ -32,10 +26,11 @@ describe('Portfolio', () => {
 
   describe('listClosedPositions', () => {
     it('lists closed positions for a wallet', async () => {
-      const result = await listClosedPositions(publicClient, {
-        user: TEST_USER,
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listClosedPositions({
+          user: TEST_USER,
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
@@ -51,7 +46,7 @@ describe('Portfolio', () => {
 
   describe('fetchPortfolioValue', () => {
     it('fetches wallet value', async () => {
-      const result = await fetchPortfolioValue(publicClient, {
+      const result = await publicClient.fetchPortfolioValue({
         user: TEST_USER,
       });
 
@@ -66,7 +61,7 @@ describe('Portfolio', () => {
 
   describe('fetchTradedMarketCount', () => {
     it('fetches total traded market count for a wallet', async () => {
-      const result = await fetchTradedMarketCount(publicClient, {
+      const result = await publicClient.fetchTradedMarketCount({
         user: TEST_USER,
       });
 
@@ -81,7 +76,7 @@ describe('Portfolio', () => {
 
   describe('downloadAccountingSnapshot', () => {
     it('downloads the accounting snapshot archive', async () => {
-      const result = await downloadAccountingSnapshot(publicClient, {
+      const result = await publicClient.downloadAccountingSnapshot({
         user: TEST_USER,
       });
 

--- a/packages/client/src/actions/positions.test.ts
+++ b/packages/client/src/actions/positions.test.ts
@@ -8,13 +8,10 @@ import {
   walletClient,
 } from '../testing';
 import { authenticateWith, completeWith } from '../viem';
-import { fetchMarket } from './markets';
-import { listPositions } from './portfolio';
-import { prepareMergePositions, prepareSplitPosition } from './positions';
 
 const TEST_MARKET_SLUG = 'eth-flipped-in-2026';
 
-const market = await fetchMarket(publicClient, {
+const market = await publicClient.fetchMarket({
   slug: TEST_MARKET_SLUG,
 });
 
@@ -29,19 +26,22 @@ invariant(
 
 describe('Positions', () => {
   it('splits a market position', async () => {
-    await prepareSplitPosition(secureClient, {
-      amount: 1_000_000n,
-      conditionId: market.conditionId,
-    })
+    await secureClient
+      .prepareSplitPosition({
+        amount: 1_000_000n,
+        conditionId: market.conditionId,
+      })
       .then(completeWith(walletClient))
       .then((handle) => handle.wait());
 
     await vi.waitFor(
       async () => {
-        const positions = await listPositions(secureClient, {
-          user: secureClient.account.wallet,
-          market: [market.conditionId],
-        }).firstPage();
+        const positions = await secureClient
+          .listPositions({
+            user: secureClient.account.wallet,
+            market: [market.conditionId],
+          })
+          .firstPage();
         expect(positions.items).toHaveLength(2);
       },
       { timeout: 15_000 },
@@ -49,28 +49,33 @@ describe('Positions', () => {
   }, 20_000);
 
   it('merges complementary positions', async ({ skip }) => {
-    const positions = await listPositions(secureClient, {
-      user: secureClient.account.wallet,
-      market: [market.conditionId],
-    }).firstPage();
+    const positions = await secureClient
+      .listPositions({
+        user: secureClient.account.wallet,
+        market: [market.conditionId],
+      })
+      .firstPage();
 
     if (positions.items.length < 2) {
       skip('Not enough positions to merge');
     }
 
-    await prepareMergePositions(secureClient, {
-      amount: 'max',
-      conditionId: market.conditionId,
-    })
+    await secureClient
+      .prepareMergePositions({
+        amount: 'max',
+        conditionId: market.conditionId,
+      })
       .then(completeWith(walletClient))
       .then((handle) => handle.wait());
 
     await vi.waitFor(
       async () => {
-        const positions = await listPositions(secureClient, {
-          user: secureClient.account.wallet,
-          market: [market.conditionId],
-        }).firstPage();
+        const positions = await secureClient
+          .listPositions({
+            user: secureClient.account.wallet,
+            market: [market.conditionId],
+          })
+          .firstPage();
         expect(positions.items).toHaveLength(0);
       },
       { timeout: 15_000 },

--- a/packages/client/src/actions/profiles.test.ts
+++ b/packages/client/src/actions/profiles.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { publicClient } from '../testing';
-import { fetchPublicProfile } from './profiles';
 
 describe('Profiles', () => {
   describe('fetchPublicProfile', () => {
     it('fetches a public profile by wallet address', async () => {
-      const result = await fetchPublicProfile(publicClient, {
+      const result = await publicClient.fetchPublicProfile({
         address: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
       });
 
@@ -18,7 +17,7 @@ describe('Profiles', () => {
 
     it('returns null when the profile does not exist', async () => {
       await expect(
-        fetchPublicProfile(publicClient, {
+        publicClient.fetchPublicProfile({
           address: '0x0000000000000000000000000000000000000001',
         }),
       ).resolves.toBeNull();

--- a/packages/client/src/actions/search.test.ts
+++ b/packages/client/src/actions/search.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { publicClient } from '../testing';
-import { search } from './search';
 
 describe('Search', () => {
   describe('search', () => {
     it('fetches public search results', async () => {
-      const result = await search(publicClient, {
+      const result = await publicClient.search({
         q: 'trump',
         limitPerType: 1,
       });

--- a/packages/client/src/actions/series.test.ts
+++ b/packages/client/src/actions/series.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import { fetchSeries, listSeries } from './series';
 
 describe('Series', () => {
   describe('listSeries', () => {
     it('fetches series', async () => {
-      const result = await listSeries(publicClient, {
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listSeries({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
@@ -24,13 +24,14 @@ describe('Series', () => {
     it('fetches a series by id', async () => {
       const {
         items: [series],
-      } = await listSeries(publicClient, {
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listSeries({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const result = await fetchSeries(publicClient, {
+      const result = await publicClient.fetchSeries({
         id: series.id,
       });
 

--- a/packages/client/src/actions/sports.test.ts
+++ b/packages/client/src/actions/sports.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { publicClient } from '../testing';
-import { fetchSportsMarketTypes, listSports } from './sports';
 
 describe('Sports', () => {
   describe('listSports', () => {
     it('fetches sports metadata', async () => {
-      const result = await listSports(publicClient);
+      const result = await publicClient.listSports();
 
       expect(result.length).toBeGreaterThan(0);
       expect(result[0]).toEqual(
@@ -18,7 +17,7 @@ describe('Sports', () => {
 
   describe('fetchSportsMarketTypes', () => {
     it('fetches sports market types', async () => {
-      const result = await fetchSportsMarketTypes(publicClient);
+      const result = await publicClient.fetchSportsMarketTypes();
 
       expect(result.marketTypes).toEqual(expect.any(Array));
       expect(result.marketTypes?.length).toBeGreaterThan(0);

--- a/packages/client/src/actions/tags.test.ts
+++ b/packages/client/src/actions/tags.test.ts
@@ -1,19 +1,14 @@
 import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import {
-  fetchRelatedTagResources,
-  fetchRelatedTags,
-  fetchTag,
-  listTags,
-} from './tags';
 
 describe('Tags', () => {
   describe('listTags', () => {
     it('fetches tags', async () => {
-      const result = await listTags(publicClient, {
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listTags({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
@@ -30,14 +25,15 @@ describe('Tags', () => {
     it('fetches a tag by id and slug', async () => {
       const {
         items: [tag],
-      } = await listTags(publicClient, {
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listTags({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const tagById = await fetchTag(publicClient, { id: tag.id });
-      const tagBySlug = await fetchTag(publicClient, {
+      const tagById = await publicClient.fetchTag({ id: tag.id });
+      const tagBySlug = await publicClient.fetchTag({
         slug: expectPresent(tag.slug),
       });
 
@@ -50,16 +46,17 @@ describe('Tags', () => {
     it('fetches related tag relationships by id and slug', async () => {
       const {
         items: [tag],
-      } = await listTags(publicClient, {
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listTags({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const relatedById = await fetchRelatedTags(publicClient, {
+      const relatedById = await publicClient.fetchRelatedTags({
         id: tag.id,
       });
-      const relatedBySlug = await fetchRelatedTags(publicClient, {
+      const relatedBySlug = await publicClient.fetchRelatedTags({
         slug: expectPresent(tag.slug),
       });
 
@@ -72,16 +69,17 @@ describe('Tags', () => {
     it('fetches related tags by id and slug', async () => {
       const {
         items: [tag],
-      } = await listTags(publicClient, {
-        pageSize: 1,
-      })
+      } = await publicClient
+        .listTags({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      const relatedTagsById = await fetchRelatedTagResources(publicClient, {
+      const relatedTagsById = await publicClient.fetchRelatedTagResources({
         id: tag.id,
       });
-      const relatedTagsBySlug = await fetchRelatedTagResources(publicClient, {
+      const relatedTagsBySlug = await publicClient.fetchRelatedTagResources({
         slug: expectPresent(tag.slug),
       });
 

--- a/packages/client/src/actions/teams.test.ts
+++ b/packages/client/src/actions/teams.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { expectNonEmptyPage, publicClient } from '../testing';
-import { listTeams } from './teams';
 
 describe('Teams', () => {
   describe('listTeams', () => {
     it('fetches teams', async () => {
-      const result = await listTeams(publicClient, {
-        pageSize: 1,
-      })
+      const result = await publicClient
+        .listTeams({
+          pageSize: 1,
+        })
         .firstPage()
         .then(expectNonEmptyPage);
 

--- a/packages/client/src/actions/transfers.test.ts
+++ b/packages/client/src/actions/transfers.test.ts
@@ -6,7 +6,6 @@ import {
   walletClient,
 } from '../testing';
 import { authenticateWith, completeWith } from '../viem';
-import { prepareErc20Transfer } from './transfers';
 
 describe('Transfers', () => {
   describe('prepareErc20Transfer', () => {
@@ -17,11 +16,13 @@ describe('Transfers', () => {
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      const handle = await prepareErc20Transfer(secureClient, {
-        amount: 1n,
-        recipientAddress: secureClient.account.signer,
-        tokenAddress: secureClient.environment.collateralToken,
-      }).then(completeWith(walletClient));
+      const handle = await secureClient
+        .prepareErc20Transfer({
+          amount: 1n,
+          recipientAddress: secureClient.account.signer,
+          tokenAddress: secureClient.environment.collateralToken,
+        })
+        .then(completeWith(walletClient));
 
       await expect(handle.wait()).resolves.toBeTruthy();
     });


### PR DESCRIPTION
## Summary
- Update action tests to call client-bound methods where they are available.
- Keep direct action calls only for actions without a bound client method.

## Verification
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor that switches action tests from standalone function calls to client-bound methods; minimal risk outside of potential test compilation/typing regressions.
> 
> **Overview**
> Refactors `packages/client` action tests to prefer **client-bound methods** (e.g. `publicClient.listMarkets()`, `secureClient.prepareErc20Approval()`) instead of calling standalone action functions.
> 
> Keeps direct action function usage only where no bound method is available (e.g. `fetchBalanceAllowance`, `prepareGaslessTransaction`, and a few CLOB helpers), and updates types/imports accordingly (e.g. `SecureClient` -> `Pick<AccountActions, ...>`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29de7656baf78bb957dcb637833c788cc14f2d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->