### PR TITLE
Normalize event response shape

### DIFF
--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -1,14 +1,23 @@
 import { z } from 'zod';
 import {
+  type EventCreatorId,
+  type EventExternalPartnerMappingId,
+  type EventId,
   EventIdSchema,
+  type IsoCalendarDateString,
   IsoCalendarDateStringSchema,
+  type IsoDateTimeString,
   IsoDateTimeStringSchema,
   PaginationCursorSchema,
+  type PartnerId,
+  type SeriesId,
+  type TagId,
   toBestLineId,
   toChatId,
   toCollectionId,
   toEventCreatorId,
   toEventExternalPartnerMappingId,
+  toEventId,
   toPartnerId,
   toSeriesId,
   toSportId,
@@ -17,11 +26,12 @@ import {
 } from '../shared';
 import {
   CategoryReferenceSchema,
+  type ImageOptimization,
   ImageOptimizationSchema,
   InternalUserSchema,
-  RelatedMarketSchema,
   TagReferenceSchema,
 } from './common';
+import { type Market, MarketSchema } from './market';
 
 const BestLineIdSchema = z.string().transform(toBestLineId);
 const ChatIdSchema = z.string().transform(toChatId);
@@ -31,6 +41,13 @@ const EventExternalPartnerMappingIdSchema = z
   .number()
   .int()
   .transform(toEventExternalPartnerMappingId);
+const EventPartnerEventIdSchema = z.union([
+  EventIdSchema,
+  z
+    .number()
+    .int()
+    .transform((value) => toEventId(String(value))),
+]);
 const PartnerIdSchema = z.number().int().transform(toPartnerId);
 export const SeriesIdSchema = z
   .union([z.string(), z.number().int().transform(String)])
@@ -38,6 +55,11 @@ export const SeriesIdSchema = z
 const SportIdSchema = z.number().int().transform(toSportId);
 const TeamIdSchema = z.number().int().transform(toTeamId);
 const TemplateIdSchema = z.string().transform(toTemplateId);
+
+const GammaEventMarketsSchema = z.preprocess(
+  filterDeployableMarkets,
+  z.array(MarketSchema),
+);
 
 export const CollectionReferenceSchema = z.object({
   id: CollectionIdSchema,
@@ -139,6 +161,7 @@ export const EventCreatorSchema = z.object({
   id: EventCreatorIdSchema,
   creatorName: z.string().nullish(),
   creatorHandle: z.string().nullish(),
+  creatorUrl: z.string().nullish(),
   creatorURL: z.string().nullish(),
   creatorImage: z.string().nullish(),
   createdAt: IsoDateTimeStringSchema.nullish(),
@@ -155,8 +178,8 @@ export const PartnerSchema = z.object({
 
 export const EventExternalPartnerMappingSchema = z.object({
   id: EventExternalPartnerMappingIdSchema,
-  eventId: z.number().int(),
-  partnerId: z.number().int(),
+  eventId: EventPartnerEventIdSchema,
+  partnerId: PartnerIdSchema,
   externalId: z.string(),
   partner: PartnerSchema.nullish(),
   createdAt: IsoDateTimeStringSchema.nullish(),
@@ -201,141 +224,298 @@ export const SportsMarketTypesResponseSchema = z.object({
   marketTypes: z.array(z.string()).nullish(),
 });
 
-export const EventSchema = z
-  .looseObject({
-    id: EventIdSchema,
-    ticker: z.string().nullish(),
-    slug: z.string().nullish(),
-    title: z.string().nullish(),
-    subtitle: z.string().nullish(),
-    description: z.string().nullish(),
-    resolutionSource: z.string().nullish(),
-    startDate: IsoDateTimeStringSchema.nullish(),
-    creationDate: IsoDateTimeStringSchema.nullish(),
-    endDate: IsoDateTimeStringSchema.nullish(),
-    image: z.string().nullish(),
-    icon: z.string().nullish(),
-    active: z.boolean().nullish(),
-    closed: z.boolean().nullish(),
-    archived: z.boolean().nullish(),
-    new: z.boolean().nullish(),
-    featured: z.boolean().nullish(),
-    restricted: z.boolean().nullish(),
-    liquidity: z.number().nullish(),
-    volume: z.number().nullish(),
-    openInterest: z.number().nullish(),
-    sortBy: z.string().nullish(),
-    category: z.string().nullish(),
-    subcategory: z.string().nullish(),
-    isTemplate: z.boolean().nullish(),
-    templateVariables: z.string().nullish(),
-    published_at: IsoDateTimeStringSchema.nullish(),
-    createdBy: z.string().nullish(),
-    updatedBy: z.string().nullish(),
-    createdAt: IsoDateTimeStringSchema.nullish(),
-    updatedAt: IsoDateTimeStringSchema.nullish(),
-    commentsEnabled: z.boolean().nullish(),
-    competitive: z.number().nullish(),
-    volume24hr: z.number().nullish(),
-    volume1wk: z.number().nullish(),
-    volume1mo: z.number().nullish(),
-    volume1yr: z.number().nullish(),
-    featuredImage: z.string().nullish(),
-    disqusThread: z.string().nullish(),
-    parentEventId: z.number().int().nullish(),
-    enableOrderBook: z.boolean().nullish(),
-    liquidityAmm: z.number().nullish(),
-    liquidityClob: z.number().nullish(),
-    negRisk: z.boolean().nullish(),
-    negRiskMarketID: z.string().nullish(),
-    negRiskFeeBips: z.number().int().nullish(),
-    commentCount: z.number().int().nullish(),
-    imageOptimized: ImageOptimizationSchema.nullish(),
-    iconOptimized: ImageOptimizationSchema.nullish(),
-    featuredImageOptimized: ImageOptimizationSchema.nullish(),
-    subEvents: z.array(z.string()).nullish(),
-    markets: z.array(RelatedMarketSchema).nullish(),
-    series: z.array(SeriesReferenceSchema).nullish(),
-    categories: z.array(CategoryReferenceSchema).nullish(),
-    collections: z.array(CollectionReferenceSchema).nullish(),
-    tags: z.array(TagReferenceSchema).nullish(),
-    tag_labels: z.array(z.string()).nullish(),
-    tag_slugs: z.array(z.string()).nullish(),
-    cyom: z.boolean().nullish(),
-    closedTime: IsoDateTimeStringSchema.nullish(),
-    showAllOutcomes: z.boolean().nullish(),
-    showMarketImages: z.boolean().nullish(),
-    automaticallyResolved: z.boolean().nullish(),
-    enableNegRisk: z.boolean().nullish(),
-    automaticallyActive: z.boolean().nullish(),
-    eventDate: IsoCalendarDateStringSchema.nullish(),
-    startTime: IsoDateTimeStringSchema.nullish(),
-    eventWeek: z.number().int().nullish(),
-    seriesSlug: z.string().nullish(),
-    score: z.string().nullish(),
-    elapsed: z.string().nullish(),
-    period: z.string().nullish(),
-    live: z.boolean().nullish(),
-    ended: z.boolean().nullish(),
-    finishedTimestamp: IsoDateTimeStringSchema.nullish(),
-    gmpChartMode: z.string().nullish(),
-    eventCreators: z.array(EventCreatorSchema).nullish(),
-    negRiskAugmented: z.boolean().nullish(),
-    countryName: z.string().nullish(),
-    electionType: z.string().nullish(),
-    color: z.string().nullish(),
-    tweetCount: z.number().int().nullish(),
-    chats: z.array(ChatSchema).nullish(),
-    featuredOrder: z.number().int().nullish(),
-    estimateValue: z.boolean().nullish(),
-    cantEstimate: z.boolean().nullish(),
-    estimatedValue: z.string().nullish(),
-    cumulativeMarkets: z.boolean().nullish(),
-    templates: z.array(TemplateReferenceSchema).nullish(),
-    spreadsMainLine: z.number().nullish(),
-    totalsMainLine: z.number().nullish(),
-    carouselMap: z.string().nullish(),
-    pendingDeployment: z.boolean().nullish(),
-    deploying: z.boolean().nullish(),
-    deployingTimestamp: IsoDateTimeStringSchema.nullish(),
-    scheduledDeploymentTimestamp: IsoDateTimeStringSchema.nullish(),
-    gameStatus: z.string().nullish(),
-    internalUsers: z.array(InternalUserSchema).nullish(),
-    gameId: z.number().int().nullish(),
-    rescheduledFromGameId: z.number().int().nullish(),
-    sportsradarMatchId: z.string().nullish(),
-    bestLines: z.array(BestLineSchema).nullish(),
-    homeTeamName: z.string().nullish(),
-    awayTeamName: z.string().nullish(),
-    requiresTranslation: z.boolean().nullish(),
-    turnProviderId: z.string().nullish(),
-    lastHighlight: z.string().nullish(),
-    lastHighlightType: z.string().nullish(),
-    lastHighlightAt: IsoDateTimeStringSchema.nullish(),
-    eventMetadata: z.record(z.string(), z.unknown()).nullish(),
-    teams: z.array(TeamSchema).nullish(),
-    sport: SportsMetadataSchema.nullish(),
-    externalPartners: z.array(EventExternalPartnerMappingSchema).nullish(),
-  })
-  .transform(
-    ({
-      deployingTimestamp,
-      finishedTimestamp,
-      published_at,
-      scheduledDeploymentTimestamp,
-      tag_labels,
-      tag_slugs,
-      ...rest
-    }) => ({
-      ...rest,
-      deployingAt: deployingTimestamp,
-      finishedAt: finishedTimestamp,
-      publishedAt: published_at,
-      scheduledDeploymentAt: scheduledDeploymentTimestamp,
-      tagLabels: tag_labels,
-      tagSlugs: tag_slugs,
-    }),
-  );
+export type EventState = {
+  active?: boolean | null;
+  closed?: boolean | null;
+  archived?: boolean | null;
+  new?: boolean | null;
+  featured?: boolean | null;
+  restricted?: boolean | null;
+  cyom?: boolean | null;
+  live?: boolean | null;
+  ended?: boolean | null;
+  automaticallyActive?: boolean | null;
+  commentsEnabled?: boolean | null;
+  requiresTranslation?: boolean | null;
+};
+
+export type EventSchedule = {
+  startDate?: IsoDateTimeString | null;
+  creationDate?: IsoDateTimeString | null;
+  endDate?: IsoDateTimeString | null;
+  publishedAt?: IsoDateTimeString | null;
+  createdAt?: IsoDateTimeString | null;
+  updatedAt?: IsoDateTimeString | null;
+  closedTime?: IsoDateTimeString | null;
+  startTime?: IsoDateTimeString | null;
+  eventDate?: IsoCalendarDateString | null;
+  eventWeek?: number | null;
+  finishedAt?: IsoDateTimeString | null;
+};
+
+export type EventMetrics = {
+  liquidity?: number | null;
+  liquidityAmm?: number | null;
+  liquidityClob?: number | null;
+  volume?: number | null;
+  volume24hr?: number | null;
+  volume1wk?: number | null;
+  volume1mo?: number | null;
+  volume1yr?: number | null;
+  openInterest?: number | null;
+  competitive?: number | null;
+  commentCount?: number | null;
+  tweetCount?: number | null;
+};
+
+export type EventDisplay = {
+  sortBy?: string | null;
+  showAllOutcomes?: boolean | null;
+  showMarketImages?: boolean | null;
+  gmpChartMode?: string | null;
+  color?: string | null;
+  featuredOrder?: number | null;
+  countryName?: string | null;
+  electionType?: string | null;
+  imageOptimized?: ImageOptimization | null;
+  iconOptimized?: ImageOptimization | null;
+  featuredImageOptimized?: ImageOptimization | null;
+};
+
+export type EventTrading = {
+  enableOrderBook?: boolean | null;
+  negRisk?: boolean | null;
+  negRiskMarketId?: string | null;
+  negRiskFeeBips?: number | null;
+  enableNegRisk?: boolean | null;
+  negRiskAugmented?: boolean | null;
+  cumulativeMarkets?: boolean | null;
+};
+
+export type EventResolution = {
+  source?: string | null;
+  automaticallyResolved?: boolean | null;
+};
+
+export type EventEstimation = {
+  estimateValue?: boolean | null;
+  cantEstimate?: boolean | null;
+  estimatedValue?: string | null;
+};
+
+export type EventSportsMetadata = {
+  seriesSlug?: string | null;
+  score?: string | null;
+  elapsed?: string | null;
+  period?: string | null;
+  gameStatus?: string | null;
+  gameId?: number | null;
+  rescheduledFromGameId?: number | null;
+  sportsradarMatchId?: string | null;
+  homeTeamName?: string | null;
+  awayTeamName?: string | null;
+  spreadsMainLine?: number | null;
+  totalsMainLine?: number | null;
+  bestLines: BestLine[];
+  teams: Team[];
+  sport?: SportsMetadata | null;
+  lastHighlight?: string | null;
+  lastHighlightType?: string | null;
+  lastHighlightAt?: IsoDateTimeString | null;
+};
+
+export type EventSeries = {
+  id: SeriesId;
+  slug?: string | null;
+  title?: string | null;
+  subtitle?: string | null;
+  description?: string | null;
+  image?: string | null;
+  icon?: string | null;
+  active?: boolean | null;
+  closed?: boolean | null;
+  archived?: boolean | null;
+  volume?: number | null;
+  liquidity?: number | null;
+  startDate?: IsoDateTimeString | null;
+};
+
+export type EventTag = {
+  id: TagId;
+  slug?: string | null;
+  label?: string | null;
+};
+
+export type EventCreator = {
+  id: EventCreatorId;
+  name?: string | null;
+  handle?: string | null;
+  url?: string | null;
+  image?: string | null;
+  createdAt?: IsoDateTimeString | null;
+  updatedAt?: IsoDateTimeString | null;
+};
+
+export type EventPartner = {
+  id: EventExternalPartnerMappingId;
+  eventId: EventId;
+  externalId: string;
+  partner: {
+    id: PartnerId;
+    slug: string;
+    name: string;
+  } | null;
+  createdAt?: IsoDateTimeString | null;
+  updatedAt?: IsoDateTimeString | null;
+};
+
+export type Event = {
+  id: EventId;
+  ticker?: string | null;
+  slug?: string | null;
+  title?: string | null;
+  subtitle?: string | null;
+  description?: string | null;
+  category?: string | null;
+  subcategory?: string | null;
+  image?: string | null;
+  icon?: string | null;
+  featuredImage?: string | null;
+  state: EventState;
+  schedule: EventSchedule;
+  metrics: EventMetrics;
+  display: EventDisplay;
+  trading: EventTrading;
+  resolution: EventResolution;
+  estimation: EventEstimation;
+  sports: EventSportsMetadata;
+  partners: EventPartner[];
+  metadata: Record<string, unknown> | null;
+  markets: Market[];
+  series: EventSeries[];
+  tags: EventTag[];
+  creators: EventCreator[];
+};
+
+export const GammaEventSchema = z.object({
+  id: EventIdSchema,
+  ticker: z.string().nullish(),
+  slug: z.string().nullish(),
+  title: z.string().nullish(),
+  subtitle: z.string().nullish(),
+  description: z.string().nullish(),
+  resolutionSource: z.string().nullish(),
+  startDate: IsoDateTimeStringSchema.nullish(),
+  creationDate: IsoDateTimeStringSchema.nullish(),
+  endDate: IsoDateTimeStringSchema.nullish(),
+  image: z.string().nullish(),
+  icon: z.string().nullish(),
+  active: z.boolean().nullish(),
+  closed: z.boolean().nullish(),
+  archived: z.boolean().nullish(),
+  new: z.boolean().nullish(),
+  featured: z.boolean().nullish(),
+  restricted: z.boolean().nullish(),
+  liquidity: z.number().nullish(),
+  volume: z.number().nullish(),
+  openInterest: z.number().nullish(),
+  sortBy: z.string().nullish(),
+  category: z.string().nullish(),
+  subcategory: z.string().nullish(),
+  isTemplate: z.boolean().nullish(),
+  templateVariables: z.string().nullish(),
+  published_at: IsoDateTimeStringSchema.nullish(),
+  createdBy: z.string().nullish(),
+  updatedBy: z.string().nullish(),
+  createdAt: IsoDateTimeStringSchema.nullish(),
+  updatedAt: IsoDateTimeStringSchema.nullish(),
+  commentsEnabled: z.boolean().nullish(),
+  competitive: z.number().nullish(),
+  volume24hr: z.number().nullish(),
+  volume1wk: z.number().nullish(),
+  volume1mo: z.number().nullish(),
+  volume1yr: z.number().nullish(),
+  featuredImage: z.string().nullish(),
+  disqusThread: z.string().nullish(),
+  parentEventId: z.number().int().nullish(),
+  enableOrderBook: z.boolean().nullish(),
+  liquidityAmm: z.number().nullish(),
+  liquidityClob: z.number().nullish(),
+  negRisk: z.boolean().nullish(),
+  negRiskMarketID: z.string().nullish(),
+  negRiskFeeBips: z.number().int().nullish(),
+  commentCount: z.number().int().nullish(),
+  imageOptimized: ImageOptimizationSchema.nullish(),
+  iconOptimized: ImageOptimizationSchema.nullish(),
+  featuredImageOptimized: ImageOptimizationSchema.nullish(),
+  subEvents: z.array(z.string()).nullish(),
+  markets: GammaEventMarketsSchema.nullish(),
+  series: z.array(SeriesReferenceSchema).nullish(),
+  categories: z.array(CategoryReferenceSchema).nullish(),
+  collections: z.array(CollectionReferenceSchema).nullish(),
+  tags: z.array(TagReferenceSchema).nullish(),
+  tag_labels: z.array(z.string()).nullish(),
+  tag_slugs: z.array(z.string()).nullish(),
+  cyom: z.boolean().nullish(),
+  closedTime: IsoDateTimeStringSchema.nullish(),
+  showAllOutcomes: z.boolean().nullish(),
+  showMarketImages: z.boolean().nullish(),
+  automaticallyResolved: z.boolean().nullish(),
+  enableNegRisk: z.boolean().nullish(),
+  automaticallyActive: z.boolean().nullish(),
+  eventDate: IsoCalendarDateStringSchema.nullish(),
+  startTime: IsoDateTimeStringSchema.nullish(),
+  eventWeek: z.number().int().nullish(),
+  seriesSlug: z.string().nullish(),
+  score: z.string().nullish(),
+  elapsed: z.string().nullish(),
+  period: z.string().nullish(),
+  live: z.boolean().nullish(),
+  ended: z.boolean().nullish(),
+  finishedTimestamp: IsoDateTimeStringSchema.nullish(),
+  gmpChartMode: z.string().nullish(),
+  eventCreators: z.array(EventCreatorSchema).nullish(),
+  negRiskAugmented: z.boolean().nullish(),
+  countryName: z.string().nullish(),
+  electionType: z.string().nullish(),
+  color: z.string().nullish(),
+  tweetCount: z.number().int().nullish(),
+  chats: z.array(ChatSchema).nullish(),
+  featuredOrder: z.number().int().nullish(),
+  estimateValue: z.boolean().nullish(),
+  cantEstimate: z.boolean().nullish(),
+  estimatedValue: z.string().nullish(),
+  cumulativeMarkets: z.boolean().nullish(),
+  templates: z.array(TemplateReferenceSchema).nullish(),
+  spreadsMainLine: z.number().nullish(),
+  totalsMainLine: z.number().nullish(),
+  carouselMap: z.string().nullish(),
+  pendingDeployment: z.boolean().nullish(),
+  deploying: z.boolean().nullish(),
+  deployingTimestamp: IsoDateTimeStringSchema.nullish(),
+  scheduledDeploymentTimestamp: IsoDateTimeStringSchema.nullish(),
+  gameStatus: z.string().nullish(),
+  internalUsers: z.array(InternalUserSchema).nullish(),
+  gameId: z.number().int().nullish(),
+  rescheduledFromGameId: z.number().int().nullish(),
+  sportsradarMatchId: z.string().nullish(),
+  bestLines: z.array(BestLineSchema).nullish(),
+  homeTeamName: z.string().nullish(),
+  awayTeamName: z.string().nullish(),
+  requiresTranslation: z.boolean().nullish(),
+  turnProviderId: z.string().nullish(),
+  lastHighlight: z.string().nullish(),
+  lastHighlightType: z.string().nullish(),
+  lastHighlightAt: IsoDateTimeStringSchema.nullish(),
+  eventMetadata: z.record(z.string(), z.unknown()).nullish(),
+  teams: z.array(TeamSchema).nullish(),
+  sport: SportsMetadataSchema.nullish(),
+  externalPartners: z.array(EventExternalPartnerMappingSchema).nullish(),
+});
+
+export const EventSchema = GammaEventSchema.transform(
+  normalizeEvent,
+) satisfies z.ZodType<Event>;
 
 export const ListEventsResponseSchema = z.array(EventSchema);
 export const ListEventsKeysetResponseSchema = z
@@ -349,7 +529,7 @@ export const ListEventsKeysetResponseSchema = z
   }));
 export const FetchEventTagsResponseSchema = z.array(TagReferenceSchema);
 
-export type Event = z.infer<typeof EventSchema>;
+export type GammaEvent = z.infer<typeof GammaEventSchema>;
 export type ListEventsResponse = z.infer<typeof ListEventsResponseSchema>;
 export type ListEventsKeysetResponse = z.infer<
   typeof ListEventsKeysetResponseSchema
@@ -368,7 +548,6 @@ export type CollectionReference = z.infer<typeof CollectionReferenceSchema>;
 export type SeriesReference = z.infer<typeof SeriesReferenceSchema>;
 export type TemplateReference = z.infer<typeof TemplateReferenceSchema>;
 export type Chat = z.infer<typeof ChatSchema>;
-export type EventCreator = z.infer<typeof EventCreatorSchema>;
 export type Partner = z.infer<typeof PartnerSchema>;
 export type EventExternalPartnerMapping = z.infer<
   typeof EventExternalPartnerMappingSchema
@@ -376,3 +555,171 @@ export type EventExternalPartnerMapping = z.infer<
 export type BestLine = z.infer<typeof BestLineSchema>;
 export type Team = z.infer<typeof TeamSchema>;
 export type SportsMetadata = z.infer<typeof SportsMetadataSchema>;
+
+function normalizeEvent(event: GammaEvent): Event {
+  return {
+    id: event.id,
+    ticker: event.ticker,
+    slug: event.slug,
+    title: event.title,
+    subtitle: event.subtitle,
+    description: event.description,
+    category: event.category,
+    subcategory: event.subcategory,
+    image: event.image,
+    icon: event.icon,
+    featuredImage: event.featuredImage,
+    state: {
+      active: event.active,
+      closed: event.closed,
+      archived: event.archived,
+      new: event.new,
+      featured: event.featured,
+      restricted: event.restricted,
+      cyom: event.cyom,
+      live: event.live,
+      ended: event.ended,
+      automaticallyActive: event.automaticallyActive,
+      commentsEnabled: event.commentsEnabled,
+      requiresTranslation: event.requiresTranslation,
+    },
+    schedule: {
+      startDate: event.startDate,
+      creationDate: event.creationDate,
+      endDate: event.endDate,
+      publishedAt: event.published_at,
+      createdAt: event.createdAt,
+      updatedAt: event.updatedAt,
+      closedTime: event.closedTime,
+      startTime: event.startTime,
+      eventDate: event.eventDate,
+      eventWeek: event.eventWeek,
+      finishedAt: event.finishedTimestamp,
+    },
+    metrics: {
+      liquidity: event.liquidity,
+      liquidityAmm: event.liquidityAmm,
+      liquidityClob: event.liquidityClob,
+      volume: event.volume,
+      volume24hr: event.volume24hr,
+      volume1wk: event.volume1wk,
+      volume1mo: event.volume1mo,
+      volume1yr: event.volume1yr,
+      openInterest: event.openInterest,
+      competitive: event.competitive,
+      commentCount: event.commentCount,
+      tweetCount: event.tweetCount,
+    },
+    display: {
+      sortBy: event.sortBy,
+      showAllOutcomes: event.showAllOutcomes,
+      showMarketImages: event.showMarketImages,
+      gmpChartMode: event.gmpChartMode,
+      color: event.color,
+      featuredOrder: event.featuredOrder,
+      countryName: event.countryName,
+      electionType: event.electionType,
+      imageOptimized: event.imageOptimized,
+      iconOptimized: event.iconOptimized,
+      featuredImageOptimized: event.featuredImageOptimized,
+    },
+    trading: {
+      enableOrderBook: event.enableOrderBook,
+      negRisk: event.negRisk,
+      negRiskMarketId: event.negRiskMarketID,
+      negRiskFeeBips: event.negRiskFeeBips,
+      enableNegRisk: event.enableNegRisk,
+      negRiskAugmented: event.negRiskAugmented,
+      cumulativeMarkets: event.cumulativeMarkets,
+    },
+    resolution: {
+      source: event.resolutionSource,
+      automaticallyResolved: event.automaticallyResolved,
+    },
+    estimation: {
+      estimateValue: event.estimateValue,
+      cantEstimate: event.cantEstimate,
+      estimatedValue: event.estimatedValue,
+    },
+    sports: {
+      seriesSlug: event.seriesSlug,
+      score: event.score,
+      elapsed: event.elapsed,
+      period: event.period,
+      gameStatus: event.gameStatus,
+      gameId: event.gameId,
+      rescheduledFromGameId: event.rescheduledFromGameId,
+      sportsradarMatchId: event.sportsradarMatchId,
+      homeTeamName: event.homeTeamName,
+      awayTeamName: event.awayTeamName,
+      spreadsMainLine: event.spreadsMainLine,
+      totalsMainLine: event.totalsMainLine,
+      bestLines: event.bestLines ?? [],
+      teams: event.teams ?? [],
+      sport: event.sport,
+      lastHighlight: event.lastHighlight,
+      lastHighlightType: event.lastHighlightType,
+      lastHighlightAt: event.lastHighlightAt,
+    },
+    partners: (event.externalPartners ?? []).map((partner) => ({
+      id: partner.id,
+      eventId: partner.eventId,
+      externalId: partner.externalId,
+      partner: partner.partner
+        ? {
+            id: partner.partner.id,
+            slug: partner.partner.slug,
+            name: partner.partner.name,
+          }
+        : null,
+      createdAt: partner.createdAt,
+      updatedAt: partner.updatedAt,
+    })),
+    metadata: event.eventMetadata ?? null,
+    markets: event.markets ?? [],
+    series: (event.series ?? []).map((series) => ({
+      id: series.id,
+      slug: series.slug,
+      title: series.title,
+      subtitle: series.subtitle,
+      description: series.description,
+      image: series.image,
+      icon: series.icon,
+      active: series.active,
+      closed: series.closed,
+      archived: series.archived,
+      volume: series.volume,
+      liquidity: series.liquidity,
+      startDate: series.startDate,
+    })),
+    tags: (event.tags ?? []).map((tag) => ({
+      id: tag.id,
+      slug: tag.slug,
+      label: tag.label,
+    })),
+    creators: (event.eventCreators ?? []).map((creator) => ({
+      id: creator.id,
+      name: creator.creatorName,
+      handle: creator.creatorHandle,
+      url: creator.creatorUrl ?? creator.creatorURL,
+      image: creator.creatorImage,
+      createdAt: creator.createdAt,
+      updatedAt: creator.updatedAt,
+    })),
+  };
+}
+
+function filterDeployableMarkets(value: unknown): unknown {
+  if (!Array.isArray(value)) {
+    return value;
+  }
+
+  return value.filter((market) => {
+    if (!market || typeof market !== 'object') {
+      return false;
+    }
+
+    const conditionId = (market as { conditionId?: unknown }).conditionId;
+    return typeof conditionId === 'string' && conditionId.length > 0;
+  });
+}

--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -238,9 +238,6 @@ export type EventSchedule = {
   startDate?: IsoDateTimeString | null;
   creationDate?: IsoDateTimeString | null;
   endDate?: IsoDateTimeString | null;
-  publishedAt?: IsoDateTimeString | null;
-  createdAt?: IsoDateTimeString | null;
-  updatedAt?: IsoDateTimeString | null;
   closedTime?: IsoDateTimeString | null;
   startTime?: IsoDateTimeString | null;
   eventDate?: IsoCalendarDateString | null;
@@ -375,6 +372,9 @@ export type Event = {
   image?: string | null;
   icon?: string | null;
   featuredImage?: string | null;
+  createdAt?: IsoDateTimeString | null;
+  updatedAt?: IsoDateTimeString | null;
+  publishedAt?: IsoDateTimeString | null;
   state: EventState;
   schedule: EventSchedule;
   metrics: EventMetrics;
@@ -563,6 +563,9 @@ function normalizeEvent(event: GammaEvent): Event {
     image: event.image,
     icon: event.icon,
     featuredImage: event.featuredImage,
+    createdAt: event.createdAt,
+    updatedAt: event.updatedAt,
+    publishedAt: event.published_at,
     state: {
       active: event.active,
       closed: event.closed,
@@ -581,9 +584,6 @@ function normalizeEvent(event: GammaEvent): Event {
       startDate: event.startDate,
       creationDate: event.creationDate,
       endDate: event.endDate,
-      publishedAt: event.published_at,
-      createdAt: event.createdAt,
-      updatedAt: event.updatedAt,
       closedTime: event.closedTime,
       startTime: event.startTime,
       eventDate: event.eventDate,

--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -56,11 +56,6 @@ const SportIdSchema = z.number().int().transform(toSportId);
 const TeamIdSchema = z.number().int().transform(toTeamId);
 const TemplateIdSchema = z.string().transform(toTemplateId);
 
-const GammaEventMarketsSchema = z.preprocess(
-  filterDeployableMarkets,
-  z.array(MarketSchema),
-);
-
 export const CollectionReferenceSchema = z.object({
   id: CollectionIdSchema,
   ticker: z.string().nullish(),
@@ -358,7 +353,6 @@ export type EventCreator = {
 
 export type EventPartner = {
   id: EventExternalPartnerMappingId;
-  eventId: EventId;
   externalId: string;
   partner: {
     id: PartnerId;
@@ -449,7 +443,7 @@ export const GammaEventSchema = z.object({
   iconOptimized: ImageOptimizationSchema.nullish(),
   featuredImageOptimized: ImageOptimizationSchema.nullish(),
   subEvents: z.array(z.string()).nullish(),
-  markets: GammaEventMarketsSchema.nullish(),
+  markets: z.array(MarketSchema).nullish(),
   series: z.array(SeriesReferenceSchema).nullish(),
   categories: z.array(CategoryReferenceSchema).nullish(),
   collections: z.array(CollectionReferenceSchema).nullish(),
@@ -663,7 +657,6 @@ function normalizeEvent(event: GammaEvent): Event {
     },
     partners: (event.externalPartners ?? []).map((partner) => ({
       id: partner.id,
-      eventId: partner.eventId,
       externalId: partner.externalId,
       partner: partner.partner
         ? {
@@ -707,19 +700,4 @@ function normalizeEvent(event: GammaEvent): Event {
       updatedAt: creator.updatedAt,
     })),
   };
-}
-
-function filterDeployableMarkets(value: unknown): unknown {
-  if (!Array.isArray(value)) {
-    return value;
-  }
-
-  return value.filter((market) => {
-    if (!market || typeof market !== 'object') {
-      return false;
-    }
-
-    const conditionId = (market as { conditionId?: unknown }).conditionId;
-    return typeof conditionId === 'string' && conditionId.length > 0;
-  });
 }

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -167,7 +167,7 @@ export type MarketTag = {
 export type Market = {
   id: MarketId;
   slug?: string | null;
-  conditionId: ConditionId;
+  conditionId: ConditionId | null;
   question?: string | null;
   description?: string | null;
   category?: string | null;
@@ -188,7 +188,9 @@ export type Market = {
 export const GammaMarketSchema = z.object({
   id: MarketIdSchema,
   question: z.string().nullish(),
-  conditionId: ConditionIdSchema,
+  conditionId: z
+    .preprocess(emptyStringToNull, ConditionIdSchema.nullish())
+    .transform(nullishToNull),
   slug: z.string().nullish(),
   twitterCardImage: z.string().nullish(),
   resolutionSource: z.string().nullish(),

--- a/packages/client/src/actions/positions.test.ts
+++ b/packages/client/src/actions/positions.test.ts
@@ -1,5 +1,5 @@
 import { WalletType } from '@polymarket/bindings/gamma';
-import { invariant } from '@polymarket/types';
+import { expectPresent, invariant } from '@polymarket/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
   createTestSecureClient,
@@ -12,6 +12,7 @@ const TEST_MARKET_SLUG = 'eth-flipped-in-2026';
 const market = await publicClient.fetchMarket({
   slug: TEST_MARKET_SLUG,
 });
+const conditionId = expectPresent(market.conditionId);
 
 const secureClient = await createTestSecureClient({
   apiKey: relayerAuthorization,
@@ -27,7 +28,7 @@ describe('Positions', () => {
     await secureClient
       .splitPosition({
         amount: 1_000_000n,
-        conditionId: market.conditionId,
+        conditionId,
       })
       .then((handle) => handle.wait());
 
@@ -36,7 +37,7 @@ describe('Positions', () => {
         const positions = await secureClient
           .listPositions({
             user: secureClient.account.wallet,
-            market: [market.conditionId],
+            market: [conditionId],
           })
           .firstPage();
         expect(positions.items).toHaveLength(2);
@@ -49,7 +50,7 @@ describe('Positions', () => {
     const positions = await secureClient
       .listPositions({
         user: secureClient.account.wallet,
-        market: [market.conditionId],
+        market: [conditionId],
       })
       .firstPage();
 
@@ -60,7 +61,7 @@ describe('Positions', () => {
     await secureClient
       .mergePositions({
         amount: 'max',
-        conditionId: market.conditionId,
+        conditionId,
       })
       .then((handle) => handle.wait());
 
@@ -69,7 +70,7 @@ describe('Positions', () => {
         const positions = await secureClient
           .listPositions({
             user: secureClient.account.wallet,
-            market: [market.conditionId],
+            market: [conditionId],
           })
           .firstPage();
         expect(positions.items).toHaveLength(0);


### PR DESCRIPTION
## Summary
- Normalize public event responses into grouped state, schedule, metrics, display, trading, resolution, estimation, sports, partners, metadata, and relationship fields.
- Keep raw Gamma event parsing separate via `GammaEventSchema` while omitting template/admin/deployment fields from the public `Event` shape.
- Parse event markets as `Market[]` and map external partner mappings to `event.partners`.

## Verification
- pnpm --filter @polymarket/bindings typecheck
- pnpm --filter @polymarket/client typecheck
- pnpm typecheck
- pnpm lint
- pnpm --filter @polymarket/bindings build
- Live parse check against sampled `/events` responses

Note: `pnpm test:client -- events.test.ts` is blocked locally because `POLYMARKET_BUILDER_CODE` is not set during test module import.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the exported `Event` shape and market `conditionId` nullability, which can break downstream consumers that expect the previous flat schema or non-null IDs.
> 
> **Overview**
> Normalizes `EventSchema` output in `@polymarket/bindings` by introducing a raw `GammaEventSchema` and transforming it into a new grouped `Event` shape (`state`, `schedule`, `metrics`, `display`, `trading`, `resolution`, `estimation`, `sports`, `partners`, `metadata`, plus `markets/series/tags/creators`). This also tightens parsing: event markets now parse as full `Market[]`, external partner mappings accept either string or numeric `eventId`, and creator URLs handle both `creatorUrl`/`creatorURL`.
> 
> Updates market parsing to allow `conditionId` to be `null` (including empty-string inputs) and adjusts the client positions tests to assert/pin a non-null `conditionId` via `expectPresent` before using it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb67fdf65890548d77839c4a45ce9879432757af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->