### PR TITLE
Normalize market response shape

### DIFF
--- a/packages/bindings/src/clob/market-data.ts
+++ b/packages/bindings/src/clob/market-data.ts
@@ -11,7 +11,7 @@ export enum PriceHistoryInterval {
 
 export const PriceHistoryIntervalSchema = z.enum(PriceHistoryInterval);
 
-export const MidpointSchema = z.looseObject({
+export const MidpointSchema = z.object({
   mid: z.string(),
 });
 export type Midpoint = z.infer<typeof MidpointSchema>;
@@ -19,7 +19,7 @@ export type Midpoint = z.infer<typeof MidpointSchema>;
 export const MidpointsSchema = z.record(z.string(), z.string());
 export type Midpoints = z.infer<typeof MidpointsSchema>;
 
-export const PriceSchema = z.looseObject({
+export const PriceSchema = z.object({
   price: z.string(),
 });
 export type Price = z.infer<typeof PriceSchema>;
@@ -30,7 +30,7 @@ export type PricesBySide = z.infer<typeof PricesBySideSchema>;
 export const PricesSchema = z.record(z.string(), PricesBySideSchema);
 export type Prices = z.infer<typeof PricesSchema>;
 
-export const SpreadSchema = z.looseObject({
+export const SpreadSchema = z.object({
   spread: z.string(),
 });
 export type Spread = z.infer<typeof SpreadSchema>;
@@ -38,7 +38,7 @@ export type Spread = z.infer<typeof SpreadSchema>;
 export const SpreadsSchema = z.record(z.string(), z.string());
 export type Spreads = z.infer<typeof SpreadsSchema>;
 
-export const LastTradePriceSchema = z.looseObject({
+export const LastTradePriceSchema = z.object({
   price: z.string(),
   side: OrderSideSchema,
 });
@@ -79,7 +79,7 @@ const PriceHistoryPointSchema = z.object({
 });
 export type PriceHistoryPoint = z.infer<typeof PriceHistoryPointSchema>;
 
-export const PriceHistorySchema = z.looseObject({
+export const PriceHistorySchema = z.object({
   history: z.array(PriceHistoryPointSchema),
 });
 export type PriceHistory = z.infer<typeof PriceHistorySchema>;

--- a/packages/bindings/src/clob/order-book.ts
+++ b/packages/bindings/src/clob/order-book.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { EpochMillisecondsStringSchema, TokenIdSchema } from '../shared';
 
-export const OrderBookLevelSchema = z.looseObject({
+export const OrderBookLevelSchema = z.object({
   price: z.string(),
   size: z.string(),
 });

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -62,7 +62,7 @@ export const ActivitySchema = z
     tokenId: asset,
   }));
 
-export const TradedSchema = z.looseObject({
+export const TradedSchema = z.object({
   user: AddressSchema.nullish(),
   traded: z.number().int().nullish(),
 });

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -20,22 +20,22 @@ export const HolderSchema = z
     tokenId: asset,
   }));
 
-export const MetaHolderSchema = z.looseObject({
+export const MetaHolderSchema = z.object({
   token: z.string().nullish(),
   holders: z.array(HolderSchema).nullish(),
 });
 
-export const OpenInterestSchema = z.looseObject({
+export const OpenInterestSchema = z.object({
   market: Hash64Schema.nullish(),
   value: z.number().nullish(),
 });
 
-export const MarketVolumeSchema = z.looseObject({
+export const MarketVolumeSchema = z.object({
   market: Hash64Schema.nullish(),
   value: z.number().nullish(),
 });
 
-export const LiveVolumeSchema = z.looseObject({
+export const LiveVolumeSchema = z.object({
   total: z.number().nullish(),
   markets: z.array(MarketVolumeSchema).nullish(),
 });

--- a/packages/bindings/src/data/leaderboard.ts
+++ b/packages/bindings/src/data/leaderboard.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { IsoDateTimeStringSchema } from '../shared';
 import { AddressSchema } from './common';
 
-export const LeaderboardEntrySchema = z.looseObject({
+export const LeaderboardEntrySchema = z.object({
   rank: z.string().nullish(),
   builder: z.string().nullish(),
   volume: z.number().nullish(),
@@ -26,7 +26,7 @@ export const BuilderVolumeEntrySchema = z
     bucketAt: dt,
   }));
 
-export const TraderLeaderboardEntrySchema = z.looseObject({
+export const TraderLeaderboardEntrySchema = z.object({
   rank: z.string().nullish(),
   proxyWallet: AddressSchema.nullish(),
   userName: z.string().nullish(),

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -69,7 +69,7 @@ export const ClosedPositionSchema = z
     oppositeTokenId: oppositeAsset,
   }));
 
-export const ValueSchema = z.looseObject({
+export const ValueSchema = z.object({
   user: AddressSchema.nullish(),
   value: z.number().nullish(),
 });
@@ -98,7 +98,7 @@ export const MarketPositionV1Schema = z
     tokenId: asset,
   }));
 
-export const MetaMarketPositionV1Schema = z.looseObject({
+export const MetaMarketPositionV1Schema = z.object({
   token: z.string().nullish(),
   positions: z.array(MarketPositionV1Schema).nullish(),
 });

--- a/packages/bindings/src/gamma/comment.ts
+++ b/packages/bindings/src/gamma/comment.ts
@@ -9,12 +9,12 @@ import {
 import { ImageOptimizationSchema } from './common';
 import { SeriesIdSchema } from './event';
 
-export const CommentPositionSchema = z.looseObject({
+export const CommentPositionSchema = z.object({
   tokenId: TokenIdSchema.nullish(),
   positionSize: z.string().nullish(),
 });
 
-export const CommentProfileSchema = z.looseObject({
+export const CommentProfileSchema = z.object({
   name: z.string().nullish(),
   pseudonym: z.string().nullish(),
   displayUsernamePublic: z.boolean().nullish(),
@@ -34,7 +34,7 @@ export enum ReactionType {
 
 export const ReactionTypeSchema = z.enum(ReactionType);
 
-export const ReactionSchema = z.looseObject({
+export const ReactionSchema = z.object({
   id: z.string(),
   commentID: z.number().int().nullish(),
   reactionType: ReactionTypeSchema.nullish(),
@@ -44,7 +44,7 @@ export const ReactionSchema = z.looseObject({
   profile: CommentProfileSchema.nullish(),
 });
 
-export const CommentMediaSchema = z.looseObject({
+export const CommentMediaSchema = z.object({
   id: z.string(),
   commentID: z.number().int().nullish(),
   provider: z.string().nullish(),
@@ -55,7 +55,7 @@ export const CommentMediaSchema = z.looseObject({
   createdAt: IsoDateTimeStringSchema.nullish(),
 });
 
-export const CommentSchema = z.looseObject({
+export const CommentSchema = z.object({
   id: CommentIdSchema,
   body: z.string().nullish(),
   parentEntityType: CommentParentEntityTypeSchema.nullish(),

--- a/packages/bindings/src/gamma/common.ts
+++ b/packages/bindings/src/gamma/common.ts
@@ -13,7 +13,7 @@ import {
   TagIdSchema,
 } from '../shared';
 
-export const ImageOptimizationSchema = z.looseObject({
+export const ImageOptimizationSchema = z.object({
   id: ImageOptimizationIdSchema,
   imageUrlSource: z.string().nullish(),
   imageUrlOptimized: z.string().nullish(),
@@ -26,16 +26,16 @@ export const ImageOptimizationSchema = z.looseObject({
   relname: z.string().nullish(),
 });
 
-export const FeeScheduleSchema = z.looseObject({
+export const FeeScheduleSchema = z.object({
   exponent: z.number(),
   rate: z.number(),
   takerOnly: z.boolean(),
   rebateRate: z.number(),
 });
 
-export const EventReferenceSchema = z.looseObject({ id: EventIdSchema });
+export const EventReferenceSchema = z.object({ id: EventIdSchema });
 
-export const CategoryReferenceSchema = z.looseObject({
+export const CategoryReferenceSchema = z.object({
   id: CategoryIdSchema,
   label: z.string().nullish(),
   parentCategory: z.string().nullish(),
@@ -47,7 +47,7 @@ export const CategoryReferenceSchema = z.looseObject({
   updatedAt: IsoDateTimeStringSchema.nullish(),
 });
 
-export const TagReferenceSchema = z.looseObject({
+export const TagReferenceSchema = z.object({
   id: TagIdSchema,
   label: z.string().nullish(),
   slug: z.string().nullish(),
@@ -63,7 +63,7 @@ export const TagReferenceSchema = z.looseObject({
   activeEventsCount: z.number().int().nullish(),
 });
 
-export const RelatedMarketSchema = z.looseObject({
+export const RelatedMarketSchema = z.object({
   id: MarketIdSchema,
   conditionId: OptionalConditionIdSchema,
   slug: z.string().nullish(),
@@ -76,7 +76,7 @@ export const RelatedMarketSchema = z.looseObject({
   eventSlug: z.string().nullish(),
 });
 
-export const ClobRewardsSchema = z.looseObject({
+export const ClobRewardsSchema = z.object({
   id: ClobRewardIdSchema,
   conditionId: ConditionIdSchema,
   assetAddress: z.string(),
@@ -86,7 +86,7 @@ export const ClobRewardsSchema = z.looseObject({
   endDate: IsoCalendarDateStringSchema.nullish(),
 });
 
-export const InternalUserSchema = z.looseObject({
+export const InternalUserSchema = z.object({
   id: InternalUserIdSchema,
   username: z.string().nullish(),
 });

--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -39,7 +39,7 @@ const SportIdSchema = z.number().int().transform(toSportId);
 const TeamIdSchema = z.number().int().transform(toTeamId);
 const TemplateIdSchema = z.string().transform(toTemplateId);
 
-export const CollectionReferenceSchema = z.looseObject({
+export const CollectionReferenceSchema = z.object({
   id: CollectionIdSchema,
   ticker: z.string().nullish(),
   slug: z.string().nullish(),
@@ -69,7 +69,7 @@ export const CollectionReferenceSchema = z.looseObject({
   commentsEnabled: z.boolean().nullish(),
 });
 
-export const SeriesReferenceSchema = z.looseObject({
+export const SeriesReferenceSchema = z.object({
   id: SeriesIdSchema,
   ticker: z.string().nullish(),
   slug: z.string().nullish(),
@@ -107,7 +107,7 @@ export const SeriesReferenceSchema = z.looseObject({
   requiresTranslation: z.boolean().nullish(),
 });
 
-export const TemplateReferenceSchema = z.looseObject({
+export const TemplateReferenceSchema = z.object({
   id: TemplateIdSchema,
   displayName: z.string().nullish(),
   eventTitle: z.string().nullish(),
@@ -125,7 +125,7 @@ export const TemplateReferenceSchema = z.looseObject({
   updatedAt: IsoDateTimeStringSchema.nullish(),
 });
 
-export const ChatSchema = z.looseObject({
+export const ChatSchema = z.object({
   id: ChatIdSchema,
   channelId: z.string().nullish(),
   channelName: z.string().nullish(),
@@ -135,7 +135,7 @@ export const ChatSchema = z.looseObject({
   endTime: IsoDateTimeStringSchema.nullish(),
 });
 
-export const EventCreatorSchema = z.looseObject({
+export const EventCreatorSchema = z.object({
   id: EventCreatorIdSchema,
   creatorName: z.string().nullish(),
   creatorHandle: z.string().nullish(),
@@ -145,7 +145,7 @@ export const EventCreatorSchema = z.looseObject({
   updatedAt: IsoDateTimeStringSchema.nullish(),
 });
 
-export const PartnerSchema = z.looseObject({
+export const PartnerSchema = z.object({
   id: PartnerIdSchema,
   slug: z.string(),
   name: z.string(),
@@ -153,7 +153,7 @@ export const PartnerSchema = z.looseObject({
   updatedAt: IsoDateTimeStringSchema.nullish(),
 });
 
-export const EventExternalPartnerMappingSchema = z.looseObject({
+export const EventExternalPartnerMappingSchema = z.object({
   id: EventExternalPartnerMappingIdSchema,
   eventId: z.number().int(),
   partnerId: z.number().int(),
@@ -163,13 +163,13 @@ export const EventExternalPartnerMappingSchema = z.looseObject({
   updatedAt: IsoDateTimeStringSchema.nullish(),
 });
 
-export const BestLineSchema = z.looseObject({
+export const BestLineSchema = z.object({
   id: BestLineIdSchema,
   lineType: z.string().nullish(),
   line: z.number().nullish(),
 });
 
-export const TeamSchema = z.looseObject({
+export const TeamSchema = z.object({
   id: TeamIdSchema,
   name: z.string().nullish(),
   league: z.string().nullish(),
@@ -183,7 +183,7 @@ export const TeamSchema = z.looseObject({
   color: z.string().nullish(),
 });
 
-export const SportsMetadataSchema = z.looseObject({
+export const SportsMetadataSchema = z.object({
   id: SportIdSchema,
   sport: z.string(),
   image: z.string(),
@@ -197,7 +197,7 @@ export const SportsMetadataSchema = z.looseObject({
 
 export const ListTeamsResponseSchema = z.array(TeamSchema);
 export const ListSportsMetadataResponseSchema = z.array(SportsMetadataSchema);
-export const SportsMarketTypesResponseSchema = z.looseObject({
+export const SportsMarketTypesResponseSchema = z.object({
   marketTypes: z.array(z.string()).nullish(),
 });
 

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -24,7 +24,6 @@ import {
   TokenIdSchema,
 } from '../shared';
 import {
-  CategoryReferenceSchema,
   type ClobRewards,
   ClobRewardsSchema,
   type FeeSchedule,
@@ -38,7 +37,7 @@ import {
 const StringPairSchema = z.tuple([z.string(), z.string()]);
 const TokenIdPairValueSchema = z.tuple([TokenIdSchema, TokenIdSchema]);
 const EmptyArraySchema = z.tuple([]).transform(() => null);
-const GammaMarketEventSchema = z.looseObject({
+const GammaMarketEventSchema = z.object({
   id: EventIdSchema,
   slug: z.string().nullish(),
   title: z.string().nullish(),
@@ -70,6 +69,8 @@ export enum UmaResolutionStatus {
   Disputed = 'disputed',
   Resolved = 'resolved',
 }
+
+const UmaResolutionStatusSchema = z.enum(UmaResolutionStatus);
 
 export type MarketState = {
   active?: boolean | null;
@@ -132,7 +133,7 @@ export type MarketTrading = {
 export type MarketResolution = {
   questionId: QuestionId | null;
   negRiskRequestId: ResolutionRequestId | null;
-  umaResolutionStatus?: string | null;
+  umaResolutionStatus: UmaResolutionStatus | null;
   source?: string | null;
   resolvedBy: EvmAddress | null;
 };
@@ -184,7 +185,7 @@ export type Market = {
   tags: MarketTag[];
 };
 
-export const GammaMarketSchema = z.looseObject({
+export const GammaMarketSchema = z.object({
   id: MarketIdSchema,
   question: z.string().nullish(),
   conditionId: ConditionIdSchema,
@@ -234,17 +235,23 @@ export const GammaMarketSchema = z.looseObject({
   twitterCardLastRefreshed: IsoDateTimeStringSchema.nullish(),
   twitterCardLastValidated: IsoDateTimeStringSchema.nullish(),
   archived: z.boolean().nullish(),
-  resolvedBy: z.string().nullish(),
+  resolvedBy: z
+    .preprocess(emptyStringToNull, EvmAddressSchema.nullish())
+    .transform(nullishToNull),
   restricted: z.boolean().nullish(),
   marketGroup: z.number().int().nullish(),
   groupItemTitle: z.string().nullish(),
   groupItemThreshold: z.string().nullish(),
-  questionID: z.string().nullish(),
+  questionID: z
+    .preprocess(emptyStringToNull, QuestionIdSchema.nullish())
+    .transform(nullishToNull),
   umaEndDate: MixedDateTimeStringSchema.nullish(),
   enableOrderBook: z.boolean().nullish(),
   orderPriceMinTickSize: TickSizeValueSchema.nullish(),
   orderMinSize: z.number().nullish(),
-  umaResolutionStatus: z.string().nullish(),
+  umaResolutionStatus: z
+    .preprocess(emptyStringToNull, UmaResolutionStatusSchema.nullish())
+    .transform(nullishToNull),
   curationOrder: z.number().int().nullish(),
   volumeNum: z.number().nullish(),
   liquidityNum: z.number().nullish(),
@@ -286,13 +293,16 @@ export const GammaMarketSchema = z.looseObject({
   acceptingOrders: z.boolean().nullish(),
   negRisk: z.boolean().nullish(),
   negRiskMarketID: z.string().nullish(),
-  negRiskRequestID: z.string().nullish(),
+  negRiskRequestID: z
+    .preprocess(emptyStringToNull, ResolutionRequestIdSchema.nullish())
+    .transform(nullishToNull),
   notificationsEnabled: z.boolean().nullish(),
   score: z.number().int().nullish(),
   imageOptimized: ImageOptimizationSchema.nullish(),
   iconOptimized: ImageOptimizationSchema.nullish(),
   events: z.array(GammaMarketEventSchema).nullish(),
-  categories: z.array(CategoryReferenceSchema).nullish(),
+  // Parsed for raw Gamma compatibility; normalized Market intentionally uses category/tags only.
+  categories: z.array(z.unknown()).nullish(),
   markets: z.array(RelatedMarketSchema).nullish(),
   creator: z.string().nullish(),
   ready: z.boolean().nullish(),
@@ -429,14 +439,11 @@ function normalizeMarket(market: GammaMarket): Market {
       feeSchedule: market.feeSchedule,
     },
     resolution: {
-      questionId: parseOptionalString(QuestionIdSchema, market.questionID),
-      negRiskRequestId: parseOptionalString(
-        ResolutionRequestIdSchema,
-        market.negRiskRequestID,
-      ),
+      questionId: market.questionID,
+      negRiskRequestId: market.negRiskRequestID,
       umaResolutionStatus: market.umaResolutionStatus,
       source: market.resolutionSource,
-      resolvedBy: parseOptionalString(EvmAddressSchema, market.resolvedBy),
+      resolvedBy: market.resolvedBy,
     },
     rewards: {
       clobRewards: market.clobRewards,
@@ -452,8 +459,8 @@ function normalizeMarket(market: GammaMarket): Market {
     },
     events: (market.events ?? []).map((event) => ({
       id: event.id,
-      slug: readOptionalString(event.slug),
-      title: readOptionalString(event.title),
+      slug: event.slug ?? null,
+      title: event.title ?? null,
     })),
     tags: (market.tags ?? []).map((tag) => ({
       id: tag.id,
@@ -463,19 +470,12 @@ function normalizeMarket(market: GammaMarket): Market {
   };
 }
 
-function parseOptionalString<T>(
-  schema: z.ZodType<T>,
-  value: string | null | undefined,
-): T | null {
-  if (value === undefined || value === null || value === '') {
-    return null;
-  }
-
-  return schema.parse(value);
+function emptyStringToNull(value: unknown): unknown {
+  return value === '' ? null : value;
 }
 
-function readOptionalString(value: unknown): string | null {
-  return typeof value === 'string' ? value : null;
+function nullishToNull<T>(value: T | null | undefined): T | null {
+  return value ?? null;
 }
 
 function parseJsonString(value: unknown): unknown {

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -1,18 +1,33 @@
 import { z } from 'zod';
 import {
+  type ConditionId,
   ConditionIdSchema,
+  type EventId,
+  EventIdSchema,
+  type EvmAddress,
+  EvmAddressSchema,
   IsoCalendarDateStringSchema,
+  type IsoDateTimeString,
   IsoDateTimeStringSchema,
+  type MarketId,
   MarketIdSchema,
   MixedDateTimeStringSchema,
   PaginationCursorSchema,
+  type QuestionId,
+  QuestionIdSchema,
+  type ResolutionRequestId,
+  ResolutionRequestIdSchema,
+  type TagId,
+  type TickSizeValue,
   TickSizeValueSchema,
+  type TokenId,
   TokenIdSchema,
 } from '../shared';
 import {
   CategoryReferenceSchema,
+  type ClobRewards,
   ClobRewardsSchema,
-  EventReferenceSchema,
+  type FeeSchedule,
   FeeScheduleSchema,
   ImageOptimizationSchema,
   InternalUserSchema,
@@ -22,212 +37,321 @@ import {
 
 const StringPairSchema = z.tuple([z.string(), z.string()]);
 const TokenIdPairValueSchema = z.tuple([TokenIdSchema, TokenIdSchema]);
+const EmptyArraySchema = z.tuple([]).transform(() => null);
+const GammaMarketEventSchema = z.looseObject({
+  id: EventIdSchema,
+  slug: z.string().nullish(),
+  title: z.string().nullish(),
+});
 
-const OutcomePairSchema = z
-  .union([z.string().transform((val) => JSON.parse(val)), StringPairSchema])
-  .pipe(StringPairSchema);
+const OutcomePairSchema = z.preprocess(parseJsonString, StringPairSchema);
 
 const OutcomePricePairSchema = z
-  .union([z.string().transform((val) => JSON.parse(val)), StringPairSchema])
-  .pipe(StringPairSchema);
+  .preprocess(
+    parseJsonString,
+    z.union([StringPairSchema, EmptyArraySchema, z.null(), z.undefined()]),
+  )
+  .transform((value) => value ?? null);
 
 const TokenIdPairSchema = z
-  .union([
-    z.string().transform((val) => JSON.parse(val)),
-    z.tuple([z.string(), z.string()]),
-  ])
-  .pipe(TokenIdPairValueSchema);
+  .preprocess(
+    parseJsonString,
+    z.union([
+      TokenIdPairValueSchema,
+      EmptyArraySchema,
+      z.null(),
+      z.undefined(),
+    ]),
+  )
+  .transform((value) => value ?? null);
 
-export const MarketSchema = z
-  .looseObject({
-    id: MarketIdSchema,
-    question: z.string().nullish(),
-    conditionId: ConditionIdSchema,
-    slug: z.string().nullish(),
-    twitterCardImage: z.string().nullish(),
-    resolutionSource: z.string().nullish(),
-    endDate: IsoDateTimeStringSchema.nullish(),
-    category: z.string().nullish(),
-    ammType: z.string().nullish(),
-    liquidity: z.string().nullish(),
-    sponsorName: z.string().nullish(),
-    sponsorImage: z.string().nullish(),
-    startDate: IsoDateTimeStringSchema.nullish(),
-    xAxisValue: z.string().nullish(),
-    yAxisValue: z.string().nullish(),
-    denominationToken: z.string().nullish(),
-    fee: z.string().nullish(),
-    image: z.string().nullish(),
-    icon: z.string().nullish(),
-    lowerBound: z.string().nullish(),
-    upperBound: z.string().nullish(),
-    description: z.string().nullish(),
-    outcomes: OutcomePairSchema.nullish(),
-    outcomePrices: OutcomePricePairSchema.nullish(),
-    volume: z.string().nullish(),
-    active: z.boolean().nullish(),
-    marketType: z.string().nullish(),
-    formatType: z.string().nullish(),
-    lowerBoundDate: IsoCalendarDateStringSchema.nullish(),
-    upperBoundDate: IsoCalendarDateStringSchema.nullish(),
-    closed: z.boolean().nullish(),
-    marketMakerAddress: z.string(),
-    createdBy: z.number().int().nullish(),
-    updatedBy: z.number().int().nullish(),
-    createdAt: IsoDateTimeStringSchema.nullish(),
-    updatedAt: IsoDateTimeStringSchema.nullish(),
-    closedTime: IsoDateTimeStringSchema.nullish(),
-    wideFormat: z.boolean().nullish(),
-    new: z.boolean().nullish(),
-    sentDiscord: z.boolean().nullish(),
-    mailchimpTag: z.string().nullish(),
-    featured: z.boolean().nullish(),
-    submitted_by: z.string().nullish(),
-    subcategory: z.string().nullish(),
-    categoryMailchimpTag: z.string().nullish(),
-    twitterCardLocation: z.string().nullish(),
-    twitterCardLastRefreshed: IsoDateTimeStringSchema.nullish(),
-    twitterCardLastValidated: IsoDateTimeStringSchema.nullish(),
-    archived: z.boolean().nullish(),
-    resolvedBy: z.string().nullish(),
-    restricted: z.boolean().nullish(),
-    marketGroup: z.number().int().nullish(),
-    groupItemTitle: z.string().nullish(),
-    groupItemThreshold: z.string().nullish(),
-    questionID: z.string().nullish(),
-    umaEndDate: MixedDateTimeStringSchema.nullish(),
-    enableOrderBook: z.boolean().nullish(),
-    orderPriceMinTickSize: TickSizeValueSchema.nullish(),
-    orderMinSize: z.number().nullish(),
-    umaResolutionStatus: z.string().nullish(),
-    curationOrder: z.number().int().nullish(),
-    volumeNum: z.number().nullish(),
-    liquidityNum: z.number().nullish(),
-    endDateIso: IsoCalendarDateStringSchema.nullish(),
-    startDateIso: IsoCalendarDateStringSchema.nullish(),
-    umaEndDateIso: IsoCalendarDateStringSchema.nullish(),
-    hasReviewedDates: z.boolean().nullish(),
-    readyForCron: z.boolean().nullish(),
-    commentsEnabled: z.boolean().nullish(),
-    volume24hr: z.number().nullish(),
-    volume1wk: z.number().nullish(),
-    volume1mo: z.number().nullish(),
-    volume1yr: z.number().nullish(),
-    gameStartTime: IsoDateTimeStringSchema.nullish(),
-    secondsDelay: z.number().int().nullish(),
-    clobTokenIds: TokenIdPairSchema.nullish(),
-    disqusThread: z.string().nullish(),
-    shortOutcomes: z.string().nullish(),
-    teamAID: z.string().nullish(),
-    teamBID: z.string().nullish(),
-    umaBond: z.string().nullish(),
-    umaReward: z.string().nullish(),
-    fpmmLive: z.boolean().nullish(),
-    volume24hrAmm: z.number().nullish(),
-    volume1wkAmm: z.number().nullish(),
-    volume1moAmm: z.number().nullish(),
-    volume1yrAmm: z.number().nullish(),
-    volume24hrClob: z.number().nullish(),
-    volume1wkClob: z.number().nullish(),
-    volume1moClob: z.number().nullish(),
-    volume1yrClob: z.number().nullish(),
-    volumeAmm: z.number().nullish(),
-    volumeClob: z.number().nullish(),
-    liquidityAmm: z.number().nullish(),
-    liquidityClob: z.number().nullish(),
-    makerBaseFee: z.number().int().nullish(),
-    takerBaseFee: z.number().int().nullish(),
-    customLiveness: z.number().int().nullish(),
-    acceptingOrders: z.boolean().nullish(),
-    negRisk: z.boolean().nullish(),
-    negRiskMarketID: z.string().nullish(),
-    negRiskRequestID: z.string().nullish(),
-    notificationsEnabled: z.boolean().nullish(),
-    score: z.number().int().nullish(),
-    imageOptimized: ImageOptimizationSchema.nullish(),
-    iconOptimized: ImageOptimizationSchema.nullish(),
-    events: z.array(EventReferenceSchema).nullish(),
-    categories: z.array(CategoryReferenceSchema).nullish(),
-    markets: z.array(RelatedMarketSchema).nullish(),
-    creator: z.string().nullish(),
-    ready: z.boolean().nullish(),
-    funded: z.boolean().nullish(),
-    pastSlugs: z.string().nullish(),
-    readyTimestamp: IsoDateTimeStringSchema.nullish(),
-    fundedTimestamp: IsoDateTimeStringSchema.nullish(),
-    acceptingOrdersTimestamp: IsoDateTimeStringSchema.nullish(),
-    tags: z.array(TagReferenceSchema).nullish(),
-    cyom: z.boolean().nullish(),
-    competitive: z.number().nullish(),
-    pagerDutyNotificationEnabled: z.boolean().nullish(),
-    approved: z.boolean().nullish(),
-    clobRewards: z.array(ClobRewardsSchema).nullish(),
-    rewardsMinSize: z.number().nullish(),
-    rewardsMaxSpread: z.number().nullish(),
-    spread: z.number().nullish(),
-    automaticallyResolved: z.boolean().nullish(),
-    oneDayPriceChange: z.number().nullish(),
-    oneHourPriceChange: z.number().nullish(),
-    oneWeekPriceChange: z.number().nullish(),
-    oneMonthPriceChange: z.number().nullish(),
-    oneYearPriceChange: z.number().nullish(),
-    lastTradePrice: z.number().nullish(),
-    bestBid: z.number().nullish(),
-    bestAsk: z.number().nullish(),
-    automaticallyActive: z.boolean().nullish(),
-    clearBookOnStart: z.boolean().nullish(),
-    chartColor: z.string().nullish(),
-    seriesColor: z.string().nullish(),
-    showGmpSeries: z.boolean().nullish(),
-    showGmpOutcome: z.boolean().nullish(),
-    manualActivation: z.boolean().nullish(),
-    negRiskOther: z.boolean().nullish(),
-    gameId: z.string().nullish(),
-    groupItemRange: z.string().nullish(),
-    sportsMarketType: z.string().nullish(),
-    line: z.number().nullish(),
-    umaResolutionStatuses: z.string().nullish(),
-    pendingDeployment: z.boolean().nullish(),
-    deploying: z.boolean().nullish(),
-    deployingTimestamp: IsoDateTimeStringSchema.nullish(),
-    scheduledDeploymentTimestamp: IsoDateTimeStringSchema.nullish(),
-    rfqEnabled: z.boolean().nullish(),
-    eventStartTime: IsoDateTimeStringSchema.nullish(),
-    internalUsers: z.array(InternalUserSchema).nullish(),
-    holdingRewardsEnabled: z.boolean().nullish(),
-    feesEnabled: z.boolean().nullish(),
-    requiresTranslation: z.boolean().nullish(),
-    makerRebatesFeeShareBps: z.number().int().nullish(),
-    feeRate: z.number().nullish(),
-    feeExponent: z.number().nullish(),
-    feeType: z.string().nullish(),
-    feeSchedule: FeeScheduleSchema.nullish(),
-  })
-  .transform(
-    ({
-      acceptingOrdersTimestamp,
-      deployingTimestamp,
-      endDateIso,
-      fundedTimestamp,
-      readyTimestamp,
-      scheduledDeploymentTimestamp,
-      startDateIso,
-      submitted_by,
-      umaEndDateIso,
-      ...rest
-    }) => ({
-      ...rest,
-      acceptingOrdersAt: acceptingOrdersTimestamp,
-      deployingAt: deployingTimestamp,
-      endDateOnly: endDateIso,
-      fundedAt: fundedTimestamp,
-      readyAt: readyTimestamp,
-      scheduledDeploymentAt: scheduledDeploymentTimestamp,
-      startDateOnly: startDateIso,
-      submittedBy: submitted_by,
-      umaEndDateOnly: umaEndDateIso,
-    }),
-  );
+export enum UmaResolutionStatus {
+  Proposed = 'proposed',
+  Disputed = 'disputed',
+  Resolved = 'resolved',
+}
+
+export type MarketState = {
+  active?: boolean | null;
+  closed?: boolean | null;
+  archived?: boolean | null;
+  acceptingOrders?: boolean | null;
+  enableOrderBook?: boolean | null;
+  negRisk?: boolean | null;
+  startDate?: IsoDateTimeString | null;
+  endDate?: IsoDateTimeString | null;
+  closedTime?: IsoDateTimeString | null;
+};
+
+export type MarketOutcome = {
+  label: string;
+  tokenId: TokenId | null;
+  price: string | null;
+};
+
+export type MarketOutcomes = {
+  yes: MarketOutcome;
+  no: MarketOutcome;
+};
+
+export type MarketMetrics = {
+  volume?: string | null;
+  volumeNum?: number | null;
+  volume24hr?: number | null;
+  volume1wk?: number | null;
+  volume1mo?: number | null;
+  volume1yr?: number | null;
+  volumeAmm?: number | null;
+  volumeClob?: number | null;
+  liquidity?: string | null;
+  liquidityNum?: number | null;
+  liquidityClob?: number | null;
+};
+
+export type MarketPrices = {
+  bestBid?: number | null;
+  bestAsk?: number | null;
+  lastTradePrice?: number | null;
+  spread?: number | null;
+  oneHourPriceChange?: number | null;
+  oneDayPriceChange?: number | null;
+  oneWeekPriceChange?: number | null;
+  oneMonthPriceChange?: number | null;
+  oneYearPriceChange?: number | null;
+};
+
+export type MarketTrading = {
+  minimumOrderSize?: number | null;
+  minimumTickSize?: TickSizeValue | null;
+  secondsDelay?: number | null;
+  feesEnabled?: boolean | null;
+  feeType?: string | null;
+  feeSchedule?: FeeSchedule | null;
+};
+
+export type MarketResolution = {
+  questionId: QuestionId | null;
+  negRiskRequestId: ResolutionRequestId | null;
+  umaResolutionStatus?: string | null;
+  source?: string | null;
+  resolvedBy: EvmAddress | null;
+};
+
+export type MarketRewards = {
+  clobRewards?: ClobRewards[] | null;
+  rewardsMinSize?: number | null;
+  rewardsMaxSpread?: number | null;
+  holdingRewardsEnabled?: boolean | null;
+};
+
+export type MarketSportsMetadata = {
+  sportsMarketType?: string | null;
+  line?: number | null;
+  gameId?: string | null;
+  gameStartTime?: IsoDateTimeString | null;
+};
+
+export type MarketEvent = {
+  id: EventId;
+  slug: string | null;
+  title: string | null;
+};
+
+export type MarketTag = {
+  id: TagId;
+  slug?: string | null;
+  label?: string | null;
+};
+
+export type Market = {
+  id: MarketId;
+  slug?: string | null;
+  conditionId: ConditionId;
+  question?: string | null;
+  description?: string | null;
+  category?: string | null;
+  image?: string | null;
+  icon?: string | null;
+  state: MarketState;
+  outcomes: MarketOutcomes;
+  metrics: MarketMetrics;
+  prices: MarketPrices;
+  trading: MarketTrading;
+  resolution: MarketResolution;
+  rewards: MarketRewards;
+  sports: MarketSportsMetadata;
+  events: MarketEvent[];
+  tags: MarketTag[];
+};
+
+export const GammaMarketSchema = z.looseObject({
+  id: MarketIdSchema,
+  question: z.string().nullish(),
+  conditionId: ConditionIdSchema,
+  slug: z.string().nullish(),
+  twitterCardImage: z.string().nullish(),
+  resolutionSource: z.string().nullish(),
+  endDate: IsoDateTimeStringSchema.nullish(),
+  category: z.string().nullish(),
+  ammType: z.string().nullish(),
+  liquidity: z.string().nullish(),
+  sponsorName: z.string().nullish(),
+  sponsorImage: z.string().nullish(),
+  startDate: IsoDateTimeStringSchema.nullish(),
+  xAxisValue: z.string().nullish(),
+  yAxisValue: z.string().nullish(),
+  denominationToken: z.string().nullish(),
+  fee: z.string().nullish(),
+  image: z.string().nullish(),
+  icon: z.string().nullish(),
+  lowerBound: z.string().nullish(),
+  upperBound: z.string().nullish(),
+  description: z.string().nullish(),
+  outcomes: OutcomePairSchema,
+  outcomePrices: OutcomePricePairSchema,
+  volume: z.string().nullish(),
+  active: z.boolean().nullish(),
+  marketType: z.string().nullish(),
+  formatType: z.string().nullish(),
+  lowerBoundDate: IsoCalendarDateStringSchema.nullish(),
+  upperBoundDate: IsoCalendarDateStringSchema.nullish(),
+  closed: z.boolean().nullish(),
+  marketMakerAddress: z.string(),
+  createdBy: z.number().int().nullish(),
+  updatedBy: z.number().int().nullish(),
+  createdAt: IsoDateTimeStringSchema.nullish(),
+  updatedAt: IsoDateTimeStringSchema.nullish(),
+  closedTime: IsoDateTimeStringSchema.nullish(),
+  wideFormat: z.boolean().nullish(),
+  new: z.boolean().nullish(),
+  sentDiscord: z.boolean().nullish(),
+  mailchimpTag: z.string().nullish(),
+  featured: z.boolean().nullish(),
+  submitted_by: z.string().nullish(),
+  subcategory: z.string().nullish(),
+  categoryMailchimpTag: z.string().nullish(),
+  twitterCardLocation: z.string().nullish(),
+  twitterCardLastRefreshed: IsoDateTimeStringSchema.nullish(),
+  twitterCardLastValidated: IsoDateTimeStringSchema.nullish(),
+  archived: z.boolean().nullish(),
+  resolvedBy: z.string().nullish(),
+  restricted: z.boolean().nullish(),
+  marketGroup: z.number().int().nullish(),
+  groupItemTitle: z.string().nullish(),
+  groupItemThreshold: z.string().nullish(),
+  questionID: z.string().nullish(),
+  umaEndDate: MixedDateTimeStringSchema.nullish(),
+  enableOrderBook: z.boolean().nullish(),
+  orderPriceMinTickSize: TickSizeValueSchema.nullish(),
+  orderMinSize: z.number().nullish(),
+  umaResolutionStatus: z.string().nullish(),
+  curationOrder: z.number().int().nullish(),
+  volumeNum: z.number().nullish(),
+  liquidityNum: z.number().nullish(),
+  endDateIso: IsoCalendarDateStringSchema.nullish(),
+  startDateIso: IsoCalendarDateStringSchema.nullish(),
+  umaEndDateIso: IsoCalendarDateStringSchema.nullish(),
+  hasReviewedDates: z.boolean().nullish(),
+  readyForCron: z.boolean().nullish(),
+  commentsEnabled: z.boolean().nullish(),
+  volume24hr: z.number().nullish(),
+  volume1wk: z.number().nullish(),
+  volume1mo: z.number().nullish(),
+  volume1yr: z.number().nullish(),
+  gameStartTime: IsoDateTimeStringSchema.nullish(),
+  secondsDelay: z.number().int().nullish(),
+  clobTokenIds: TokenIdPairSchema,
+  disqusThread: z.string().nullish(),
+  shortOutcomes: z.string().nullish(),
+  teamAID: z.string().nullish(),
+  teamBID: z.string().nullish(),
+  umaBond: z.string().nullish(),
+  umaReward: z.string().nullish(),
+  fpmmLive: z.boolean().nullish(),
+  volume24hrAmm: z.number().nullish(),
+  volume1wkAmm: z.number().nullish(),
+  volume1moAmm: z.number().nullish(),
+  volume1yrAmm: z.number().nullish(),
+  volume24hrClob: z.number().nullish(),
+  volume1wkClob: z.number().nullish(),
+  volume1moClob: z.number().nullish(),
+  volume1yrClob: z.number().nullish(),
+  volumeAmm: z.number().nullish(),
+  volumeClob: z.number().nullish(),
+  liquidityAmm: z.number().nullish(),
+  liquidityClob: z.number().nullish(),
+  makerBaseFee: z.number().int().nullish(),
+  takerBaseFee: z.number().int().nullish(),
+  customLiveness: z.number().int().nullish(),
+  acceptingOrders: z.boolean().nullish(),
+  negRisk: z.boolean().nullish(),
+  negRiskMarketID: z.string().nullish(),
+  negRiskRequestID: z.string().nullish(),
+  notificationsEnabled: z.boolean().nullish(),
+  score: z.number().int().nullish(),
+  imageOptimized: ImageOptimizationSchema.nullish(),
+  iconOptimized: ImageOptimizationSchema.nullish(),
+  events: z.array(GammaMarketEventSchema).nullish(),
+  categories: z.array(CategoryReferenceSchema).nullish(),
+  markets: z.array(RelatedMarketSchema).nullish(),
+  creator: z.string().nullish(),
+  ready: z.boolean().nullish(),
+  funded: z.boolean().nullish(),
+  pastSlugs: z.string().nullish(),
+  readyTimestamp: IsoDateTimeStringSchema.nullish(),
+  fundedTimestamp: IsoDateTimeStringSchema.nullish(),
+  acceptingOrdersTimestamp: IsoDateTimeStringSchema.nullish(),
+  tags: z.array(TagReferenceSchema).nullish(),
+  cyom: z.boolean().nullish(),
+  competitive: z.number().nullish(),
+  pagerDutyNotificationEnabled: z.boolean().nullish(),
+  approved: z.boolean().nullish(),
+  clobRewards: z.array(ClobRewardsSchema).nullish(),
+  rewardsMinSize: z.number().nullish(),
+  rewardsMaxSpread: z.number().nullish(),
+  spread: z.number().nullish(),
+  automaticallyResolved: z.boolean().nullish(),
+  oneDayPriceChange: z.number().nullish(),
+  oneHourPriceChange: z.number().nullish(),
+  oneWeekPriceChange: z.number().nullish(),
+  oneMonthPriceChange: z.number().nullish(),
+  oneYearPriceChange: z.number().nullish(),
+  lastTradePrice: z.number().nullish(),
+  bestBid: z.number().nullish(),
+  bestAsk: z.number().nullish(),
+  automaticallyActive: z.boolean().nullish(),
+  clearBookOnStart: z.boolean().nullish(),
+  chartColor: z.string().nullish(),
+  seriesColor: z.string().nullish(),
+  showGmpSeries: z.boolean().nullish(),
+  showGmpOutcome: z.boolean().nullish(),
+  manualActivation: z.boolean().nullish(),
+  negRiskOther: z.boolean().nullish(),
+  gameId: z.string().nullish(),
+  groupItemRange: z.string().nullish(),
+  sportsMarketType: z.string().nullish(),
+  line: z.number().nullish(),
+  umaResolutionStatuses: z.string().nullish(),
+  pendingDeployment: z.boolean().nullish(),
+  deploying: z.boolean().nullish(),
+  deployingTimestamp: IsoDateTimeStringSchema.nullish(),
+  scheduledDeploymentTimestamp: IsoDateTimeStringSchema.nullish(),
+  rfqEnabled: z.boolean().nullish(),
+  eventStartTime: IsoDateTimeStringSchema.nullish(),
+  internalUsers: z.array(InternalUserSchema).nullish(),
+  holdingRewardsEnabled: z.boolean().nullish(),
+  feesEnabled: z.boolean().nullish(),
+  requiresTranslation: z.boolean().nullish(),
+  makerRebatesFeeShareBps: z.number().int().nullish(),
+  feeRate: z.number().nullish(),
+  feeExponent: z.number().nullish(),
+  feeType: z.string().nullish(),
+  feeSchedule: FeeScheduleSchema.nullish(),
+});
+
+export const MarketSchema = GammaMarketSchema.transform(
+  normalizeMarket,
+) satisfies z.ZodType<Market>;
 
 export const ListMarketsResponseSchema = z.array(MarketSchema);
 export const ListMarketsKeysetResponseSchema = z
@@ -241,7 +365,7 @@ export const ListMarketsKeysetResponseSchema = z
   }));
 export const FetchMarketTagsResponseSchema = z.array(TagReferenceSchema);
 
-export type Market = z.infer<typeof MarketSchema>;
+export type GammaMarket = z.infer<typeof GammaMarketSchema>;
 export type ListMarketsResponse = z.infer<typeof ListMarketsResponseSchema>;
 export type ListMarketsKeysetResponse = z.infer<
   typeof ListMarketsKeysetResponseSchema
@@ -249,3 +373,126 @@ export type ListMarketsKeysetResponse = z.infer<
 export type FetchMarketTagsResponse = z.infer<
   typeof FetchMarketTagsResponseSchema
 >;
+
+function normalizeMarket(market: GammaMarket): Market {
+  return {
+    id: market.id,
+    slug: market.slug,
+    conditionId: market.conditionId,
+    question: market.question,
+    description: market.description,
+    category: market.category,
+    image: market.image,
+    icon: market.icon,
+    state: {
+      active: market.active,
+      closed: market.closed,
+      archived: market.archived,
+      acceptingOrders: market.acceptingOrders,
+      enableOrderBook: market.enableOrderBook,
+      negRisk: market.negRisk,
+      startDate: market.startDate,
+      endDate: market.endDate,
+      closedTime: market.closedTime,
+    },
+    outcomes: normalizeOutcomes(market),
+    metrics: {
+      volume: market.volume,
+      volumeNum: market.volumeNum,
+      volume24hr: market.volume24hr,
+      volume1wk: market.volume1wk,
+      volume1mo: market.volume1mo,
+      volume1yr: market.volume1yr,
+      volumeAmm: market.volumeAmm,
+      volumeClob: market.volumeClob,
+      liquidity: market.liquidity,
+      liquidityNum: market.liquidityNum,
+      liquidityClob: market.liquidityClob,
+    },
+    prices: {
+      bestBid: market.bestBid,
+      bestAsk: market.bestAsk,
+      lastTradePrice: market.lastTradePrice,
+      spread: market.spread,
+      oneHourPriceChange: market.oneHourPriceChange,
+      oneDayPriceChange: market.oneDayPriceChange,
+      oneWeekPriceChange: market.oneWeekPriceChange,
+      oneMonthPriceChange: market.oneMonthPriceChange,
+      oneYearPriceChange: market.oneYearPriceChange,
+    },
+    trading: {
+      minimumOrderSize: market.orderMinSize,
+      minimumTickSize: market.orderPriceMinTickSize,
+      secondsDelay: market.secondsDelay,
+      feesEnabled: market.feesEnabled,
+      feeType: market.feeType,
+      feeSchedule: market.feeSchedule,
+    },
+    resolution: {
+      questionId: parseOptionalString(QuestionIdSchema, market.questionID),
+      negRiskRequestId: parseOptionalString(
+        ResolutionRequestIdSchema,
+        market.negRiskRequestID,
+      ),
+      umaResolutionStatus: market.umaResolutionStatus,
+      source: market.resolutionSource,
+      resolvedBy: parseOptionalString(EvmAddressSchema, market.resolvedBy),
+    },
+    rewards: {
+      clobRewards: market.clobRewards,
+      rewardsMinSize: market.rewardsMinSize,
+      rewardsMaxSpread: market.rewardsMaxSpread,
+      holdingRewardsEnabled: market.holdingRewardsEnabled,
+    },
+    sports: {
+      sportsMarketType: market.sportsMarketType,
+      line: market.line,
+      gameId: market.gameId,
+      gameStartTime: market.gameStartTime,
+    },
+    events: (market.events ?? []).map((event) => ({
+      id: event.id,
+      slug: readOptionalString(event.slug),
+      title: readOptionalString(event.title),
+    })),
+    tags: (market.tags ?? []).map((tag) => ({
+      id: tag.id,
+      slug: tag.slug,
+      label: tag.label,
+    })),
+  };
+}
+
+function parseOptionalString<T>(
+  schema: z.ZodType<T>,
+  value: string | null | undefined,
+): T | null {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  return schema.parse(value);
+}
+
+function readOptionalString(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
+function parseJsonString(value: unknown): unknown {
+  return typeof value === 'string' ? JSON.parse(value) : value;
+}
+
+function normalizeOutcomes(market: GammaMarket) {
+  return {
+    yes: {
+      label: market.outcomes[0],
+      tokenId: market.clobTokenIds?.[0] ?? null,
+      price: market.outcomePrices?.[0] ?? null,
+    },
+    no: {
+      label: market.outcomes[1],
+      tokenId: market.clobTokenIds?.[1] ?? null,
+      price: market.outcomePrices?.[1] ?? null,
+    },
+  };
+}

--- a/packages/bindings/src/gamma/profile.ts
+++ b/packages/bindings/src/gamma/profile.ts
@@ -2,14 +2,14 @@ import { z } from 'zod';
 import { EvmAddressSchema, IsoDateTimeStringSchema } from '../shared';
 import { ImageOptimizationSchema } from './common';
 
-export const PublicProfileUserSchema = z.looseObject({
+export const PublicProfileUserSchema = z.object({
   id: z.string(),
   communityMod: z.boolean().nullish(),
   creator: z.boolean().nullish(),
   mod: z.boolean().nullish(),
 });
 
-export const ProfileSchema = z.looseObject({
+export const ProfileSchema = z.object({
   id: z.string().nullish(),
   name: z.string().nullish(),
   user: z.number().int().nullish(),
@@ -42,7 +42,7 @@ export const ProfileSchema = z.looseObject({
   isReferralRestricted: z.boolean().nullish(),
 });
 
-export const PublicProfileSchema = z.looseObject({
+export const PublicProfileSchema = z.object({
   createdAt: IsoDateTimeStringSchema.nullish(),
   proxyWallet: EvmAddressSchema.nullish(),
   profileImage: z.string().nullish(),

--- a/packages/bindings/src/gamma/search.ts
+++ b/packages/bindings/src/gamma/search.ts
@@ -15,12 +15,12 @@ export const SearchTagSchema = z
     eventCount: event_count,
   }));
 
-export const SearchPaginationSchema = z.looseObject({
+export const SearchPaginationSchema = z.object({
   hasMore: z.boolean().nullish(),
   totalResults: z.number().int().nullish(),
 });
 
-export const PublicSearchResponseSchema = z.looseObject({
+export const PublicSearchResponseSchema = z.object({
   events: z.array(EventSchema).nullish(),
   tags: z.array(SearchTagSchema).nullish(),
   profiles: z.array(ProfileSchema).nullish(),

--- a/packages/bindings/src/gamma/tag.ts
+++ b/packages/bindings/src/gamma/tag.ts
@@ -8,7 +8,7 @@ export const TagSchema = TagReferenceSchema.extend({
   templates: z.array(TemplateReferenceSchema).nullish(),
 });
 
-export const RelatedTagSchema = z.looseObject({
+export const RelatedTagSchema = z.object({
   id: z.string(),
   tagID: z.number().int().nullish(),
   relatedTagID: z.number().int().nullish(),

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -65,6 +65,8 @@ export type MixedDateTimeString = Tagged<string, 'MixedDateTimeString'>;
 export type NotificationId = Tagged<number, 'NotificationId'>;
 export type PartnerId = Tagged<number, 'PartnerId'>;
 export type PaginationCursor = Tagged<string, 'PaginationCursor'>;
+export type QuestionId = Tagged<HexString, 'QuestionId'>;
+export type ResolutionRequestId = Tagged<HexString, 'ResolutionRequestId'>;
 export type SeriesId = Tagged<string, 'SeriesId'>;
 export type SportId = Tagged<number, 'SportId'>;
 export type TagId = Tagged<string, 'TagId'>;
@@ -110,11 +112,7 @@ export function toCommentId(value: string): CommentId {
 }
 
 export function toConditionId(value: string): ConditionId {
-  if (!isHexString(value) || value.length !== 66) {
-    throw new TypeError(`Expected a 32-byte hex string, received: ${value}`);
-  }
-
-  return value as ConditionId;
+  return to32ByteHexString(value) as ConditionId;
 }
 
 export function toCollectionId(value: string): CollectionId {
@@ -173,6 +171,14 @@ export function toPartnerId(value: number): PartnerId {
 
 export function toPaginationCursor(value: string): PaginationCursor {
   return toTaggedString<PaginationCursor>(value);
+}
+
+export function toQuestionId(value: string): QuestionId {
+  return to32ByteHexString(value) as QuestionId;
+}
+
+export function toResolutionRequestId(value: string): ResolutionRequestId {
+  return to32ByteHexString(value) as ResolutionRequestId;
 }
 
 export function toSeriesId(value: string): SeriesId {
@@ -303,6 +309,10 @@ export const PaginationCursorSchema = z
   .string()
   .min(1)
   .transform(toPaginationCursor);
+export const QuestionIdSchema = z.string().transform(toQuestionId);
+export const ResolutionRequestIdSchema = z
+  .string()
+  .transform(toResolutionRequestId);
 export const TagIdSchema = z.string().transform(toTagId);
 export const TokenIdSchema = z.string().transform(toTokenId);
 export const TransactionIdSchema = z.string().min(1).transform(toTransactionId);
@@ -320,4 +330,12 @@ function toEvmAddress(value: string): EvmAddress {
 
 function toTxHash(value: string): TxHash {
   return expectTxHash(value);
+}
+
+function to32ByteHexString(value: string): HexString {
+  if (!isHexString(value) || value.length !== 66) {
+    throw new TypeError(`Expected a 32-byte hex string, received: ${value}`);
+  }
+
+  return value;
 }

--- a/packages/bindings/src/subscriptions/clob.ts
+++ b/packages/bindings/src/subscriptions/clob.ts
@@ -35,7 +35,7 @@ export enum UserOrderStatus {
 
 const UserOrderStatusSchema = z.enum(UserOrderStatus);
 
-const OrderBookLevelSchema = z.looseObject({
+const OrderBookLevelSchema = z.object({
   price: z.string(),
   size: z.string(),
 });
@@ -229,7 +229,7 @@ export const MarketBestBidAskEventSchema = z
 
 export type MarketBestBidAskEvent = z.infer<typeof MarketBestBidAskEventSchema>;
 
-const MarketEventMessageSchema = z.looseObject({
+const MarketEventMessageSchema = z.object({
   id: z.string(),
   ticker: z.string().nullish(),
   slug: z.string().nullish(),

--- a/packages/bindings/src/subscriptions/rtds.ts
+++ b/packages/bindings/src/subscriptions/rtds.ts
@@ -10,7 +10,7 @@ import {
   EpochMillisecondsSchema,
 } from '../shared';
 
-const CommentRemovedPayloadSchema = z.looseObject({
+const CommentRemovedPayloadSchema = z.object({
   id: z.string(),
   body: z.string().nullish(),
   parentEntityType: CommentParentEntityTypeSchema.nullish(),
@@ -30,7 +30,7 @@ const CommentRemovedPayloadSchema = z.looseObject({
 
 export type CommentRemovedPayload = z.infer<typeof CommentRemovedPayloadSchema>;
 
-export const CommentCreatedEventSchema = z.looseObject({
+export const CommentCreatedEventSchema = z.object({
   topic: z.literal('comments'),
   type: z.literal('comment_created'),
   timestamp: EpochMillisecondsSchema,
@@ -39,7 +39,7 @@ export const CommentCreatedEventSchema = z.looseObject({
 
 export type CommentCreatedEvent = z.infer<typeof CommentCreatedEventSchema>;
 
-export const CommentRemovedEventSchema = z.looseObject({
+export const CommentRemovedEventSchema = z.object({
   topic: z.literal('comments'),
   type: z.literal('comment_removed'),
   timestamp: EpochMillisecondsSchema,
@@ -48,7 +48,7 @@ export const CommentRemovedEventSchema = z.looseObject({
 
 export type CommentRemovedEvent = z.infer<typeof CommentRemovedEventSchema>;
 
-export const ReactionCreatedEventSchema = z.looseObject({
+export const ReactionCreatedEventSchema = z.object({
   topic: z.literal('comments'),
   type: z.literal('reaction_created'),
   timestamp: EpochMillisecondsSchema,
@@ -57,7 +57,7 @@ export const ReactionCreatedEventSchema = z.looseObject({
 
 export type ReactionCreatedEvent = z.infer<typeof ReactionCreatedEventSchema>;
 
-export const ReactionRemovedEventSchema = z.looseObject({
+export const ReactionRemovedEventSchema = z.object({
   topic: z.literal('comments'),
   type: z.literal('reaction_removed'),
   timestamp: EpochMillisecondsSchema,
@@ -66,7 +66,7 @@ export const ReactionRemovedEventSchema = z.looseObject({
 
 export type ReactionRemovedEvent = z.infer<typeof ReactionRemovedEventSchema>;
 
-const PriceUpdatePayloadSchema = z.looseObject({
+const PriceUpdatePayloadSchema = z.object({
   symbol: z.string(),
   timestamp: EpochMillisecondsSchema,
   value: z.number(),
@@ -98,7 +98,7 @@ const CryptoPricesChainlinkTopicSchema: z.ZodType<CryptoPricesChainlinkTopic> =
     return CRYPTO_PRICES_CHAINLINK_TOPIC;
   });
 
-export const CryptoPricesBinanceEventSchema = z.looseObject({
+export const CryptoPricesBinanceEventSchema = z.object({
   topic: CryptoPricesBinanceTopicSchema,
   type: z.literal('update'),
   timestamp: EpochMillisecondsSchema,
@@ -109,7 +109,7 @@ export type CryptoPricesBinanceEvent = z.infer<
   typeof CryptoPricesBinanceEventSchema
 >;
 
-export const CryptoPricesChainlinkEventSchema = z.looseObject({
+export const CryptoPricesChainlinkEventSchema = z.object({
   topic: CryptoPricesChainlinkTopicSchema,
   type: z.literal('update'),
   timestamp: EpochMillisecondsSchema,
@@ -149,7 +149,7 @@ export type EquityPriceUpdatePayload = z.infer<
   typeof EquityPriceUpdatePayloadSchema
 >;
 
-const EquityPriceSnapshotPointSchema = z.looseObject({
+const EquityPriceSnapshotPointSchema = z.object({
   timestamp: z.number(),
   value: z.number(),
 });
@@ -158,7 +158,7 @@ export type EquityPriceSnapshotPoint = z.infer<
   typeof EquityPriceSnapshotPointSchema
 >;
 
-const EquityPriceSubscribePayloadSchema = z.looseObject({
+const EquityPriceSubscribePayloadSchema = z.object({
   symbol: z.string(),
   data: z.array(EquityPriceSnapshotPointSchema),
 });
@@ -178,7 +178,7 @@ const EquityPricesTopicSchema: z.ZodType<EquityPricesTopic> =
     return EQUITY_PRICES_TOPIC;
   });
 
-export const EquityPricesUpdateEventSchema = z.looseObject({
+export const EquityPricesUpdateEventSchema = z.object({
   topic: EquityPricesTopicSchema,
   type: z.literal('update'),
   timestamp: EpochMillisecondsSchema,
@@ -189,7 +189,7 @@ export type EquityPricesUpdateEvent = z.infer<
   typeof EquityPricesUpdateEventSchema
 >;
 
-export const EquityPricesSubscribeEventSchema = z.looseObject({
+export const EquityPricesSubscribeEventSchema = z.object({
   topic: EquityPricesTopicSchema,
   type: z.literal('subscribe'),
   timestamp: EpochMillisecondsSchema,

--- a/packages/client/src/actions/builders.test.ts
+++ b/packages/client/src/actions/builders.test.ts
@@ -36,11 +36,11 @@ describe('Builders', () => {
         .then(authenticateWith(walletClient));
 
       console.log(market.slug);
-      const [tokenId] = expectPresent(market.clobTokenIds);
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
 
       const response = await secureClient
         .prepareMarketOrder({
-          amount: expectPresent(market.orderMinSize),
+          amount: expectPresent(market.trading.minimumOrderSize),
           builderCode: testBuilderCode,
           side: OrderSide.BUY,
           tokenId,

--- a/packages/client/src/actions/clob.test.ts
+++ b/packages/client/src/actions/clob.test.ts
@@ -253,7 +253,7 @@ async function selectLiquidClobTokenId(): Promise<string> {
     .then((page) => page.items);
 
   for (const market of markets) {
-    const [tokenId] = expectPresent(market.clobTokenIds);
+    const tokenId = expectPresent(market.outcomes.yes.tokenId);
 
     return tokenId;
   }

--- a/packages/client/src/actions/orders.test.ts
+++ b/packages/client/src/actions/orders.test.ts
@@ -28,10 +28,10 @@ const secureClient = await publicClient
 describe('Orders', { timeout: 60_000 }, () => {
   describe('estimateMarketPrice', () => {
     it('calculates the price for a market buy at the minimum size', async () => {
-      const [yesTokenId] = expectPresent(market.clobTokenIds);
+      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
 
       const result = await publicClient.estimateMarketPrice({
-        amount: expectPresent(market.orderMinSize),
+        amount: expectPresent(market.trading.minimumOrderSize),
         orderType: OrderType.FAK,
         side: OrderSide.BUY,
         tokenId: yesTokenId,
@@ -43,7 +43,7 @@ describe('Orders', { timeout: 60_000 }, () => {
     });
 
     it('throws an explicit liquidity error when an FOK amount cannot fully fill', async () => {
-      const [yesTokenId] = expectPresent(market.clobTokenIds);
+      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
 
       await expect(
         publicClient.estimateMarketPrice({
@@ -69,7 +69,7 @@ describe('Orders', { timeout: 60_000 }, () => {
       }
 
       const position = page.items.find(
-        (candidate) => candidate.tokenId === market.clobTokenIds?.[0],
+        (candidate) => candidate.tokenId === market.outcomes.yes.tokenId,
       );
 
       await secureClient
@@ -120,7 +120,7 @@ describe('Orders', { timeout: 60_000 }, () => {
           'No existing positions found, placing a minimum-size buy market order…',
         );
 
-        const [yesTokenId] = expectPresent(market.clobTokenIds);
+        const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
         const buyResult = await secureClient
           .prepareMarketOrder({
             amount: expectPresent(1),
@@ -136,11 +136,11 @@ describe('Orders', { timeout: 60_000 }, () => {
     );
 
     it('carries builder attribution onto the prepared market order', async () => {
-      const [yesTokenId] = expectPresent(market.clobTokenIds);
+      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
 
       const order = await secureClient
         .prepareMarketOrder({
-          amount: expectPresent(market.orderMinSize),
+          amount: expectPresent(market.trading.minimumOrderSize),
           builderCode: testBuilderCode,
           side: OrderSide.BUY,
           tokenId: yesTokenId,
@@ -152,9 +152,9 @@ describe('Orders', { timeout: 60_000 }, () => {
   });
 
   describe('prepareLimitOrder', () => {
-    const [yesTokenId] = expectPresent(market.clobTokenIds);
-    const minPrice = expectPresent(market.orderPriceMinTickSize);
-    const minSize = expectPresent(market.orderMinSize);
+    const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+    const minPrice = expectPresent(market.trading.minimumTickSize);
+    const minSize = expectPresent(market.trading.minimumOrderSize);
 
     it('allows to place a limit order for the desired size and price', async () => {
       const result = await secureClient
@@ -226,9 +226,9 @@ describe('Orders', { timeout: 60_000 }, () => {
   });
 
   describe('prepareLimitOrderPosting', () => {
-    const [yesTokenId] = expectPresent(market.clobTokenIds);
-    const minPrice = expectPresent(market.orderPriceMinTickSize);
-    const minSize = expectPresent(market.orderMinSize);
+    const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+    const minPrice = expectPresent(market.trading.minimumTickSize);
+    const minSize = expectPresent(market.trading.minimumOrderSize);
 
     it('creates, signs, and posts a limit order in one workflow', async () => {
       const response = await secureClient
@@ -323,9 +323,9 @@ async function createRestingLimitOrder(): Promise<{
   tokenId: string;
   orderId: string;
 }> {
-  const [yesTokenId] = expectPresent(market.clobTokenIds);
-  const tickSize = expectPresent(market.orderPriceMinTickSize);
-  const size = expectPresent(market.orderMinSize);
+  const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+  const tickSize = expectPresent(market.trading.minimumTickSize);
+  const size = expectPresent(market.trading.minimumOrderSize);
   const response = await secureClient
     .prepareLimitOrderPosting({
       price: tickSize,
@@ -341,15 +341,15 @@ async function createRestingLimitOrder(): Promise<{
   expect(acceptedResponse.status).toBe(OrderPostStatus.LIVE);
 
   return {
-    tokenId: expectPresent(market.clobTokenIds)[0],
+    tokenId: expectPresent(market.outcomes.yes.tokenId),
     orderId: acceptedResponse.orderId,
   };
 }
 
 async function createSignedRestingLimitOrder() {
-  const [yesTokenId] = expectPresent(market.clobTokenIds);
-  const tickSize = expectPresent(market.orderPriceMinTickSize);
-  const size = expectPresent(market.orderMinSize);
+  const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+  const tickSize = expectPresent(market.trading.minimumTickSize);
+  const size = expectPresent(market.trading.minimumOrderSize);
 
   return secureClient
     .prepareLimitOrder({

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -378,11 +378,11 @@ async function resolveMarketNegativeRiskFlag(
     `No market found for condition ${conditionId}`,
   );
   invariant(
-    isPresent(market.negRisk),
+    isPresent(market.state.negRisk),
     `Missing negRisk flag for condition ${conditionId}`,
   );
 
-  return market.negRisk;
+  return market.state.negRisk;
 }
 
 function resolveMergeTargetAddress(client: BaseSecureClient, negRisk: boolean) {

--- a/packages/client/src/actions/subscriptions.test.ts
+++ b/packages/client/src/actions/subscriptions.test.ts
@@ -44,7 +44,7 @@ describe('subscribe', () => {
     timeout: 20_000,
   }, async () => {
     const market = await findHighVolumeLowPriceMarket();
-    const [tokenId] = expectPresent(market.clobTokenIds);
+    const tokenId = expectPresent(market.outcomes.yes.tokenId);
 
     const handle = await publicClient.subscribe([
       { tokenIds: [tokenId], topic: 'market' },
@@ -84,7 +84,7 @@ describe('subscribe', () => {
     timeout: 20_000,
   }, async () => {
     const market = await findHighVolumeLowPriceMarket();
-    const [tokenId] = expectPresent(market.clobTokenIds);
+    const tokenId = expectPresent(market.outcomes.yes.tokenId);
 
     const handle = await publicClient.subscribe([
       { tokenIds: [tokenId], topic: 'market' },

--- a/packages/client/src/backend-compat.test.ts
+++ b/packages/client/src/backend-compat.test.ts
@@ -216,7 +216,7 @@ describe.runIf(runBackendCompatTests)('backend compatibility', () => {
 
   it('validates order book responses against the response schema', async () => {
     const market = await findHighVolumeLowPriceMarket();
-    const [tokenId] = expectPresent(market.clobTokenIds);
+    const tokenId = expectPresent(market.outcomes.yes.tokenId);
 
     await publicClient.fetchOrderBook({ tokenId });
     await publicClient.fetchOrderBooks([{ tokenId }]);

--- a/packages/client/src/ethers-v5.test.ts
+++ b/packages/client/src/ethers-v5.test.ts
@@ -49,9 +49,9 @@ describe('ethers-v5', () => {
       const market = await fetchMarket(publicClient, {
         slug: TEST_MARKET_SLUG,
       });
-      const [yesTokenId] = expectPresent(market.clobTokenIds);
-      const price = expectPresent(market.orderPriceMinTickSize);
-      const size = expectPresent(market.orderMinSize);
+      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+      const price = expectPresent(market.trading.minimumTickSize);
+      const size = expectPresent(market.trading.minimumOrderSize);
       const secureClient = await publicClient
         .beginAuthentication({ wallet: safeWalletAddress })
         .then(authenticateWith(signer));

--- a/packages/client/src/privy.test.ts
+++ b/packages/client/src/privy.test.ts
@@ -110,9 +110,9 @@ describe.runIf(hasPrivyTestConfig)('privy', () => {
         const market = await fetchMarket(publicClient, {
           slug: TEST_MARKET_SLUG,
         });
-        const [yesTokenId] = expectPresent(market.clobTokenIds);
-        const price = expectPresent(market.orderPriceMinTickSize);
-        const size = expectPresent(market.orderMinSize);
+        const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+        const price = expectPresent(market.trading.minimumTickSize);
+        const size = expectPresent(market.trading.minimumOrderSize);
         const secureClient = await publicClient
           .beginAuthentication({ wallet: safeWalletAddress })
           .then(authenticateWith(wallet));

--- a/packages/client/src/testing.ts
+++ b/packages/client/src/testing.ts
@@ -135,12 +135,11 @@ export async function findHighVolumeLowPriceMarket(): Promise<Market> {
 
 function hasRequiredOrderFields(candidate: Market) {
   return (
-    candidate.enableOrderBook === true &&
-    candidate.acceptingOrders !== false &&
-    candidate.orderMinSize !== null &&
-    candidate.orderMinSize !== undefined &&
-    candidate.clobTokenIds !== null &&
-    candidate.clobTokenIds !== undefined
+    candidate.state.enableOrderBook === true &&
+    candidate.state.acceptingOrders !== false &&
+    candidate.trading.minimumOrderSize !== null &&
+    candidate.trading.minimumOrderSize !== undefined &&
+    candidate.outcomes.yes.tokenId !== null
   );
 }
 
@@ -159,28 +158,30 @@ async function isEligibleTradeCandidate(candidate: Market) {
 
 function hasTradableBestAsk(candidate: Market) {
   return (
-    candidate.bestAsk !== null &&
-    candidate.bestAsk !== undefined &&
-    candidate.bestAsk < 1
+    candidate.prices.bestAsk !== null &&
+    candidate.prices.bestAsk !== undefined &&
+    candidate.prices.bestAsk < 1
   );
 }
 
 function hasTradableBestBid(candidate: Market) {
   return (
-    candidate.bestBid !== null &&
-    candidate.bestBid !== undefined &&
-    candidate.bestBid > 0
+    candidate.prices.bestBid !== null &&
+    candidate.prices.bestBid !== undefined &&
+    candidate.prices.bestBid > 0
   );
 }
 
 function hasClobLiquidity(candidate: Market) {
-  return (candidate.liquidityClob ?? candidate.liquidityNum ?? 0) > 0;
+  return (
+    (candidate.metrics.liquidityClob ?? candidate.metrics.liquidityNum ?? 0) > 0
+  );
 }
 
 async function hasLiveOrderBook(candidate: Market) {
-  const tokenId = candidate.clobTokenIds?.[0];
+  const tokenId = candidate.outcomes.yes.tokenId;
 
-  if (tokenId === undefined) {
+  if (tokenId === null) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- Normalize public market responses into grouped state, outcomes, metrics, prices, trading, resolution, rewards, sports, events, and tags fields.
- Add branded resolution identifiers for question IDs and negative-risk request IDs.
- Strip unknown response fields by using strict inferred Zod object outputs instead of loose objects.

## Verification
- pnpm --filter @polymarket/bindings typecheck
- pnpm --filter @polymarket/client typecheck
- pnpm typecheck
- pnpm lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the public `Market` response shape (nesting many previously top-level fields) and tightens Zod schemas, which can break downstream consumers or reject previously-tolerated API payloads.
> 
> **Overview**
> Normalizes Gamma `Market` responses into a new grouped shape (`state`, `outcomes`, `metrics`, `prices`, `trading`, `resolution`, `rewards`, `sports`, plus normalized `events`/`tags`) via `GammaMarketSchema` -> `MarketSchema` transformation, and updates client code/tests to use the new nested fields (e.g., `market.outcomes.yes.tokenId`, `market.trading.minimumOrderSize`).
> 
> Adds branded identifiers for `questionID` and negative-risk request IDs (`QuestionId`, `ResolutionRequestId`) and introduces safer parsing/normalization for Gamma payload quirks (JSON-string fields, empty strings/empty arrays becoming `null`, and UMA resolution status enum).
> 
> Tightens multiple bindings/subscription response schemas by replacing `z.looseObject` with `z.object`, reducing acceptance of unknown fields across market data, analytics/portfolio/leaderboard, comments/search/tags, and realtime event payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a63476a3965c8c5071a439b0892001b5e4294e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->