### PR TITLE
Default list positions to account wallet

### DIFF
--- a/packages/client/src/actions/account.test.ts
+++ b/packages/client/src/actions/account.test.ts
@@ -1,6 +1,6 @@
 import { AssetType } from '@polymarket/bindings/clob';
 import { describe, expect, it } from 'vitest';
-import type { AccountActions } from '../decorators';
+import type { SecureAccountActions } from '../decorators';
 import { publicClient, safeWalletAddress, walletClient } from '../testing';
 import { authenticateWith } from '../viem';
 import { fetchBalanceAllowance } from './account';
@@ -69,7 +69,7 @@ describe('Account', () => {
 });
 
 async function waitForNotificationsToClear(
-  secureClient: Pick<AccountActions, 'fetchNotifications'>,
+  secureClient: Pick<SecureAccountActions, 'fetchNotifications'>,
   ids: string[],
 ) {
   for (let attempt = 0; attempt < 10; attempt += 1) {

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -40,43 +40,18 @@ import type {
 } from '../clients';
 import type { Paginated } from '../pagination';
 
-export type AccountPublicActions = {
-  /**
-   * Lists current positions for a wallet.
-   *
-   * @throws {@link ListPositionsError}
-   * Thrown on failure.
-   *
-   * @example
-   * Fetch the first page of results:
-   * ```ts
-   * const paginator = client.listPositions({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   *   pageSize: 10,
-   * });
-   *
-   * const firstPage = await paginator.firstPage();
-   *
-   * // Optionally, fetch additional pages:
-   * for await (const page of paginator.from(firstPage.nextCursor)) {
-   *   // page.items: Position[]
-   * }
-   * ```
-   *
-   * @example
-   * Loop through all pages with `for await`:
-   * ```ts
-   * const paginator = client.listPositions({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   *   pageSize: 10,
-   * });
-   *
-   * for await (const page of paginator) {
-   *   // page.items: Position[]
-   * }
-   * ```
-   */
-  listPositions(request: ListPositionsRequest): Paginated<Position>;
+export type SecureListPositionsRequest = Prettify<
+  Omit<ListPositionsRequest, 'user'> & {
+    /**
+     * Wallet address to list positions for.
+     *
+     * @defaultValue `client.account.wallet`
+     */
+    user?: ListPositionsRequest['user'];
+  }
+>;
+
+export type CommonAccountActions = {
   /**
    * Lists closed positions for a wallet.
    *
@@ -237,86 +212,141 @@ export type AccountPublicActions = {
   listActivity(request: ListActivityRequest): Paginated<Activity>;
 };
 
-export type AccountActions = Prettify<
-  AccountPublicActions & {
-    /**
-     * Lists trades for the authenticated account across all pages.
-     *
-     * @throws {@link ListAccountTradesError}
-     * Thrown on failure.
-     *
-     * @example
-     * Fetch the first page of results:
-     * ```ts
-     * const paginator = client.listAccountTrades({
-     *   market: '0x0000000000000000000000000000000000000000000000000000000000000001',
-     * });
-     *
-     * const firstPage = await paginator.firstPage();
-     *
-     * // Optionally, fetch additional pages:
-     * for await (const page of paginator.from(firstPage.nextCursor)) {
-     *   // page.items: ClobTrade[]
-     * }
-     * ```
-     *
-     * @example
-     * Loop through all pages with `for await`:
-     * ```ts
-     * const paginator = client.listAccountTrades({
-     *   market: '0x0000000000000000000000000000000000000000000000000000000000000001',
-     * });
-     *
-     * for await (const page of paginator) {
-     *   // page.items: ClobTrade[]
-     * }
-     * ```
-     */
-    listAccountTrades(request?: ListAccountTradesRequest): Paginated<ClobTrade>;
-    /**
-     * Fetches notifications for the authenticated account.
-     *
-     * @throws {@link FetchNotificationsError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const notifications = await client.fetchNotifications();
-     * ```
-     */
-    fetchNotifications(): Promise<NotificationsResponse>;
-    /**
-     * Drops notifications for the authenticated account.
-     *
-     * @throws {@link DropNotificationsError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * await client.dropNotifications({
-     *   ids: ['1', '2'],
-     * });
-     * ```
-     */
-    dropNotifications(request: DropNotificationsRequest): Promise<void>;
-    /**
-     * Fetches whether the account is restricted to closed-only trading.
-     *
-     * @throws {@link FetchClosedOnlyModeError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const closedOnly = await client.fetchClosedOnlyMode();
-     * ```
-     */
-    fetchClosedOnlyMode(): Promise<boolean>;
-  }
->;
+export type PublicAccountActions = CommonAccountActions & {
+  /**
+   * Lists current positions for a wallet.
+   *
+   * @throws {@link ListPositionsError}
+   * Thrown on failure.
+   *
+   * @example
+   * Fetch the first page of results:
+   * ```ts
+   * const paginator = client.listPositions({
+   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+   *   pageSize: 10,
+   * });
+   *
+   * const firstPage = await paginator.firstPage();
+   *
+   * // Optionally, fetch additional pages:
+   * for await (const page of paginator.from(firstPage.nextCursor)) {
+   *   // page.items: Position[]
+   * }
+   * ```
+   *
+   * @example
+   * Loop through all pages with `for await`:
+   * ```ts
+   * const paginator = client.listPositions({
+   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+   *   pageSize: 10,
+   * });
+   *
+   * for await (const page of paginator) {
+   *   // page.items: Position[]
+   * }
+   * ```
+   */
+  listPositions(request: ListPositionsRequest): Paginated<Position>;
+};
 
-function publicAccountActions(client: BaseClient): AccountPublicActions {
+export type SecureAccountActions = CommonAccountActions & {
+  /**
+   * Lists current positions for a wallet.
+   *
+   * Defaults to the authenticated account's wallet when `user` is omitted.
+   *
+   * @throws {@link ListPositionsError}
+   * Thrown on failure.
+   *
+   * @example
+   * Fetch the first page of results for the authenticated account:
+   * ```ts
+   * const paginator = client.listPositions({
+   *   pageSize: 10,
+   * });
+   *
+   * const firstPage = await paginator.firstPage();
+   * ```
+   */
+  listPositions(request?: SecureListPositionsRequest): Paginated<Position>;
+  /**
+   * Lists trades for the authenticated account across all pages.
+   *
+   * @throws {@link ListAccountTradesError}
+   * Thrown on failure.
+   *
+   * @example
+   * Fetch the first page of results:
+   * ```ts
+   * const paginator = client.listAccountTrades({
+   *   market: '0x0000000000000000000000000000000000000000000000000000000000000001',
+   * });
+   *
+   * const firstPage = await paginator.firstPage();
+   *
+   * // Optionally, fetch additional pages:
+   * for await (const page of paginator.from(firstPage.nextCursor)) {
+   *   // page.items: ClobTrade[]
+   * }
+   * ```
+   *
+   * @example
+   * Loop through all pages with `for await`:
+   * ```ts
+   * const paginator = client.listAccountTrades({
+   *   market: '0x0000000000000000000000000000000000000000000000000000000000000001',
+   * });
+   *
+   * for await (const page of paginator) {
+   *   // page.items: ClobTrade[]
+   * }
+   * ```
+   */
+  listAccountTrades(request?: ListAccountTradesRequest): Paginated<ClobTrade>;
+  /**
+   * Fetches notifications for the authenticated account.
+   *
+   * @throws {@link FetchNotificationsError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const notifications = await client.fetchNotifications();
+   * ```
+   */
+  fetchNotifications(): Promise<NotificationsResponse>;
+  /**
+   * Drops notifications for the authenticated account.
+   *
+   * @throws {@link DropNotificationsError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * await client.dropNotifications({
+   *   ids: ['1', '2'],
+   * });
+   * ```
+   */
+  dropNotifications(request: DropNotificationsRequest): Promise<void>;
+  /**
+   * Fetches whether the account is restricted to closed-only trading.
+   *
+   * @throws {@link FetchClosedOnlyModeError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const closedOnly = await client.fetchClosedOnlyMode();
+   * ```
+   */
+  fetchClosedOnlyMode(): Promise<boolean>;
+};
+
+function commonAccountActions(client: BaseClient): CommonAccountActions {
   return {
-    listPositions: listPositions.bind(null, client),
     listClosedPositions: listClosedPositions.bind(null, client),
     fetchPortfolioValue: fetchPortfolioValue.bind(null, client),
     fetchTradedMarketCount: fetchTradedMarketCount.bind(null, client),
@@ -326,19 +356,27 @@ function publicAccountActions(client: BaseClient): AccountPublicActions {
   };
 }
 
-export function accountActions(client: BasePublicClient): AccountPublicActions;
-export function accountActions(client: BaseSecureClient): AccountActions;
+export function accountActions(client: BasePublicClient): PublicAccountActions;
+export function accountActions(client: BaseSecureClient): SecureAccountActions;
 export function accountActions(
   client: BaseClient,
-): AccountPublicActions | AccountActions {
-  const actions = publicAccountActions(client);
+): PublicAccountActions | SecureAccountActions {
+  const actions = commonAccountActions(client);
 
   if (client.isPublicClient()) {
-    return actions;
+    return {
+      ...actions,
+      listPositions: listPositions.bind(null, client),
+    };
   }
 
   return {
     ...actions,
+    listPositions: (request: SecureListPositionsRequest = {}) =>
+      listPositions(client, {
+        ...request,
+        user: request.user ?? client.account.wallet,
+      }),
     listAccountTrades: listAccountTrades.bind(null, client),
     fetchNotifications: fetchNotifications.bind(null, client),
     dropNotifications: dropNotifications.bind(null, client),
@@ -348,7 +386,7 @@ export function accountActions(
 
 // Error unions and runtime `isError` guards for every action bound above.
 // Surfaced at the root entry point through `export * from './decorators'`.
-// Keep this list in sync with the methods on AccountPublicActions / AccountActions.
+// Keep this list in sync with the methods on PublicAccountActions / SecureAccountActions.
 export {
   DownloadAccountingSnapshotError,
   DropNotificationsError,

--- a/packages/client/src/decorators/index.ts
+++ b/packages/client/src/decorators/index.ts
@@ -5,9 +5,9 @@ import type {
   BaseSecureClient,
 } from '../clients';
 import {
-  type AccountActions,
-  type AccountPublicActions,
   accountActions,
+  type PublicAccountActions,
+  type SecureAccountActions,
 } from './account';
 import { type AnalyticsActions, analyticsActions } from './analytics';
 import { type DataActions, dataActions } from './data';
@@ -33,7 +33,7 @@ export type PublicActions = Prettify<
   DiscoveryActions &
     DataActions &
     AnalyticsActions &
-    AccountPublicActions &
+    PublicAccountActions &
     RewardsPublicActions &
     PublicSubscriptionsActions &
     PublicWalletActions
@@ -43,7 +43,7 @@ export type SecureActions = Prettify<
   DiscoveryActions &
     DataActions &
     AnalyticsActions &
-    AccountActions &
+    SecureAccountActions &
     RewardsActions &
     SecureSubscriptionsActions &
     SecureWalletActions &


### PR DESCRIPTION
## Summary
- Split account decorator types into common, public, and secure action surfaces.
- Allow secure clients to call `listPositions()` without passing `user`, defaulting to `client.account.wallet`.
- Keep public clients and free actions explicit about the `user` parameter.

## Verification
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the API/type surface and alters `listPositions` parameter behavior for secure clients, which could break downstream TypeScript callers or change which wallet’s positions are fetched if assumptions were different.
> 
> **Overview**
> Secure account clients can now call `listPositions()` without a `user`, with the decorator defaulting to `client.account.wallet`.
> 
> To support this, the account decorator surface is split into `CommonAccountActions`, `PublicAccountActions`, and `SecureAccountActions`, and `decorators/index.ts` and tests are updated to reference the new secure/public types and keep public usage requiring an explicit `user`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc0bb41f1f6655f5cada4f7f07df79bffa71845a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->