### PR TITLE
Add secure client signer factory

### DIFF
--- a/packages/client/src/actions/account.test.ts
+++ b/packages/client/src/actions/account.test.ts
@@ -1,16 +1,13 @@
 import { AssetType } from '@polymarket/bindings/clob';
 import { describe, expect, it } from 'vitest';
 import type { AccountActions } from '../decorators';
-import { publicClient, safeWalletAddress, walletClient } from '../testing';
-import { authenticateWith } from '../viem';
+import { createTestSecureClient } from '../testing';
 import { fetchBalanceAllowance } from './account';
 
 describe('Account', () => {
   describe('authenticated reads', () => {
     it('fetches authenticated account state', async () => {
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient();
 
       const [closedOnly, openOrders, trades, notifications, balanceAllowance] =
         await Promise.all([
@@ -38,9 +35,7 @@ describe('Account', () => {
 
   describe('dropNotifications', () => {
     it('marks notifications as read by id', async () => {
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient();
 
       const notifications = await secureClient.fetchNotifications();
 

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -1,73 +1,66 @@
 import { WalletType } from '@polymarket/bindings/gamma';
 import { ZERO_ADDRESS } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
-import { createPublicClient } from '../clients';
+import { createSecureClient } from '../clients';
 import { SigningError } from '../errors';
 import {
   createRandomWalletClient,
-  publicClientWithRelayerKey,
-  safeWalletAddress,
-  walletClient,
+  createTestSecureClient,
+  relayerAuthorization,
 } from '../testing';
-import { authenticateWith, completeWith } from '../viem';
+import { signerFrom } from '../viem';
 
 describe('Approvals', () => {
   describe('prepareErc20Approval', () => {
     it('submits a collateral approval for the standard exchange', async () => {
-      const secureClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      const handle = await secureClient
-        .prepareErc20Approval({
-          spenderAddress: secureClient.environment.standardExchange,
-          tokenAddress: secureClient.environment.collateralToken,
-          amount: 'max',
-        })
-        .then(completeWith(walletClient));
+      const handle = await secureClient.approveErc20({
+        spenderAddress: secureClient.environment.standardExchange,
+        tokenAddress: secureClient.environment.collateralToken,
+        amount: 'max',
+      });
 
       await expect(handle.wait()).resolves.toBeTruthy();
     });
 
     it('supports EOA approvals as traditional transactions', async () => {
-      const publicClient = createPublicClient();
       const walletClient = createRandomWalletClient();
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: walletClient.account.address })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createSecureClient({
+        wallet: walletClient.account.address,
+        signer: signerFrom(walletClient),
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.EOA);
 
       // to avoid having to fund the wallet we stop the test by proving the
       // transaction request is correctly formed, without actually sending it
       await expect(
-        secureClient
-          .prepareErc20Approval({
-            amount: 'max',
-            spenderAddress: ZERO_ADDRESS,
-            tokenAddress: secureClient.environment.collateralToken,
-          })
-          .then(completeWith(walletClient)),
+        secureClient.approveErc20({
+          amount: 'max',
+          spenderAddress: ZERO_ADDRESS,
+          tokenAddress: secureClient.environment.collateralToken,
+        }),
       ).rejects.toBeInstanceOf(SigningError);
     });
   });
 
   describe('prepareErc1155ApprovalForAll', () => {
     it('submits a Conditional Tokens approval for the standard exchange', async () => {
-      const secureClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      const handle = await secureClient
-        .prepareErc1155ApprovalForAll({
-          operatorAddress: secureClient.environment.standardExchange,
-          tokenAddress: secureClient.environment.conditionalTokens,
-        })
-        .then(completeWith(walletClient));
+      const handle = await secureClient.approveErc1155ForAll({
+        operatorAddress: secureClient.environment.standardExchange,
+        tokenAddress: secureClient.environment.conditionalTokens,
+      });
 
       await expect(handle.wait()).resolves.toBeTruthy();
     });
@@ -75,15 +68,13 @@ describe('Approvals', () => {
 
   describe('prepareTradingApprovals', () => {
     it('submits a combined trading-setup approval workflow', async () => {
-      const secureClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      const handle = await secureClient
-        .prepareTradingApprovals()
-        .then(completeWith(walletClient));
+      const handle = await secureClient.setupTradingApprovals();
 
       await expect(handle.wait()).resolves.toBeTruthy();
     });

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -8,11 +8,20 @@ import {
   MAX_UINT256,
 } from '../abis';
 import type { BaseSecureClient } from '../clients';
-import { makeErrorGuard, UserInputError } from '../errors';
-import { parseUserInput } from '../input';
-import { expectTransactionHandle, type TransactionHandle } from '../types';
-import type { SignerTransactionRequest } from '../workflow';
 import {
+  CancelledSigningError,
+  makeErrorGuard,
+  SigningError,
+  UserInputError,
+} from '../errors';
+import { parseUserInput } from '../input';
+import {
+  expectTransactionHandle,
+  type SignerTransactionRequest,
+  type TransactionHandle,
+} from '../types';
+import {
+  completeWith,
   type SendErc20ApprovalTransactionRequest,
   type SendErc1155ApprovalForAllTransactionRequest,
   signerTransactionRequest,
@@ -47,20 +56,29 @@ export type PrepareErc20ApprovalRequest = z.input<
 export type PrepareErc20ApprovalError = UserInputError;
 export const PrepareErc20ApprovalError = makeErrorGuard(UserInputError);
 
+export type ApproveErc20Error =
+  | PrepareErc20ApprovalError
+  | CancelledSigningError
+  | SigningError;
+export const ApproveErc20Error = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
+
 /**
  * Starts an ERC-20 approval workflow.
  *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
  * @example
  * ```ts
- * const handle = await prepareErc20Approval(client, {
+ * const workflow = await prepareErc20Approval(client, {
  *   amount: 'max',
  *   spenderAddress: '0x1234…',
  *   tokenAddress: '0x5678…',
- * }).then(completeWith(wallet));
- *
- * const outcome = await handle.wait();
- *
- * // outcome.transactionHash: TxHash
+ * });
  * ```
  *
  * @throws {@link PrepareErc20ApprovalError}
@@ -100,6 +118,21 @@ export async function prepareErc20Approval(
   }.call(null);
 }
 
+/**
+ * Approves ERC-20 token spending for the authenticated account.
+ *
+ * @throws {@link ApproveErc20Error}
+ * Thrown on failure.
+ */
+export function approveErc20(
+  client: BaseSecureClient,
+  request: PrepareErc20ApprovalRequest,
+): Promise<TransactionHandle> {
+  return prepareErc20Approval(client, request).then(
+    completeWith(client.signer),
+  );
+}
+
 export type Erc1155ApprovalForAllWorkflowRequest =
   | GaslessWorkflowRequest
   | SendErc1155ApprovalForAllTransactionRequest;
@@ -124,19 +157,28 @@ export type PrepareErc1155ApprovalForAllRequest = z.input<
 export type PrepareErc1155ApprovalForAllError = UserInputError;
 export const PrepareErc1155ApprovalForAllError = makeErrorGuard(UserInputError);
 
+export type ApproveErc1155ForAllError =
+  | PrepareErc1155ApprovalForAllError
+  | CancelledSigningError
+  | SigningError;
+export const ApproveErc1155ForAllError = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
+
 /**
  * Starts an ERC-1155 approval-for-all workflow.
  *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
  * @example
  * ```ts
- * const handle = await prepareErc1155ApprovalForAll(client, {
+ * const workflow = await prepareErc1155ApprovalForAll(client, {
  *   operatorAddress: '0x1234…',
  *   tokenAddress: '0x5678…',
- * }).then(completeWith(wallet));
- *
- * const outcome = await handle.wait();
- *
- * // outcome.transactionHash: TxHash
+ * });
  * ```
  *
  * @throws {@link PrepareErc1155ApprovalForAllError}
@@ -182,6 +224,21 @@ export async function prepareErc1155ApprovalForAll(
   }.call(null);
 }
 
+/**
+ * Approves or revokes ERC-1155 operator access for the authenticated account.
+ *
+ * @throws {@link ApproveErc1155ForAllError}
+ * Thrown on failure.
+ */
+export function approveErc1155ForAll(
+  client: BaseSecureClient,
+  request: PrepareErc1155ApprovalForAllRequest,
+): Promise<TransactionHandle> {
+  return prepareErc1155ApprovalForAll(client, request).then(
+    completeWith(client.signer),
+  );
+}
+
 export type TradingApprovalsWorkflowRequest =
   | GaslessWorkflowRequest
   | SendErc20ApprovalTransactionRequest
@@ -196,8 +253,21 @@ export type TradingApprovalsWorkflow = AsyncGenerator<
 export type PrepareTradingApprovalsError = UserInputError;
 export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
 
+export type SetupTradingApprovalsError =
+  | PrepareTradingApprovalsError
+  | CancelledSigningError
+  | SigningError;
+export const SetupTradingApprovalsError = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
+
 /**
  * Starts a trading-setup approval workflow.
+ *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
  *
  * Prepares all approvals required for trading, including collateral and
  * position token approvals for both standard and neg-risk market flows.
@@ -206,11 +276,7 @@ export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
  *
  * @example
  * ```ts
- * const handle = await prepareTradingApprovals(client).then(completeWith(wallet));
- *
- * const outcome = await handle.wait();
- *
- * // outcome.transactionHash: TxHash
+ * const workflow = await prepareTradingApprovals(client);
  * ```
  *
  * @throws {@link PrepareTradingApprovalsError}
@@ -301,6 +367,18 @@ export async function prepareTradingApprovals(
       metadata: 'Trading setup approvals',
     });
   }.call(null);
+}
+
+/**
+ * Sets up the approvals required for trading.
+ *
+ * @throws {@link SetupTradingApprovalsError}
+ * Thrown on failure.
+ */
+export function setupTradingApprovals(
+  client: BaseSecureClient,
+): Promise<TransactionHandle> {
+  return prepareTradingApprovals(client).then(completeWith(client.signer));
 }
 
 function sendErc20ApprovalTransaction(

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -56,16 +56,6 @@ export type PrepareErc20ApprovalRequest = z.input<
 export type PrepareErc20ApprovalError = UserInputError;
 export const PrepareErc20ApprovalError = makeErrorGuard(UserInputError);
 
-export type ApproveErc20Error =
-  | PrepareErc20ApprovalError
-  | CancelledSigningError
-  | SigningError;
-export const ApproveErc20Error = makeErrorGuard(
-  CancelledSigningError,
-  SigningError,
-  UserInputError,
-);
-
 /**
  * Starts an ERC-20 approval workflow.
  *
@@ -118,6 +108,16 @@ export async function prepareErc20Approval(
   }.call(null);
 }
 
+export type ApproveErc20Error =
+  | PrepareErc20ApprovalError
+  | CancelledSigningError
+  | SigningError;
+export const ApproveErc20Error = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
+
 /**
  * Approves ERC-20 token spending for the authenticated account.
  *
@@ -156,16 +156,6 @@ export type PrepareErc1155ApprovalForAllRequest = z.input<
 
 export type PrepareErc1155ApprovalForAllError = UserInputError;
 export const PrepareErc1155ApprovalForAllError = makeErrorGuard(UserInputError);
-
-export type ApproveErc1155ForAllError =
-  | PrepareErc1155ApprovalForAllError
-  | CancelledSigningError
-  | SigningError;
-export const ApproveErc1155ForAllError = makeErrorGuard(
-  CancelledSigningError,
-  SigningError,
-  UserInputError,
-);
 
 /**
  * Starts an ERC-1155 approval-for-all workflow.
@@ -224,6 +214,16 @@ export async function prepareErc1155ApprovalForAll(
   }.call(null);
 }
 
+export type ApproveErc1155ForAllError =
+  | PrepareErc1155ApprovalForAllError
+  | CancelledSigningError
+  | SigningError;
+export const ApproveErc1155ForAllError = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
+
 /**
  * Approves or revokes ERC-1155 operator access for the authenticated account.
  *
@@ -252,16 +252,6 @@ export type TradingApprovalsWorkflow = AsyncGenerator<
 
 export type PrepareTradingApprovalsError = UserInputError;
 export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
-
-export type SetupTradingApprovalsError =
-  | PrepareTradingApprovalsError
-  | CancelledSigningError
-  | SigningError;
-export const SetupTradingApprovalsError = makeErrorGuard(
-  CancelledSigningError,
-  SigningError,
-  UserInputError,
-);
 
 /**
  * Starts a trading-setup approval workflow.
@@ -368,6 +358,16 @@ export async function prepareTradingApprovals(
     });
   }.call(null);
 }
+
+export type SetupTradingApprovalsError =
+  | PrepareTradingApprovalsError
+  | CancelledSigningError
+  | SigningError;
+export const SetupTradingApprovalsError = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
 
 /**
  * Sets up the approvals required for trading.

--- a/packages/client/src/actions/builders.test.ts
+++ b/packages/client/src/actions/builders.test.ts
@@ -2,14 +2,13 @@ import { OrderSide } from '@polymarket/bindings';
 import { delay, expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import {
+  builderAuthorization,
+  createTestSecureClient,
   expectNonEmptyPage,
   findHighVolumeLowPriceMarket,
   publicClientWithBuilderKey,
-  safeWalletAddress,
   testBuilderCode,
-  walletClient,
 } from '../testing';
-import { authenticateWith, completeWith } from '../viem';
 
 const market = await findHighVolumeLowPriceMarket();
 
@@ -31,22 +30,19 @@ describe('Builders', () => {
         return;
       }
 
-      const secureClient = await publicClientWithBuilderKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: builderAuthorization,
+      });
 
       console.log(market.slug);
       const tokenId = expectPresent(market.outcomes.yes.tokenId);
 
-      const response = await secureClient
-        .prepareMarketOrder({
-          amount: expectPresent(market.trading.minimumOrderSize),
-          builderCode: testBuilderCode,
-          side: OrderSide.BUY,
-          tokenId,
-        })
-        .then(completeWith(walletClient))
-        .then(secureClient.postOrder);
+      const response = await secureClient.placeMarketOrder({
+        amount: expectPresent(market.trading.minimumOrderSize),
+        builderCode: testBuilderCode,
+        side: OrderSide.BUY,
+        tokenId,
+      });
 
       expect(response.ok).toBe(true);
 

--- a/packages/client/src/actions/gasless.test.ts
+++ b/packages/client/src/actions/gasless.test.ts
@@ -3,25 +3,28 @@ import { expectEvmAddress } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import { erc20ApprovalCall } from '../abis';
 import { deriveSafeWalletAddress } from '../account';
-import { createPublicClient } from '../clients';
+import { createPublicClient, createSecureClient } from '../clients';
 import {
+  builderAuthorization,
   createRandomWalletClient,
+  createTestSecureClient,
   deriveProxyAddress,
   publicClientWithBuilderKey,
   publicClientWithRelayerKey,
+  relayerAuthorization,
   runMeteredTests,
   safeWalletAddress,
   walletClient,
 } from '../testing';
-import { authenticateWith, completeWith } from '../viem';
+import { signerFrom } from '../viem';
 import { prepareGaslessTransaction } from './gasless';
 
 describe('Gasless', () => {
   describe('isGaslessReady', () => {
     it('returns true for a deployed safe-backed account', async () => {
-      const secureClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
@@ -41,11 +44,11 @@ describe('Gasless', () => {
     });
 
     it('returns false for an EOA wallet type', async () => {
-      const publicClient = createPublicClient();
       const walletClient = createRandomWalletClient();
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: walletClient.account.address })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createSecureClient({
+        wallet: walletClient.account.address,
+        signer: signerFrom(walletClient),
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.EOA);
 
@@ -70,9 +73,9 @@ describe('Gasless', () => {
 
   describe('prepareGaslessTransaction', () => {
     it('prepares a single-call workflow without multisend aggregation', async () => {
-      const secureClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
@@ -110,9 +113,9 @@ describe('Gasless', () => {
     });
 
     it('prepares a multisend workflow when given multiple calls', async () => {
-      const secureClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
@@ -154,9 +157,10 @@ describe('Gasless', () => {
       const signerAddress = expectEvmAddress(walletClient.account.address);
       const proxyWallet = deriveProxyAddress(signerAddress);
 
-      const secureClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: proxyWallet })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+        wallet: proxyWallet,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_PROXY);
 
@@ -194,9 +198,10 @@ describe('Gasless', () => {
 
     it('rejects for EOA wallet type', async () => {
       const eoaClient = createRandomWalletClient();
-      const secureClient = await createPublicClient()
-        .beginAuthentication({ wallet: eoaClient.account.address })
-        .then(authenticateWith(eoaClient));
+      const secureClient = await createSecureClient({
+        wallet: eoaClient.account.address,
+        signer: signerFrom(eoaClient),
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.EOA);
 
@@ -231,9 +236,12 @@ describe('Gasless', () => {
           }),
         ).resolves.toBe(false);
 
-        const handle = await publicClientWithBuilderKey
-          .prepareGaslessWallet()
-          .then(completeWith(walletClient));
+        const secureClient = await createSecureClient({
+          apiKey: builderAuthorization,
+          signer: signerFrom(walletClient),
+          wallet: safeWallet,
+        });
+        const handle = await secureClient.setupGaslessWallet();
 
         expect(handle.wallet).toBe(safeWallet);
 

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -34,9 +34,11 @@ import { encodeProxyCall, encodeSafeMultisendCall } from '../abis';
 import { deriveSafeWalletAddress } from '../account';
 import type { BaseClient, BaseSecureClient } from '../clients';
 import {
+  CancelledSigningError,
   makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
+  SigningError,
   TimeoutError,
   TransactionFailedError,
   TransportError,
@@ -54,6 +56,7 @@ import type {
   TypedDataPayload,
 } from '../types';
 import {
+  completeWith,
   type RequestAddressRequest,
   requestAddress,
   type SignGaslessMessageRequest,
@@ -217,19 +220,32 @@ export const PrepareGaslessWalletError = makeErrorGuard(
   UserInputError,
 );
 
+export type SetupGaslessWalletError =
+  | PrepareGaslessWalletError
+  | CancelledSigningError
+  | SigningError;
+export const SetupGaslessWalletError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
 /**
  * Starts preparing the wallet for gasless transactions.
+ *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
  *
  * @throws {@link PrepareGaslessWalletError}
  * Thrown on failure.
  *
  * @example
  * ```ts
- * const handle = await prepareGaslessWallet(client).then(completeWith(wallet));
- *
- * const outcome = await handle.wait();
- *
- * // outcome.transactionHash: TxHash
+ * const workflow = await prepareGaslessWallet(client);
  * ```
  */
 export async function prepareGaslessWallet(
@@ -286,6 +302,18 @@ export async function prepareGaslessWallet(
 
     return new GaslessWalletHandle(safeWallet, handle);
   }.call(null);
+}
+
+/**
+ * Sets up a wallet for gasless transactions.
+ *
+ * @throws {@link SetupGaslessWalletError}
+ * Thrown on failure.
+ */
+export function setupGaslessWallet(
+  client: BaseSecureClient,
+): Promise<DeployTransactionHandle> {
+  return prepareGaslessWallet(client).then(completeWith(client.signer));
 }
 
 /**

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -220,20 +220,6 @@ export const PrepareGaslessWalletError = makeErrorGuard(
   UserInputError,
 );
 
-export type SetupGaslessWalletError =
-  | PrepareGaslessWalletError
-  | CancelledSigningError
-  | SigningError;
-export const SetupGaslessWalletError = makeErrorGuard(
-  CancelledSigningError,
-  RateLimitError,
-  RequestRejectedError,
-  SigningError,
-  TransportError,
-  UnexpectedResponseError,
-  UserInputError,
-);
-
 /**
  * Starts preparing the wallet for gasless transactions.
  *
@@ -303,6 +289,20 @@ export async function prepareGaslessWallet(
     return new GaslessWalletHandle(safeWallet, handle);
   }.call(null);
 }
+
+export type SetupGaslessWalletError =
+  | PrepareGaslessWalletError
+  | CancelledSigningError
+  | SigningError;
+export const SetupGaslessWalletError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Sets up a wallet for gasless transactions.

--- a/packages/client/src/actions/orders.test.ts
+++ b/packages/client/src/actions/orders.test.ts
@@ -8,22 +8,18 @@ import { expectPresent } from '@polymarket/types';
 import { afterAll, describe, expect, it } from 'vitest';
 import { InsufficientLiquidityError } from '../errors';
 import {
+  createTestSecureClient,
   findHighVolumeLowPriceMarket,
   publicClient,
-  publicClientWithRelayerKey,
+  relayerAuthorization,
   runMeteredTests,
-  safeWalletAddress,
   testBuilderCode,
-  walletClient,
 } from '../testing';
-import { authenticateWith, completeWith } from '../viem';
 import { fetchNegRisk } from './clob';
 
 const market = await findHighVolumeLowPriceMarket();
 
-const secureClient = await publicClient
-  .beginAuthentication({ wallet: safeWalletAddress })
-  .then(authenticateWith(walletClient));
+const secureClient = await createTestSecureClient();
 
 describe('Orders', { timeout: 60_000 }, () => {
   describe('estimateMarketPrice', () => {
@@ -73,12 +69,11 @@ describe('Orders', { timeout: 60_000 }, () => {
       );
 
       await secureClient
-        .prepareMarketOrderPosting({
+        .placeMarketOrder({
           amount: expectPresent(position?.size),
           side: OrderSide.SELL,
           tokenId: expectPresent(position?.tokenId),
         })
-        .then(completeWith(walletClient))
         .then(expectAcceptedOrderResponse);
     });
 
@@ -103,13 +98,11 @@ describe('Orders', { timeout: 60_000 }, () => {
           // leftover inventory, and use that cleanup path to exercise market
           // order posting.
           const result = await secureClient
-            .prepareMarketOrder({
+            .placeMarketOrder({
               amount: expectPresent(position.size),
               side: OrderSide.SELL,
               tokenId: expectPresent(position.tokenId),
             })
-            .then(completeWith(walletClient))
-            .then(secureClient.postOrder)
             .then(expectAcceptedOrderResponse);
 
           expect(result.orderId).not.toBe('');
@@ -122,13 +115,11 @@ describe('Orders', { timeout: 60_000 }, () => {
 
         const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
         const buyResult = await secureClient
-          .prepareMarketOrder({
+          .placeMarketOrder({
             amount: expectPresent(1),
             side: OrderSide.BUY,
             tokenId: yesTokenId,
           })
-          .then(completeWith(walletClient))
-          .then(secureClient.postOrder)
           .then(expectAcceptedOrderResponse);
 
         expect(buyResult.orderId).not.toBe('');
@@ -138,14 +129,12 @@ describe('Orders', { timeout: 60_000 }, () => {
     it('carries builder attribution onto the prepared market order', async () => {
       const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
 
-      const order = await secureClient
-        .prepareMarketOrder({
-          amount: expectPresent(market.trading.minimumOrderSize),
-          builderCode: testBuilderCode,
-          side: OrderSide.BUY,
-          tokenId: yesTokenId,
-        })
-        .then(completeWith(walletClient));
+      const order = await secureClient.createMarketOrder({
+        amount: expectPresent(market.trading.minimumOrderSize),
+        builderCode: testBuilderCode,
+        side: OrderSide.BUY,
+        tokenId: yesTokenId,
+      });
 
       expect(order.builder).toBe(testBuilderCode);
     });
@@ -157,62 +146,53 @@ describe('Orders', { timeout: 60_000 }, () => {
     const minSize = expectPresent(market.trading.minimumOrderSize);
 
     it('allows to place a limit order for the desired size and price', async () => {
-      const result = await secureClient
-        .prepareLimitOrder({
-          price: minPrice,
-          side: OrderSide.BUY,
-          size: minSize,
-          tokenId: yesTokenId,
-        })
-        .then(completeWith(walletClient))
-        .then(secureClient.postOrder);
+      const result = await secureClient.placeLimitOrder({
+        price: minPrice,
+        side: OrderSide.BUY,
+        size: minSize,
+        tokenId: yesTokenId,
+      });
 
       expect(result.ok).toBe(true);
     });
 
     it('carries post-only submission options onto the prepared order', async () => {
-      const order = await secureClient
-        .prepareLimitOrder({
-          builderCode: testBuilderCode,
-          postOnly: true,
-          price: minPrice,
-          side: OrderSide.BUY,
-          size: minSize,
-          tokenId: yesTokenId,
-        })
-        .then(completeWith(walletClient));
+      const order = await secureClient.createLimitOrder({
+        builderCode: testBuilderCode,
+        postOnly: true,
+        price: minPrice,
+        side: OrderSide.BUY,
+        size: minSize,
+        tokenId: yesTokenId,
+      });
 
       expect(order.postOnly).toBe(true);
       expect(order.builder).toBe(testBuilderCode);
     });
 
     it('requests a collateral approval if necessary', async () => {
-      const gaslessClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const gaslessClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+      });
       const exchangeAddress = await resolveExchangeAddressForToken(
         gaslessClient,
         yesTokenId,
       );
 
       await gaslessClient
-        .prepareErc20Approval({
+        .approveErc20({
           amount: 0n,
           spenderAddress: exchangeAddress,
           tokenAddress: gaslessClient.environment.collateralToken,
         })
-        .then(completeWith(walletClient))
         .then((handle) => handle.wait());
 
-      const response = await gaslessClient
-        .prepareLimitOrder({
-          price: minPrice,
-          side: OrderSide.BUY,
-          size: minSize,
-          tokenId: yesTokenId,
-        })
-        .then(completeWith(walletClient))
-        .then((order) => gaslessClient.postOrder(order));
+      const response = await gaslessClient.placeLimitOrder({
+        price: minPrice,
+        side: OrderSide.BUY,
+        size: minSize,
+        tokenId: yesTokenId,
+      });
 
       expect(response.ok).toBe(true);
       const acceptedResponse = expectAcceptedOrderResponse(response);
@@ -231,15 +211,13 @@ describe('Orders', { timeout: 60_000 }, () => {
     const minSize = expectPresent(market.trading.minimumOrderSize);
 
     it('creates, signs, and posts a limit order in one workflow', async () => {
-      const response = await secureClient
-        .prepareLimitOrderPosting({
-          postOnly: true,
-          price: minPrice,
-          side: OrderSide.BUY,
-          size: minSize,
-          tokenId: yesTokenId,
-        })
-        .then(completeWith(walletClient));
+      const response = await secureClient.placeLimitOrder({
+        postOnly: true,
+        price: minPrice,
+        side: OrderSide.BUY,
+        size: minSize,
+        tokenId: yesTokenId,
+      });
 
       expect(response.ok).toBe(true);
       const acceptedResponse = expectAcceptedOrderResponse(response);
@@ -326,14 +304,12 @@ async function createRestingLimitOrder(): Promise<{
   const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
   const tickSize = expectPresent(market.trading.minimumTickSize);
   const size = expectPresent(market.trading.minimumOrderSize);
-  const response = await secureClient
-    .prepareLimitOrderPosting({
-      price: tickSize,
-      side: OrderSide.BUY,
-      size,
-      tokenId: yesTokenId,
-    })
-    .then(completeWith(walletClient));
+  const response = await secureClient.placeLimitOrder({
+    price: tickSize,
+    side: OrderSide.BUY,
+    size,
+    tokenId: yesTokenId,
+  });
   expect(response.ok).toBe(true);
   const acceptedResponse = expectAcceptedOrderResponse(response);
 
@@ -351,14 +327,12 @@ async function createSignedRestingLimitOrder() {
   const tickSize = expectPresent(market.trading.minimumTickSize);
   const size = expectPresent(market.trading.minimumOrderSize);
 
-  return secureClient
-    .prepareLimitOrder({
-      price: tickSize,
-      side: OrderSide.BUY,
-      size,
-      tokenId: yesTokenId,
-    })
-    .then(completeWith(walletClient));
+  return secureClient.createLimitOrder({
+    price: tickSize,
+    side: OrderSide.BUY,
+    size,
+    tokenId: yesTokenId,
+  });
 }
 
 async function resolveExchangeAddressForToken(

--- a/packages/client/src/actions/orders/index.ts
+++ b/packages/client/src/actions/orders/index.ts
@@ -2,4 +2,5 @@ export * from './cancel';
 export * from './estimate';
 export * from './post';
 export * from './prepare';
+export * from './trade';
 export * from './types';

--- a/packages/client/src/actions/orders/post.ts
+++ b/packages/client/src/actions/orders/post.ts
@@ -60,13 +60,12 @@ export const PostOrdersError = makeErrorGuard(
  *
  * @example
  * ```ts
- * const response = await prepareMarketOrder(client, {
+ * const order = await client.createMarketOrder({
  *   amount: 10,
  *   side: OrderSide.BUY,
  *   tokenId: '123',
- * })
- *   .then(completeWith(wallet))
- *   .then(postOrder(client));
+ * });
+ * const response = await postOrder(client)(order);
  * ```
  *
  * @throws {@link PostOrderError}

--- a/packages/client/src/actions/orders/prepare.ts
+++ b/packages/client/src/actions/orders/prepare.ts
@@ -64,20 +64,19 @@ export const PrepareMarketOrderError = makeErrorGuard(
 /**
  * Starts the market-order workflow.
  *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
  * @throws {@link PrepareMarketOrderError}
  * Thrown on failure.
  *
  * @example
  * ```ts
- * const response = await prepareMarketOrder(client, {
+ * const workflow = await prepareMarketOrder(client, {
  *   amount: 10,
  *   side: OrderSide.BUY,
  *   tokenId: '123',
- * })
- *   .then(completeWith(wallet))
- *   .then(postOrder(client));
- *
- * // response: OrderResponse
+ * });
  * ```
  */
 export async function prepareMarketOrder(
@@ -120,21 +119,21 @@ export const PrepareLimitOrderError = makeErrorGuard(
 /**
  * Starts the limit-order workflow.
  *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
  * @throws {@link PrepareLimitOrderError}
  * Thrown on failure.
  *
  * @example
  * ```ts
- * const order = await prepareLimitOrder(client, {
+ * const workflow = await prepareLimitOrder(client, {
  *   postOnly: true,
  *   price: 0.52,
  *   side: OrderSide.BUY,
  *   size: 10,
  *   tokenId: '123',
- * }).then(completeWith(wallet))
- *   .then(postOrder(client));
- *
- * // response: OrderResponse
+ * });
  * ```
  */
 export async function prepareLimitOrder(
@@ -166,18 +165,19 @@ export const PrepareMarketOrderPostingError = PrepareMarketOrderError;
 /**
  * Starts and posts a market-order workflow.
  *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
  * @throws {@link PrepareMarketOrderPostingError}
  * Thrown on failure.
  *
  * @example
  * ```ts
- * const response = await prepareMarketOrderPosting(client, {
+ * const workflow = await prepareMarketOrderPosting(client, {
  *   amount: 10,
  *   side: OrderSide.BUY,
  *   tokenId: '123',
- * }).then(completeWith(wallet));
- *
- * // response: OrderResponse
+ * });
  * ```
  */
 export async function prepareMarketOrderPosting(
@@ -196,20 +196,21 @@ export const PrepareLimitOrderPostingError = PrepareLimitOrderError;
 /**
  * Starts and posts a limit-order workflow.
  *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
  * @throws {@link PrepareLimitOrderPostingError}
  * Thrown on failure.
  *
  * @example
  * ```ts
- * const response = await prepareLimitOrderPosting(client, {
+ * const workflow = await prepareLimitOrderPosting(client, {
  *   postOnly: true,
  *   price: 0.52,
  *   side: OrderSide.BUY,
  *   size: 10,
  *   tokenId: '123',
- * }).then(completeWith(wallet));
- *
- * // response: OrderResponse
+ * });
  * ```
  */
 export async function prepareLimitOrderPosting(

--- a/packages/client/src/actions/orders/trade.ts
+++ b/packages/client/src/actions/orders/trade.ts
@@ -1,0 +1,128 @@
+import type { OrderResponse } from '@polymarket/bindings/clob';
+import type { BaseSecureClient } from '../../clients';
+import {
+  CancelledSigningError,
+  InsufficientLiquidityError,
+  makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+} from '../../errors';
+import { completeWith } from '../../workflow';
+import { type PostOrderError, postOrder } from './post';
+import {
+  type PrepareLimitOrderError,
+  type PrepareMarketOrderError,
+  prepareLimitOrder,
+  prepareMarketOrder,
+} from './prepare';
+import type {
+  PrepareLimitOrderRequest,
+  PrepareMarketOrderRequest,
+  SignedOrder,
+} from './types';
+
+export type CreateMarketOrderError =
+  | PrepareMarketOrderError
+  | CancelledSigningError;
+export const CreateMarketOrderError = makeErrorGuard(
+  CancelledSigningError,
+  InsufficientLiquidityError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Creates a signed market order for the authenticated account.
+ *
+ * @throws {@link CreateMarketOrderError}
+ * Thrown on failure.
+ */
+export function createMarketOrder(
+  client: BaseSecureClient,
+  request: PrepareMarketOrderRequest,
+): Promise<SignedOrder> {
+  return prepareMarketOrder(client, request).then(completeWith(client.signer));
+}
+
+export type PlaceMarketOrderError = CreateMarketOrderError | PostOrderError;
+export const PlaceMarketOrderError = makeErrorGuard(
+  CancelledSigningError,
+  InsufficientLiquidityError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Creates and posts a market order for the authenticated account.
+ *
+ * @throws {@link PlaceMarketOrderError}
+ * Thrown on failure.
+ */
+export function placeMarketOrder(
+  client: BaseSecureClient,
+  request: PrepareMarketOrderRequest,
+): Promise<OrderResponse> {
+  return createMarketOrder(client, request).then(postOrder(client));
+}
+
+export type CreateLimitOrderError =
+  | PrepareLimitOrderError
+  | CancelledSigningError;
+export const CreateLimitOrderError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Creates a signed limit order for the authenticated account.
+ *
+ * @throws {@link CreateLimitOrderError}
+ * Thrown on failure.
+ */
+export function createLimitOrder(
+  client: BaseSecureClient,
+  request: PrepareLimitOrderRequest,
+): Promise<SignedOrder> {
+  return prepareLimitOrder(client, request).then(completeWith(client.signer));
+}
+
+export type PlaceLimitOrderError = CreateLimitOrderError | PostOrderError;
+export const PlaceLimitOrderError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Creates and posts a limit order for the authenticated account.
+ *
+ * @throws {@link PlaceLimitOrderError}
+ * Thrown on failure.
+ */
+export function placeLimitOrder(
+  client: BaseSecureClient,
+  request: PrepareLimitOrderRequest,
+): Promise<OrderResponse> {
+  return createLimitOrder(client, request).then(postOrder(client));
+}

--- a/packages/client/src/actions/positions.test.ts
+++ b/packages/client/src/actions/positions.test.ts
@@ -2,12 +2,10 @@ import { WalletType } from '@polymarket/bindings/gamma';
 import { invariant } from '@polymarket/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createTestSecureClient,
   publicClient,
-  publicClientWithRelayerKey,
-  safeWalletAddress,
-  walletClient,
+  relayerAuthorization,
 } from '../testing';
-import { authenticateWith, completeWith } from '../viem';
 
 const TEST_MARKET_SLUG = 'eth-flipped-in-2026';
 
@@ -15,9 +13,9 @@ const market = await publicClient.fetchMarket({
   slug: TEST_MARKET_SLUG,
 });
 
-const secureClient = await publicClientWithRelayerKey
-  .beginAuthentication({ wallet: safeWalletAddress })
-  .then(authenticateWith(walletClient));
+const secureClient = await createTestSecureClient({
+  apiKey: relayerAuthorization,
+});
 
 invariant(
   secureClient.account.walletType === WalletType.POLY_GNOSIS_SAFE,
@@ -27,11 +25,10 @@ invariant(
 describe('Positions', () => {
   it('splits a market position', async () => {
     await secureClient
-      .prepareSplitPosition({
+      .splitPosition({
         amount: 1_000_000n,
         conditionId: market.conditionId,
       })
-      .then(completeWith(walletClient))
       .then((handle) => handle.wait());
 
     await vi.waitFor(
@@ -61,11 +58,10 @@ describe('Positions', () => {
     }
 
     await secureClient
-      .prepareMergePositions({
+      .mergePositions({
         amount: 'max',
         conditionId: market.conditionId,
       })
-      .then(completeWith(walletClient))
       .then((handle) => handle.wait());
 
     await vi.waitFor(

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -116,15 +116,6 @@ export type PrepareRedeemPositionsRequest = z.input<
 
 export type PrepareSplitPositionError = UserInputError;
 export const PrepareSplitPositionError = makeErrorGuard(UserInputError);
-export type SplitPositionError =
-  | PrepareSplitPositionError
-  | CancelledSigningError
-  | SigningError;
-export const SplitPositionError = makeErrorGuard(
-  CancelledSigningError,
-  SigningError,
-  UserInputError,
-);
 export type PrepareMergePositionsError =
   | RateLimitError
   | RequestRejectedError
@@ -138,19 +129,6 @@ export const PrepareMergePositionsError = makeErrorGuard(
   UnexpectedResponseError,
   UserInputError,
 );
-export type MergePositionsError =
-  | PrepareMergePositionsError
-  | CancelledSigningError
-  | SigningError;
-export const MergePositionsError = makeErrorGuard(
-  CancelledSigningError,
-  RateLimitError,
-  RequestRejectedError,
-  SigningError,
-  TransportError,
-  UnexpectedResponseError,
-  UserInputError,
-);
 export type PrepareRedeemPositionsError =
   | RateLimitError
   | RequestRejectedError
@@ -160,19 +138,6 @@ export type PrepareRedeemPositionsError =
 export const PrepareRedeemPositionsError = makeErrorGuard(
   RateLimitError,
   RequestRejectedError,
-  TransportError,
-  UnexpectedResponseError,
-  UserInputError,
-);
-export type RedeemPositionsError =
-  | PrepareRedeemPositionsError
-  | CancelledSigningError
-  | SigningError;
-export const RedeemPositionsError = makeErrorGuard(
-  CancelledSigningError,
-  RateLimitError,
-  RequestRejectedError,
-  SigningError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
@@ -230,6 +195,16 @@ export async function prepareSplitPosition(
     });
   }.call(null);
 }
+
+export type SplitPositionError =
+  | PrepareSplitPositionError
+  | CancelledSigningError
+  | SigningError;
+export const SplitPositionError = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
 
 /**
  * Splits collateral into market positions.
@@ -312,6 +287,20 @@ export async function prepareMergePositions(
   }.call(null);
 }
 
+export type MergePositionsError =
+  | PrepareMergePositionsError
+  | CancelledSigningError
+  | SigningError;
+export const MergePositionsError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
 /**
  * Merges complementary market positions back into collateral.
  *
@@ -390,6 +379,20 @@ export async function prepareRedeemPositions(
     });
   }.call(null);
 }
+
+export type RedeemPositionsError =
+  | PrepareRedeemPositionsError
+  | CancelledSigningError
+  | SigningError;
+export const RedeemPositionsError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Redeems resolved market positions.

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -18,17 +18,23 @@ import {
 } from '../abis';
 import type { BaseSecureClient } from '../clients';
 import {
+  CancelledSigningError,
   makeErrorGuard,
   RateLimitError,
   RequestRejectedError,
+  SigningError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
 } from '../errors';
 import { parseUserInput } from '../input';
-import { expectTransactionHandle, type TransactionHandle } from '../types';
-import type { SignerTransactionRequest } from '../workflow';
 import {
+  expectTransactionHandle,
+  type SignerTransactionRequest,
+  type TransactionHandle,
+} from '../types';
+import {
+  completeWith,
   type SendMergePositionsTransactionRequest,
   type SendRedeemPositionsTransactionRequest,
   type SendSplitPositionTransactionRequest,
@@ -110,6 +116,15 @@ export type PrepareRedeemPositionsRequest = z.input<
 
 export type PrepareSplitPositionError = UserInputError;
 export const PrepareSplitPositionError = makeErrorGuard(UserInputError);
+export type SplitPositionError =
+  | PrepareSplitPositionError
+  | CancelledSigningError
+  | SigningError;
+export const SplitPositionError = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
 export type PrepareMergePositionsError =
   | RateLimitError
   | RequestRejectedError
@@ -119,6 +134,19 @@ export type PrepareMergePositionsError =
 export const PrepareMergePositionsError = makeErrorGuard(
   RateLimitError,
   RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+export type MergePositionsError =
+  | PrepareMergePositionsError
+  | CancelledSigningError
+  | SigningError;
+export const MergePositionsError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
@@ -136,21 +164,33 @@ export const PrepareRedeemPositionsError = makeErrorGuard(
   UnexpectedResponseError,
   UserInputError,
 );
+export type RedeemPositionsError =
+  | PrepareRedeemPositionsError
+  | CancelledSigningError
+  | SigningError;
+export const RedeemPositionsError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 
 /**
  * Starts a split workflow for a market condition.
  *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
  * @example
  * ```ts
- * const handle = await prepareSplitPosition(client, {
+ * const workflow = await prepareSplitPosition(client, {
  *   amount: 1n,
  *   conditionId:
  *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
- * }).then(completeWith(wallet));
- *
- * const outcome = await handle.wait();
- *
- * // outcome.transactionHash: TxHash
+ * });
  * ```
  *
  * @throws {@link PrepareSplitPositionError}
@@ -192,19 +232,33 @@ export async function prepareSplitPosition(
 }
 
 /**
+ * Splits collateral into market positions.
+ *
+ * @throws {@link SplitPositionError}
+ * Thrown on failure.
+ */
+export function splitPosition(
+  client: BaseSecureClient,
+  request: PrepareSplitPositionRequest,
+): Promise<TransactionHandle> {
+  return prepareSplitPosition(client, request).then(
+    completeWith(client.signer),
+  );
+}
+
+/**
  * Starts a workflow to merge complementary positions in a market back into collateral.
+ *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
  *
  * @example
  * ```ts
- * const handle = await prepareMergePositions(client, {
+ * const workflow = await prepareMergePositions(client, {
  *   amount: 'max',
  *   conditionId:
  *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
- * }).then(completeWith(wallet));
- *
- * const outcome = await handle.wait();
- *
- * // outcome.transactionHash: TxHash
+ * });
  * ```
  *
  * @throws {@link PrepareMergePositionsError}
@@ -259,18 +313,32 @@ export async function prepareMergePositions(
 }
 
 /**
+ * Merges complementary market positions back into collateral.
+ *
+ * @throws {@link MergePositionsError}
+ * Thrown on failure.
+ */
+export function mergePositions(
+  client: BaseSecureClient,
+  request: PrepareMergePositionsRequest,
+): Promise<TransactionHandle> {
+  return prepareMergePositions(client, request).then(
+    completeWith(client.signer),
+  );
+}
+
+/**
  * Starts a redemption workflow for resolved positions.
+ *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
  *
  * @example
  * ```ts
- * const handle = await prepareRedeemPositions(client, {
+ * const workflow = await prepareRedeemPositions(client, {
  *   conditionId:
  *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
- * }).then(completeWith(wallet));
- *
- * const outcome = await handle.wait();
- *
- * // outcome.transactionHash: TxHash
+ * });
  * ```
  *
  * @throws {@link PrepareRedeemPositionsError}
@@ -321,6 +389,21 @@ export async function prepareRedeemPositions(
         `Redeem positions for condition ${params.conditionId}`,
     });
   }.call(null);
+}
+
+/**
+ * Redeems resolved market positions.
+ *
+ * @throws {@link RedeemPositionsError}
+ * Thrown on failure.
+ */
+export function redeemPositions(
+  client: BaseSecureClient,
+  request: PrepareRedeemPositionsRequest,
+): Promise<TransactionHandle> {
+  return prepareRedeemPositions(client, request).then(
+    completeWith(client.signer),
+  );
 }
 
 function sendSplitPositionTransaction(

--- a/packages/client/src/actions/subscriptions.test.ts
+++ b/packages/client/src/actions/subscriptions.test.ts
@@ -1,12 +1,10 @@
 import { expectPresent } from '@polymarket/types';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
+  createTestSecureClient,
   findHighVolumeLowPriceMarket,
   publicClient,
-  safeWalletAddress,
-  walletClient,
 } from '../testing';
-import { authenticateWith } from '../viem';
 import { waitForNextEvent } from '../websockets/testing';
 
 type EventWithOptionalSymbol = {
@@ -68,9 +66,7 @@ describe('subscribe', () => {
   it('routes secure-only subscriptions when the client supports them', {
     timeout: 20_000,
   }, async () => {
-    const secureClient = await publicClient
-      .beginAuthentication({ wallet: safeWalletAddress })
-      .then(authenticateWith(walletClient));
+    const secureClient = await createTestSecureClient();
 
     try {
       const handle = await secureClient.subscribe([{ topic: 'user' }]);

--- a/packages/client/src/actions/transfers.test.ts
+++ b/packages/client/src/actions/transfers.test.ts
@@ -1,28 +1,21 @@
 import { WalletType } from '@polymarket/bindings/gamma';
 import { describe, expect, it } from 'vitest';
-import {
-  publicClientWithRelayerKey,
-  safeWalletAddress,
-  walletClient,
-} from '../testing';
-import { authenticateWith, completeWith } from '../viem';
+import { createTestSecureClient, relayerAuthorization } from '../testing';
 
 describe('Transfers', () => {
   describe('prepareErc20Transfer', () => {
     it('submits a self-transfer for the collateral token', async () => {
-      const secureClient = await publicClientWithRelayerKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        apiKey: relayerAuthorization,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      const handle = await secureClient
-        .prepareErc20Transfer({
-          amount: 1n,
-          recipientAddress: secureClient.account.signer,
-          tokenAddress: secureClient.environment.collateralToken,
-        })
-        .then(completeWith(walletClient));
+      const handle = await secureClient.transferErc20({
+        amount: 1n,
+        recipientAddress: secureClient.account.signer,
+        tokenAddress: secureClient.environment.collateralToken,
+      });
 
       await expect(handle.wait()).resolves.toBeTruthy();
     });

--- a/packages/client/src/actions/transfers.ts
+++ b/packages/client/src/actions/transfers.ts
@@ -50,15 +50,6 @@ export type PrepareErc20TransferRequest = z.input<
 
 export type PrepareErc20TransferError = UserInputError;
 export const PrepareErc20TransferError = makeErrorGuard(UserInputError);
-export type TransferErc20Error =
-  | PrepareErc20TransferError
-  | CancelledSigningError
-  | SigningError;
-export const TransferErc20Error = makeErrorGuard(
-  CancelledSigningError,
-  SigningError,
-  UserInputError,
-);
 
 /**
  * Starts an ERC-20 transfer workflow.
@@ -114,6 +105,16 @@ export async function prepareErc20Transfer(
     });
   }.call(null);
 }
+
+export type TransferErc20Error =
+  | PrepareErc20TransferError
+  | CancelledSigningError
+  | SigningError;
+export const TransferErc20Error = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
 
 /**
  * Transfers ERC-20 tokens from the authenticated account.

--- a/packages/client/src/actions/transfers.ts
+++ b/packages/client/src/actions/transfers.ts
@@ -4,11 +4,20 @@ import type { EvmSignature } from '@polymarket/types';
 import { z } from 'zod';
 import { erc20TransferCall } from '../abis';
 import type { BaseSecureClient } from '../clients';
-import { makeErrorGuard, UserInputError } from '../errors';
-import { parseUserInput } from '../input';
-import { expectTransactionHandle, type TransactionHandle } from '../types';
-import type { SignerTransactionRequest } from '../workflow';
 import {
+  CancelledSigningError,
+  makeErrorGuard,
+  SigningError,
+  UserInputError,
+} from '../errors';
+import { parseUserInput } from '../input';
+import {
+  expectTransactionHandle,
+  type SignerTransactionRequest,
+  type TransactionHandle,
+} from '../types';
+import {
+  completeWith,
   type SendErc20TransferTransactionRequest,
   signerTransactionRequest,
 } from '../workflow';
@@ -41,21 +50,29 @@ export type PrepareErc20TransferRequest = z.input<
 
 export type PrepareErc20TransferError = UserInputError;
 export const PrepareErc20TransferError = makeErrorGuard(UserInputError);
+export type TransferErc20Error =
+  | PrepareErc20TransferError
+  | CancelledSigningError
+  | SigningError;
+export const TransferErc20Error = makeErrorGuard(
+  CancelledSigningError,
+  SigningError,
+  UserInputError,
+);
 
 /**
  * Starts an ERC-20 transfer workflow.
  *
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
  * @example
  * ```ts
- * const handle = await prepareErc20Transfer(client, {
+ * const workflow = await prepareErc20Transfer(client, {
  *   amount: 1n,
  *   recipientAddress: client.account.signer,
  *   tokenAddress: client.environment.collateralToken,
- * }).then(completeWith(wallet));
- *
- * const outcome = await handle.wait();
- *
- * // outcome.transactionHash: TxHash
+ * });
  * ```
  *
  * @throws {@link PrepareErc20TransferError}
@@ -96,6 +113,21 @@ export async function prepareErc20Transfer(
         `Transfer ${params.amount} of ${params.tokenAddress} to ${params.recipientAddress}`,
     });
   }.call(null);
+}
+
+/**
+ * Transfers ERC-20 tokens from the authenticated account.
+ *
+ * @throws {@link TransferErc20Error}
+ * Thrown on failure.
+ */
+export function transferErc20(
+  client: BaseSecureClient,
+  request: PrepareErc20TransferRequest,
+): Promise<TransactionHandle> {
+  return prepareErc20Transfer(client, request).then(
+    completeWith(client.signer),
+  );
 }
 
 function sendErc20TransferTransaction(

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -2,43 +2,35 @@ import { WalletType } from '@polymarket/bindings/gamma';
 import { expectEvmAddress, InvariantError } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import { fetchApiKeys } from './actions';
+import { createSecureClient } from './clients';
 import {
   createRandomWalletClient,
+  createTestSecureClient,
   deriveProxyAddress,
-  publicClient,
-  safeWalletAddress,
   walletClient,
 } from './testing';
-import { authenticateWith } from './viem';
+import { signerFrom } from './viem';
 
 describe('clients', () => {
-  describe('PublicClient.beginAuthentication', () => {
+  describe('createSecureClient', () => {
     it('authenticates a secure client from an authentication workflow', async () => {
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient();
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
     it('authenticates with a non-zero nonce', async () => {
-      const secureClient = await publicClient
-        .beginAuthentication({ nonce: 1, wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({ nonce: 1 });
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
     it('authenticates twice with the same nonce', async () => {
-      const firstClient = await publicClient
-        .beginAuthentication({ nonce: 2, wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const firstClient = await createTestSecureClient({ nonce: 2 });
 
       await expect(fetchApiKeys(firstClient)).resolves.toBeDefined();
 
-      const secondClient = await publicClient
-        .beginAuthentication({ nonce: 2, wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secondClient = await createTestSecureClient({ nonce: 2 });
 
       await expect(fetchApiKeys(secondClient)).resolves.toBeDefined();
     });
@@ -47,9 +39,9 @@ describe('clients', () => {
       const signerAddress = expectEvmAddress(walletClient.account.address);
       const proxyWallet = deriveProxyAddress(signerAddress);
 
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: proxyWallet })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        wallet: proxyWallet,
+      });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_PROXY);
       expect(secureClient.account.wallet).toBe(proxyWallet);
@@ -60,9 +52,9 @@ describe('clients', () => {
 
     it('authenticates as EOA when wallet equals signer address', async () => {
       const signerAddress = walletClient.account.address;
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: signerAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({
+        wallet: signerAddress,
+      });
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
@@ -71,42 +63,33 @@ describe('clients', () => {
       const unrelatedWallet = createRandomWalletClient();
 
       await expect(
-        publicClient
-          .beginAuthentication({ wallet: unrelatedWallet.account.address })
-          .then(authenticateWith(walletClient)),
+        createSecureClient({
+          wallet: unrelatedWallet.account.address,
+          signer: signerFrom(walletClient),
+        }),
       ).rejects.toBeInstanceOf(InvariantError);
     });
 
     it('reuses stored credentials during authentication when they remain valid', async () => {
-      const initialClient = await publicClient
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
-      const snapshot = initialClient.getSessionSnapshot();
+      const initialClient = await createTestSecureClient();
+      const { credentials } = initialClient;
 
-      const secureClient = await publicClient
-        .beginAuthentication(snapshot)
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({ credentials });
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
-    it('falls back to fresh authentication when a stored session snapshot has been revoked', async () => {
-      const controlClient = await publicClient
-        .beginAuthentication({ nonce: 1997, wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
-      const secureClient = await publicClient
-        .beginAuthentication({ nonce: 1998, wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
-      const snapshot = secureClient.getSessionSnapshot();
-      const revokedKey = snapshot.credentials.key;
+    it('falls back to fresh authentication when stored credentials have been revoked', async () => {
+      const controlClient = await createTestSecureClient({ nonce: 1997 });
+      const secureClient = await createTestSecureClient({ nonce: 1998 });
+      const { credentials } = secureClient;
+      const revokedKey = credentials.key;
 
       await expect(fetchApiKeys(controlClient)).resolves.toContain(revokedKey);
 
       await secureClient.endAuthentication();
 
-      const resumedClient = await publicClient
-        .beginAuthentication(snapshot)
-        .then(authenticateWith(walletClient));
+      const resumedClient = await createTestSecureClient({ credentials });
       const remainingApiKeys = await fetchApiKeys(controlClient);
 
       expect(resumedClient.credentials.key).not.toBe(revokedKey);
@@ -118,12 +101,8 @@ describe('clients', () => {
 
   describe('SecureClient.endAuthentication', () => {
     it('returns a public client and invalidates the secure client', async () => {
-      const controlClient = await publicClient
-        .beginAuthentication({ nonce: 997, wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
-      const secureClient = await publicClient
-        .beginAuthentication({ nonce: 998, wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const controlClient = await createTestSecureClient({ nonce: 997 });
+      const secureClient = await createTestSecureClient({ nonce: 998 });
       const revokedKey = secureClient.credentials.key;
       const signer = secureClient.account.signer;
 
@@ -143,9 +122,7 @@ describe('clients', () => {
     });
 
     it('closes active subscription iterators before ending authentication', async () => {
-      const secureClient = await publicClient
-        .beginAuthentication({ nonce: 999, wallet: safeWalletAddress })
-        .then(authenticateWith(walletClient));
+      const secureClient = await createTestSecureClient({ nonce: 999 });
       const handle = await secureClient.subscribe([{ topic: 'user' }]);
 
       await secureClient.endAuthentication();

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -754,6 +754,23 @@ export type CreateSecureClientOptions = PublicClientOptions & {
       }
   );
 
+/**
+ * Creates a new `PublicClient` instance.
+ *
+ * @example
+ * ```ts
+ * const client = createPublicClient();
+ * ```
+ */
+export function createPublicClient(
+  options: PublicClientOptions = {},
+): PublicClient<PublicActions, SecureActions> {
+  return new BasePublicClient({
+    environment: options.environment ?? production,
+    apiKey: options.apiKey,
+  }).extend(allActions);
+}
+
 export type CreateSecureClientError =
   | CancelledSigningError
   | RateLimitError
@@ -771,23 +788,6 @@ export const CreateSecureClientError = makeErrorGuard(
   UnexpectedResponseError,
   UserInputError,
 );
-
-/**
- * Creates a new `PublicClient` instance.
- *
- * @example
- * ```ts
- * const client = createPublicClient();
- * ```
- */
-export function createPublicClient(
-  options: PublicClientOptions = {},
-): PublicClient<PublicActions, SecureActions> {
-  return new BasePublicClient({
-    environment: options.environment ?? production,
-    apiKey: options.apiKey,
-  }).extend(allActions);
-}
 
 /**
  * Creates a new authenticated `SecureClient` instance.

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -21,12 +21,21 @@ import {
   type SecureActions,
 } from './decorators';
 import { type EnvironmentConfig, production } from './environments';
-import { RequestRejectedError, SigningError } from './errors';
+import {
+  CancelledSigningError,
+  makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+} from './errors';
 import { buildHmacSignature } from './hmac';
 import { parseUserInput } from './input';
 import type { ServiceRequest } from './ServiceClient';
 import { ServiceClient } from './ServiceClient';
-import type { ApiKeyAuthorization } from './types';
+import type { ApiKeyAuthorization, Signer } from './types';
 import {
   ClobMarketWebSocketManager,
   ClobUserWebSocketManager,
@@ -35,7 +44,11 @@ import {
   type SecureWebSocketManagers,
   SportsWebSocketManager,
 } from './websockets';
-import { type AuthenticationWorkflow, requestAddress } from './workflow';
+import {
+  type AuthenticationWorkflow,
+  authenticateWith,
+  requestAddress,
+} from './workflow';
 
 type PublicContext = {
   /** @internal */
@@ -164,26 +177,7 @@ const BeginAuthenticationCredentialsSchema = z.object({
   secret: z.string(),
 });
 
-/**
- * Persistable authenticated session state that can later be passed to
- * {@link PublicClient.beginAuthentication}.
- */
-export type SessionSnapshot = {
-  /**
-   * Wallet address to authenticate as.
-   *
-   * Pass the signer address itself to authenticate as an EOA account.
-   */
-  wallet: string;
-
-  /**
-   * Existing API credentials to reuse when they remain valid.
-   */
-  credentials: ApiKeyCreds;
-  nonce?: never;
-};
-
-export type FreshAuthenticationRequest = {
+export type BeginAuthenticationRequest = {
   /**
    * Wallet address to authenticate as.
    *
@@ -194,15 +188,20 @@ export type FreshAuthenticationRequest = {
   /**
    * Nonce used when creating or deriving fresh credentials.
    *
+   * Mutually exclusive with `credentials`.
+   *
    * @defaultValue 0
    */
   nonce?: number;
-  credentials?: never;
-};
 
-export type BeginAuthenticationRequest =
-  | SessionSnapshot
-  | FreshAuthenticationRequest;
+  /**
+   * Existing API credentials to reuse when they remain valid.
+   *
+   * If these credentials are revoked or invalid, authentication falls back to
+   * fresh authentication and the signer may be asked to sign again.
+   */
+  credentials?: ApiKeyCreds;
+};
 
 const BeginAuthenticationRequestSchema: z.ZodType<BeginAuthenticationRequest> =
   z
@@ -295,7 +294,7 @@ class BasePublicClient<
    * @example
    * ```ts
    * if (client.isPublicClient()) {
-   *   client.beginAuthentication(...); // PublicClient
+   *   client.closeSubscriptions(); // PublicClient
    * }
    * ```
    */
@@ -344,12 +343,14 @@ class BasePublicClient<
    * Begins an authentication workflow that produces a {@link SecureClient}.
    *
    * @remarks
-   * Pass a {@link SessionSnapshot} to reuse stored credentials when they remain
-   * valid. If the stored credential is no longer valid, the workflow falls back
-   * to fresh authentication.
+   * This is a low-level method for building wallet-interactive workflows. Most
+   * applications should use {@link createSecureClient} instead.
+   *
+   * @internal
    */
   beginAuthentication(
     request: BeginAuthenticationRequest,
+    signer?: Signer,
   ): Promise<
     AuthenticationWorkflow<SecureClient<TPublicActions, TSecureActions>>
   > {
@@ -361,16 +362,20 @@ class BasePublicClient<
       ): AuthenticationWorkflow<SecureClient<TPublicActions, TSecureActions>> {
         const timestamp = Math.floor(Date.now() / 1000);
         const nonce = params?.nonce ?? 0;
-        const signer = expectEvmAddress(yield requestAddress());
+        const signerAddress = expectEvmAddress(yield requestAddress());
         const wallet = expectEvmAddress(params.wallet);
         const identity = resolveAccountIdentity(
           this.environment,
-          signer,
+          signerAddress,
           wallet,
         );
 
         if (params.credentials !== undefined) {
-          const client = this.#createSecureClient(params.credentials, identity);
+          const client = this.#createSecureClient(
+            params.credentials,
+            identity,
+            signer,
+          );
 
           try {
             const apiKeys = await fetchApiKeys(client);
@@ -390,20 +395,20 @@ class BasePublicClient<
         const signature = yield {
           kind: 'signAuthMessage',
           payload: createApiKeyAuthTypedDataPayload({
-            address: signer,
+            address: signerAddress,
             chainId: this.environment.chainId,
             nonce,
             timestamp,
           }),
         };
         const credentials = await createOrDeriveApiKey(this, {
-          address: signer,
+          address: signerAddress,
           nonce,
           signature: expectEvmSignature(signature),
           timestamp,
         });
 
-        return this.#createSecureClient(credentials, identity);
+        return this.#createSecureClient(credentials, identity, signer);
       }.call(this as unknown as PublicClient<TPublicActions, TSecureActions>),
     );
   }
@@ -411,12 +416,14 @@ class BasePublicClient<
   #createSecureClient(
     credentials: ApiKeyCreds,
     account: AccountIdentity,
+    signer?: Signer,
   ): SecureClient<TPublicActions, TSecureActions> {
     const client = new BaseSecureClient({
       account: account,
       apiKey: this.context.apiKey,
       credentials,
       environment: this.environment,
+      signer,
     });
 
     for (const decorator of this.decorators) {
@@ -456,6 +463,7 @@ class BaseSecureClient<
       credentials: config.credentials,
       apiKey: config.apiKey,
       environment: config.environment,
+      signer: config.signer,
       clob: new ServiceClient({
         root: config.environment.clob,
         resolveHeaders: (request) => this.resolveClobHeaders(request),
@@ -489,7 +497,14 @@ class BaseSecureClient<
     });
   }
 
-  /** @internal */
+  /**
+   * API credentials for the authenticated session.
+   *
+   * @remarks
+   * These credentials are sensitive. Store them securely if you want to create
+   * another secure client later without requiring a new authentication signature
+   * while the credentials remain valid.
+   */
   get credentials(): ApiKeyCreds {
     return this.context.credentials;
   }
@@ -499,6 +514,16 @@ class BaseSecureClient<
    */
   get account(): AccountIdentity {
     return this.context.account;
+  }
+
+  /** @internal */
+  get signer(): Signer {
+    invariant(
+      this.context.signer !== undefined,
+      'Secure client does not have a signer. Create secure clients with createSecureClient to use wallet-interactive methods.',
+    );
+
+    return this.context.signer;
   }
 
   /** @internal */
@@ -553,7 +578,7 @@ class BaseSecureClient<
    * @example
    * ```ts
    * if (client.isPublicClient()) {
-   *   client.beginAuthentication(...); // PublicClient
+   *   client.closeSubscriptions(); // PublicClient
    * }
    * ```
    */
@@ -577,28 +602,6 @@ class BaseSecureClient<
       TPublicActions,
       Prettify<TSecureActions & DecoratorSecureActions<TDecorator>>
     >;
-  }
-
-  /**
-   * Returns a persistable snapshot of the current authenticated session.
-   *
-   * @remarks
-   * Pass the returned snapshot to {@link PublicClient.beginAuthentication} to
-   * reuse the current session in a later authentication attempt. Capture the
-   * snapshot before calling {@link endAuthentication}; ending authentication
-   * revokes the current credential, so reusing an older snapshot will fall back
-   * to fresh authentication.
-   *
-   * @example
-   * ```ts
-   * const snapshot = secureClient.getSessionSnapshot();
-   * ```
-   */
-  getSessionSnapshot(): SessionSnapshot {
-    return {
-      wallet: this.account.wallet,
-      credentials: this.credentials,
-    };
   }
 
   /**
@@ -667,6 +670,8 @@ type SecureContext = PublicContext & {
   /** @internal */
   credentials: ApiKeyCreds;
   /** @internal */
+  signer?: Signer;
+  /** @internal */
   secureClob: ServiceClient;
   /** @internal */
   webSockets: SecureWebSocketManagers;
@@ -675,6 +680,7 @@ type SecureContext = PublicContext & {
 type SecureClientConfig = PublicClientConfig & {
   account: AccountIdentity;
   credentials: ApiKeyCreds;
+  signer?: Signer;
 };
 
 export type PublicClient<
@@ -717,6 +723,55 @@ export type PublicClientOptions = {
   apiKey?: ApiKeyAuthorization;
 };
 
+export type CreateSecureClientOptions = PublicClientOptions & {
+  /**
+   * Wallet address to authenticate as.
+   *
+   * Pass the signer address itself to authenticate as an EOA account.
+   */
+  wallet: string;
+
+  /**
+   * Wallet-library adapter used to authenticate and complete wallet operations.
+   */
+  signer: Signer;
+} & (
+    | {
+        /**
+         * Existing API credentials to reuse when they remain valid.
+         */
+        credentials?: ApiKeyCreds;
+        nonce?: never;
+      }
+    | {
+        credentials?: never;
+        /**
+         * Nonce used when creating or deriving fresh credentials.
+         *
+         * @defaultValue 0
+         */
+        nonce?: number;
+      }
+  );
+
+export type CreateSecureClientError =
+  | CancelledSigningError
+  | RateLimitError
+  | RequestRejectedError
+  | SigningError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const CreateSecureClientError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
 /**
  * Creates a new `PublicClient` instance.
  *
@@ -732,4 +787,38 @@ export function createPublicClient(
     environment: options.environment ?? production,
     apiKey: options.apiKey,
   }).extend(allActions);
+}
+
+/**
+ * Creates a new authenticated `SecureClient` instance.
+ *
+ * @example
+ * ```ts
+ * const secureClient = await createSecureClient({
+ *   signer,
+ *   wallet,
+ * });
+ * ```
+ *
+ * @throws {@link CreateSecureClientError}
+ * Thrown on failure.
+ */
+export async function createSecureClient(
+  options: CreateSecureClientOptions,
+): Promise<SecureClient<PublicActions, SecureActions>> {
+  const client = createPublicClient({
+    environment: options.environment,
+    apiKey: options.apiKey,
+  });
+
+  return client
+    .beginAuthentication(
+      {
+        wallet: options.wallet,
+        credentials: options.credentials,
+        nonce: options.nonce,
+      },
+      options.signer,
+    )
+    .then(authenticateWith(options.signer));
 }

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -723,7 +723,7 @@ export type PublicClientOptions = {
   apiKey?: ApiKeyAuthorization;
 };
 
-export type CreateSecureClientOptions = PublicClientOptions & {
+export type SecureClientOptions = PublicClientOptions & {
   /**
    * Wallet address to authenticate as.
    *
@@ -804,7 +804,7 @@ export const CreateSecureClientError = makeErrorGuard(
  * Thrown on failure.
  */
 export async function createSecureClient(
-  options: CreateSecureClientOptions,
+  options: SecureClientOptions,
 ): Promise<SecureClient<PublicActions, SecureActions>> {
   const client = createPublicClient({
     environment: options.environment,

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -4,7 +4,6 @@ import type {
   OrderResponse,
   OrderResponses,
 } from '@polymarket/bindings/clob';
-import type { OrderWorkflow } from '../actions';
 import {
   type CancelMarketOrdersRequest,
   type CancelOrderRequest,
@@ -13,20 +12,19 @@ import {
   cancelMarketOrders,
   cancelOrder,
   cancelOrders,
+  createLimitOrder,
+  createMarketOrder,
   type FetchOrderRequest,
   fetchOrder,
   type ListOpenOrdersRequest,
   listOpenOrders,
-  type OrderPostingWorkflow,
   type PostOrdersRequest,
   type PrepareLimitOrderRequest,
   type PrepareMarketOrderRequest,
+  placeLimitOrder,
+  placeMarketOrder,
   postOrder,
   postOrders,
-  prepareLimitOrder,
-  prepareLimitOrderPosting,
-  prepareMarketOrder,
-  prepareMarketOrderPosting,
 } from '../actions';
 import type { SignedOrder } from '../actions/orders';
 import type { BaseSecureClient } from '../clients';
@@ -34,91 +32,77 @@ import type { Paginated } from '../pagination';
 
 export type TradingActions = {
   /**
-   * Starts the market-order workflow.
+   * Creates a signed market order for the authenticated account.
    *
-   * @throws {@link PrepareMarketOrderError}
+   * @throws {@link CreateMarketOrderError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const order = await client.prepareMarketOrder({
+   * const order = await client.createMarketOrder({
    *   amount: 10,
    *   side: OrderSide.BUY,
    *   tokenId: '123',
-   * }).then(completeWith(wallet));
+   * });
+   * ```
+   */
+  createMarketOrder(request: PrepareMarketOrderRequest): Promise<SignedOrder>;
+  /**
+   * Creates and posts a market order for the authenticated account.
    *
-   * const response = await client.postOrder(order);
+   * @throws {@link PlaceMarketOrderError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const response = await client.placeMarketOrder({
+   *   amount: 10,
+   *   side: OrderSide.BUY,
+   *   tokenId: '123',
+   * });
    *
    * // response: OrderResponse
    * ```
    */
-  prepareMarketOrder(
-    request: PrepareMarketOrderRequest,
-  ): Promise<OrderWorkflow>;
+  placeMarketOrder(request: PrepareMarketOrderRequest): Promise<OrderResponse>;
   /**
-   * Starts and posts a market-order workflow.
+   * Creates a signed limit order for the authenticated account.
    *
-   * @throws {@link PrepareMarketOrderPostingError}
+   * @throws {@link CreateLimitOrderError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const response = await client.prepareMarketOrderPosting({
-   *   amount: 10,
-   *   side: OrderSide.BUY,
-   *   tokenId: '123',
-   * }).then(completeWith(wallet));
-   *
-   * // response: OrderResponse
-   * ```
-   */
-  prepareMarketOrderPosting(
-    request: PrepareMarketOrderRequest,
-  ): Promise<OrderPostingWorkflow>;
-  /**
-   * Starts the limit-order workflow.
-   *
-   * @throws {@link PrepareLimitOrderError}
-   * Thrown on failure.
-   *
-   * @example
-   * ```ts
-   * const order = await client.prepareLimitOrder({
+   * const order = await client.createLimitOrder({
    *   postOnly: true,
    *   price: 0.52,
    *   side: OrderSide.BUY,
    *   size: 10,
    *   tokenId: '123',
-   * }).then(completeWith(wallet));
-   *
-   * const response = await client.postOrder(order);
-   *
-   * // response: OrderResponse
+   * });
    * ```
    */
-  prepareLimitOrder(request: PrepareLimitOrderRequest): Promise<OrderWorkflow>;
+  createLimitOrder(request: PrepareLimitOrderRequest): Promise<SignedOrder>;
   /**
-   * Starts and posts a limit-order workflow.
+   * Creates and posts a limit order for the authenticated account.
    *
-   * @throws {@link PrepareLimitOrderPostingError}
+   * @throws {@link PlaceLimitOrderError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const response = await client.prepareLimitOrderPosting({
+   * const response = await client.placeLimitOrder({
    *   postOnly: true,
    *   price: 0.52,
    *   side: OrderSide.BUY,
    *   size: 10,
    *   tokenId: '123',
-   * }).then(completeWith(wallet));
+   * });
    *
    * // response: OrderResponse
    * ```
    */
-  prepareLimitOrderPosting(
-    request: PrepareLimitOrderRequest,
-  ): Promise<OrderPostingWorkflow>;
+  placeLimitOrder(request: PrepareLimitOrderRequest): Promise<OrderResponse>;
   /**
    * Posts a signed order for the authenticated account.
    *
@@ -257,10 +241,10 @@ export type TradingActions = {
 export function tradingActions(client: BaseSecureClient): TradingActions;
 export function tradingActions(client: BaseSecureClient): TradingActions {
   return {
-    prepareMarketOrder: prepareMarketOrder.bind(null, client),
-    prepareMarketOrderPosting: prepareMarketOrderPosting.bind(null, client),
-    prepareLimitOrder: prepareLimitOrder.bind(null, client),
-    prepareLimitOrderPosting: prepareLimitOrderPosting.bind(null, client),
+    createMarketOrder: createMarketOrder.bind(null, client),
+    placeMarketOrder: placeMarketOrder.bind(null, client),
+    createLimitOrder: createLimitOrder.bind(null, client),
+    placeLimitOrder: placeLimitOrder.bind(null, client),
     postOrder: postOrder(client),
     postOrders: postOrders(client),
     cancelOrder: cancelOrder.bind(null, client),
@@ -280,12 +264,12 @@ export {
   CancelMarketOrdersError,
   CancelOrderError,
   CancelOrdersError,
+  CreateLimitOrderError,
+  CreateMarketOrderError,
   FetchOrderError,
   ListOpenOrdersError,
+  PlaceLimitOrderError,
+  PlaceMarketOrderError,
   PostOrderError,
   PostOrdersError,
-  PrepareLimitOrderError,
-  PrepareLimitOrderPostingError,
-  PrepareMarketOrderError,
-  PrepareMarketOrderPostingError,
 } from '../actions';

--- a/packages/client/src/decorators/wallet.ts
+++ b/packages/client/src/decorators/wallet.ts
@@ -1,35 +1,28 @@
 import type { Prettify } from '@polymarket/types';
 import {
-  type Erc20ApprovalWorkflow,
-  type Erc20TransferWorkflow,
-  type Erc1155ApprovalForAllWorkflow,
-  type GaslessWalletWorkflow,
+  approveErc20,
+  approveErc1155ForAll,
   type IsGaslessReadyRequest,
   isGaslessReady,
-  type MergePositionsWorkflow,
+  mergePositions,
   type PrepareErc20ApprovalRequest,
   type PrepareErc20TransferRequest,
   type PrepareErc1155ApprovalForAllRequest,
   type PrepareMergePositionsRequest,
   type PrepareRedeemPositionsRequest,
   type PrepareSplitPositionRequest,
-  prepareErc20Approval,
-  prepareErc20Transfer,
-  prepareErc1155ApprovalForAll,
-  prepareGaslessWallet,
-  prepareMergePositions,
-  prepareRedeemPositions,
-  prepareSplitPosition,
-  prepareTradingApprovals,
-  type RedeemPositionsWorkflow,
-  type SplitPositionWorkflow,
-  type TradingApprovalsWorkflow,
+  redeemPositions,
+  setupGaslessWallet,
+  setupTradingApprovals,
+  splitPosition,
+  transferErc20,
 } from '../actions';
 import type {
   BaseClient,
   BasePublicClient,
   BaseSecureClient,
 } from '../clients';
+import type { DeployTransactionHandle, TransactionHandle } from '../types';
 
 export type PublicWalletActions = {
   /**
@@ -46,179 +39,169 @@ export type PublicWalletActions = {
    * ```
    */
   isGaslessReady(request: IsGaslessReadyRequest): Promise<boolean>;
-  /**
-   * Starts preparing the wallet for gasless transactions.
-   *
-   * @throws {@link PrepareGaslessWalletError}
-   * Thrown on failure.
-   *
-   * @example
-   * ```ts
-   * const handle = await client.prepareGaslessWallet().then(completeWith(wallet));
-   *
-   * const outcome = await handle.wait();
-   *
-   * // outcome.transactionHash: TxHash
-   * ```
-   */
-  prepareGaslessWallet(): Promise<GaslessWalletWorkflow>;
 };
 
 export type SecureWalletActions = Prettify<
   PublicWalletActions & {
     /**
-     * Starts a trading-setup approval workflow.
+     * Sets up the approvals required for trading.
      *
-     * @throws {@link PrepareTradingApprovalsError}
+     * @throws {@link SetupTradingApprovalsError}
      * Thrown on failure.
      *
      * @example
      * ```ts
-     * const handle = await client.prepareTradingApprovals().then(completeWith(wallet));
+     * const handle = await client.setupTradingApprovals();
      *
      * const outcome = await handle.wait();
      *
      * // outcome.transactionHash: TxHash
      * ```
      */
-    prepareTradingApprovals(): Promise<TradingApprovalsWorkflow>;
+    setupTradingApprovals(): Promise<TransactionHandle>;
     /**
-     * Starts an ERC-20 approval workflow.
+     * Approves ERC-20 token spending for the authenticated account.
      *
-     * @throws {@link PrepareErc20ApprovalError}
+     * @throws {@link ApproveErc20Error}
      * Thrown on failure.
      *
      * @example
      * ```ts
-     * const handle = await client.prepareErc20Approval({
+     * const handle = await client.approveErc20({
      *   amount: 'max',
      *   spenderAddress: '0x1234…',
      *   tokenAddress: '0x5678…',
-     * }).then(completeWith(wallet));
+     * });
      *
      * const outcome = await handle.wait();
      *
      * // outcome.transactionHash: TxHash
      * ```
      */
-    prepareErc20Approval(
+    approveErc20(
       request: PrepareErc20ApprovalRequest,
-    ): Promise<Erc20ApprovalWorkflow>;
+    ): Promise<TransactionHandle>;
     /**
-     * Starts an ERC-1155 approval-for-all workflow.
+     * Approves or revokes ERC-1155 operator access for the authenticated account.
      *
-     * @throws {@link PrepareErc1155ApprovalForAllError}
+     * @throws {@link ApproveErc1155ForAllError}
      * Thrown on failure.
      *
      * @example
      * ```ts
-     * const handle = await client.prepareErc1155ApprovalForAll({
+     * const handle = await client.approveErc1155ForAll({
      *   operatorAddress: '0x1234…',
      *   tokenAddress: '0x5678…',
-     * }).then(completeWith(wallet));
+     * });
      *
      * const outcome = await handle.wait();
      *
      * // outcome.transactionHash: TxHash
      * ```
      */
-    prepareErc1155ApprovalForAll(
+    approveErc1155ForAll(
       request: PrepareErc1155ApprovalForAllRequest,
-    ): Promise<Erc1155ApprovalForAllWorkflow>;
+    ): Promise<TransactionHandle>;
     /**
-     * Starts an ERC-20 transfer workflow.
+     * Transfers ERC-20 tokens from the authenticated account.
      *
-     * @throws {@link PrepareErc20TransferError}
+     * @throws {@link TransferErc20Error}
      * Thrown on failure.
      *
      * @example
      * ```ts
-     * const handle = await client.prepareErc20Transfer({
+     * const handle = await client.transferErc20({
      *   amount: 1n,
      *   recipientAddress: client.account.signer,
      *   tokenAddress: client.environment.collateralToken,
-     * }).then(completeWith(wallet));
+     * });
      *
      * const outcome = await handle.wait();
      *
      * // outcome.transactionHash: TxHash
      * ```
      */
-    prepareErc20Transfer(
+    transferErc20(
       request: PrepareErc20TransferRequest,
-    ): Promise<Erc20TransferWorkflow>;
+    ): Promise<TransactionHandle>;
     /**
-     * Starts a split workflow for a market condition.
+     * Splits collateral into market positions.
      *
-     * @throws {@link PrepareSplitPositionError}
+     * @throws {@link SplitPositionError}
      * Thrown on failure.
      *
      * @example
      * ```ts
-     * const handle = await client.prepareSplitPosition({
+     * const handle = await client.splitPosition({
      *   amount: 1n,
      *   conditionId:
      *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-     * }).then(completeWith(wallet));
+     * });
      *
      * const outcome = await handle.wait();
      *
      * // outcome.transactionHash: TxHash
      * ```
      */
-    prepareSplitPosition(
+    splitPosition(
       request: PrepareSplitPositionRequest,
-    ): Promise<SplitPositionWorkflow>;
+    ): Promise<TransactionHandle>;
     /**
-     * Starts a workflow to merge complementary positions in a market back into collateral.
+     * Merges complementary market positions back into collateral.
      *
-     * @throws {@link PrepareMergePositionsError}
+     * @throws {@link MergePositionsError}
      * Thrown on failure.
      *
      * @example
      * ```ts
-     * const handle = await client.prepareMergePositions({
+     * const handle = await client.mergePositions({
      *   amount: 'max',
      *   conditionId:
      *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-     * }).then(completeWith(wallet));
+     * });
      *
      * const outcome = await handle.wait();
      *
      * // outcome.transactionHash: TxHash
      * ```
      */
-    prepareMergePositions(
+    mergePositions(
       request: PrepareMergePositionsRequest,
-    ): Promise<MergePositionsWorkflow>;
+    ): Promise<TransactionHandle>;
     /**
-     * Starts a redemption workflow for resolved positions.
+     * Redeems resolved market positions.
      *
-     * @throws {@link PrepareRedeemPositionsError}
+     * @throws {@link RedeemPositionsError}
      * Thrown on failure.
      *
      * @example
      * ```ts
-     * const handle = await client.prepareRedeemPositions({
+     * const handle = await client.redeemPositions({
      *   conditionId:
      *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-     * }).then(completeWith(wallet));
+     * });
      *
      * const outcome = await handle.wait();
      *
      * // outcome.transactionHash: TxHash
      * ```
      */
-    prepareRedeemPositions(
+    redeemPositions(
       request: PrepareRedeemPositionsRequest,
-    ): Promise<RedeemPositionsWorkflow>;
+    ): Promise<TransactionHandle>;
+    /**
+     * Sets up a wallet for gasless transactions.
+     *
+     * @throws {@link SetupGaslessWalletError}
+     * Thrown on failure.
+     */
+    setupGaslessWallet(): Promise<DeployTransactionHandle>;
   }
 >;
 
 function publicWalletActions(client: BaseClient): PublicWalletActions {
   return {
     isGaslessReady: isGaslessReady.bind(null, client),
-    prepareGaslessWallet: prepareGaslessWallet.bind(null, client),
   };
 }
 
@@ -235,16 +218,14 @@ export function walletActions(
 
   return {
     ...actions,
-    prepareTradingApprovals: prepareTradingApprovals.bind(null, client),
-    prepareErc20Approval: prepareErc20Approval.bind(null, client),
-    prepareErc1155ApprovalForAll: prepareErc1155ApprovalForAll.bind(
-      null,
-      client,
-    ),
-    prepareErc20Transfer: prepareErc20Transfer.bind(null, client),
-    prepareSplitPosition: prepareSplitPosition.bind(null, client),
-    prepareMergePositions: prepareMergePositions.bind(null, client),
-    prepareRedeemPositions: prepareRedeemPositions.bind(null, client),
+    setupTradingApprovals: setupTradingApprovals.bind(null, client),
+    approveErc20: approveErc20.bind(null, client),
+    approveErc1155ForAll: approveErc1155ForAll.bind(null, client),
+    transferErc20: transferErc20.bind(null, client),
+    splitPosition: splitPosition.bind(null, client),
+    mergePositions: mergePositions.bind(null, client),
+    redeemPositions: redeemPositions.bind(null, client),
+    setupGaslessWallet: setupGaslessWallet.bind(null, client),
   };
 }
 
@@ -252,13 +233,13 @@ export function walletActions(
 // Surfaced at the root entry point through `export * from './decorators'`.
 // Keep this list in sync with the methods on PublicWalletActions / SecureWalletActions.
 export {
+  ApproveErc20Error,
+  ApproveErc1155ForAllError,
   IsGaslessReadyError,
-  PrepareErc20ApprovalError,
-  PrepareErc20TransferError,
-  PrepareErc1155ApprovalForAllError,
-  PrepareGaslessWalletError,
-  PrepareMergePositionsError,
-  PrepareRedeemPositionsError,
-  PrepareSplitPositionError,
-  PrepareTradingApprovalsError,
+  MergePositionsError,
+  RedeemPositionsError,
+  SetupGaslessWalletError,
+  SetupTradingApprovalsError,
+  SplitPositionError,
+  TransferErc20Error,
 } from '../actions';

--- a/packages/client/src/ethers-v5.test.ts
+++ b/packages/client/src/ethers-v5.test.ts
@@ -4,13 +4,9 @@ import { expectPresent } from '@polymarket/types';
 import { ethers } from 'ethers-v5';
 import { polygon } from 'viem/chains';
 import { describe, expect, it } from 'vitest';
-import {
-  cancelOrder,
-  fetchApiKeys,
-  fetchMarket,
-  prepareLimitOrderPosting,
-} from './actions';
-import { authenticateWith, completeWith } from './ethers-v5';
+import { cancelOrder, fetchApiKeys, fetchMarket } from './actions';
+import { createSecureClient } from './clients';
+import { signerFrom } from './ethers-v5';
 import {
   publicClient,
   runMeteredTests,
@@ -33,35 +29,37 @@ function createSigner() {
 }
 
 describe('ethers-v5', () => {
-  describe('authenticateWith', () => {
-    it('authenticates a secure client from an authentication workflow', async () => {
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(createSigner()));
+  describe('signerFrom', () => {
+    it('authenticates a secure client', async () => {
+      const secureClient = await createSecureClient({
+        wallet: safeWalletAddress,
+        signer: signerFrom(createSigner()),
+      });
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
   });
 
-  describe('completeWith', () => {
+  describe('wallet operations', () => {
     it.runIf(runMeteredTests)('places and cancels a limit order', async () => {
-      const signer = createSigner();
+      const signer = signerFrom(createSigner());
       const market = await fetchMarket(publicClient, {
         slug: TEST_MARKET_SLUG,
       });
       const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
       const price = expectPresent(market.trading.minimumTickSize);
       const size = expectPresent(market.trading.minimumOrderSize);
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(signer));
+      const secureClient = await createSecureClient({
+        wallet: safeWalletAddress,
+        signer,
+      });
 
-      const response = await prepareLimitOrderPosting(secureClient, {
+      const response = await secureClient.placeLimitOrder({
         price,
         size,
         side: OrderSide.BUY,
         tokenId: yesTokenId,
-      }).then(completeWith(signer));
+      });
 
       expect(response.ok).toBe(true);
       const acceptedResponse = expectAcceptedOrderResponse(response);

--- a/packages/client/src/ethers-v5.test.ts
+++ b/packages/client/src/ethers-v5.test.ts
@@ -29,49 +29,45 @@ function createSigner() {
 }
 
 describe('ethers-v5', () => {
-  describe('signerFrom', () => {
-    it('authenticates a secure client', async () => {
-      const secureClient = await createSecureClient({
-        wallet: safeWalletAddress,
-        signer: signerFrom(createSigner()),
-      });
-
-      await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
+  it('authenticates a secure client', async () => {
+    const secureClient = await createSecureClient({
+      wallet: safeWalletAddress,
+      signer: signerFrom(createSigner()),
     });
+
+    await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
   });
 
-  describe('wallet operations', () => {
-    it.runIf(runMeteredTests)('places and cancels a limit order', async () => {
-      const signer = signerFrom(createSigner());
-      const market = await fetchMarket(publicClient, {
-        slug: TEST_MARKET_SLUG,
-      });
-      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
-      const price = expectPresent(market.trading.minimumTickSize);
-      const size = expectPresent(market.trading.minimumOrderSize);
-      const secureClient = await createSecureClient({
-        wallet: safeWalletAddress,
-        signer,
-      });
-
-      const response = await secureClient.placeLimitOrder({
-        price,
-        size,
-        side: OrderSide.BUY,
-        tokenId: yesTokenId,
-      });
-
-      expect(response.ok).toBe(true);
-      const acceptedResponse = expectAcceptedOrderResponse(response);
-
-      await expect(
-        cancelOrder(secureClient, { orderId: acceptedResponse.orderId }),
-      ).resolves.toEqual(
-        expect.objectContaining({
-          canceled: expect.arrayContaining([acceptedResponse.orderId]),
-        }),
-      );
+  it.runIf(runMeteredTests)('places and cancels a limit order', async () => {
+    const signer = signerFrom(createSigner());
+    const market = await fetchMarket(publicClient, {
+      slug: TEST_MARKET_SLUG,
     });
+    const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+    const price = expectPresent(market.trading.minimumTickSize);
+    const size = expectPresent(market.trading.minimumOrderSize);
+    const secureClient = await createSecureClient({
+      wallet: safeWalletAddress,
+      signer,
+    });
+
+    const response = await secureClient.placeLimitOrder({
+      price,
+      size,
+      side: OrderSide.BUY,
+      tokenId: yesTokenId,
+    });
+
+    expect(response.ok).toBe(true);
+    const acceptedResponse = expectAcceptedOrderResponse(response);
+
+    await expect(
+      cancelOrder(secureClient, { orderId: acceptedResponse.orderId }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        canceled: expect.arrayContaining([acceptedResponse.orderId]),
+      }),
+    );
   });
 });
 

--- a/packages/client/src/ethers-v5.ts
+++ b/packages/client/src/ethers-v5.ts
@@ -12,8 +12,12 @@ import {
   TransactionFailedError,
   TransportError,
 } from './errors';
-import type { TransactionHandle, TypedData, TypedDataPayload } from './types';
-import type { AuthenticateWith, CompleteWith } from './workflow';
+import type {
+  Signer,
+  TransactionHandle,
+  TypedData,
+  TypedDataPayload,
+} from './types';
 
 type EthersV5Signer = ethers.Signer & {
   _signTypedData(
@@ -23,94 +27,22 @@ type EthersV5Signer = ethers.Signer & {
   ): Promise<string>;
 };
 
-/**
- * Drives an authentication workflow with an ethers v5 signer.
- *
- * @throws {@link AuthenticateWithError}
- * Thrown when the required wallet signature is rejected or cannot be produced.
- */
-export function authenticateWith(signer: EthersV5Signer): AuthenticateWith {
-  return async function authenticate(workflow) {
-    let result = await workflow.next();
-
-    while (!result.done) {
-      try {
-        switch (result.value.kind) {
-          case 'requestAddress': {
-            const address = await getAddress(signer);
-            result = await workflow.next(address);
-            break;
-          }
-          case 'signAuthMessage':
-            result = await workflow.next(
-              await signTypedData(signer, result.value.payload),
-            );
-            break;
-        }
-      } catch (error) {
-        result = await workflow.throw(error);
-      }
-    }
-
-    return result.value;
-  };
-}
-
-/**
- * Drives a workflow with an ethers v5 signer.
- *
- * Supports the current non-auth workflow set, including order signing,
- * approvals, transfers, redemptions, and gasless wallet preparation.
- *
- * @throws {@link CompleteWithError}
- * Thrown when the required wallet signature or submission is rejected or cannot be produced.
- */
-export function completeWith(signer: EthersV5Signer): CompleteWith {
-  return async function complete(workflow) {
-    let result = await workflow.next();
-
-    while (!result.done) {
-      try {
-        switch (result.value.kind) {
-          case 'sendErc20ApprovalTransaction':
-          case 'sendErc1155ApprovalForAllTransaction':
-          case 'sendErc20TransferTransaction':
-          case 'sendMergePositionsTransaction':
-          case 'sendRedeemPositionsTransaction':
-          case 'sendSplitPositionTransaction': {
-            const response = await sendTransaction(
-              signer,
-              result.value.request,
-            );
-            result = await workflow.next(new DirectTransactionHandle(response));
-            break;
-          }
-
-          case 'requestAddress': {
-            const address = await getAddress(signer);
-            result = await workflow.next(address);
-            break;
-          }
-
-          case 'signGaslessTypedData':
-          case 'signOrder':
-            result = await workflow.next(
-              await signTypedData(signer, result.value.payload),
-            );
-            break;
-
-          case 'signGaslessMessage':
-            result = await workflow.next(
-              await signMessage(signer, result.value.payload),
-            );
-            break;
-        }
-      } catch (error) {
-        result = await workflow.throw(error);
-      }
-    }
-
-    return result.value;
+export function signerFrom(signer: EthersV5Signer): Signer {
+  return {
+    getAddress() {
+      return getAddress(signer);
+    },
+    signTypedData(payload) {
+      return signTypedData(signer, payload);
+    },
+    signMessage(message) {
+      return signMessage(signer, message);
+    },
+    async sendTransaction(request) {
+      return new DirectTransactionHandle(
+        await sendTransaction(signer, request),
+      );
+    },
   };
 }
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,15 +14,14 @@ export type {
 } from './authorization';
 export { relayerApiKey, remoteBuilderSigning } from './authorization';
 export type * from './clients';
-export { createPublicClient } from './clients';
+export {
+  CreateSecureClientError,
+  createPublicClient,
+  createSecureClient,
+} from './clients';
 export * from './decorators';
 export * from './environments';
 export * from './errors';
 export * from './hmac';
 export type * from './pagination';
 export * from './types';
-export type {
-  AuthenticationWorkflow,
-  AuthenticationWorkflowRequest,
-} from './workflow';
-export { AuthenticateWithError, CompleteWithError } from './workflow';

--- a/packages/client/src/privy.test.ts
+++ b/packages/client/src/privy.test.ts
@@ -92,57 +92,53 @@ describe.runIf(hasPrivyTestConfig)('privy', () => {
     }
   }, 120_000);
 
-  describe('signerFrom', () => {
-    it('authenticates a secure client', async () => {
+  it('authenticates a secure client', async () => {
+    const secureClient = await createSecureClient({
+      signer: signerFrom(wallet),
+      wallet: safeWalletAddress,
+    });
+
+    await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
+  });
+
+  it.runIf(runMeteredTests)(
+    'places and cancels a limit order',
+    async () => {
+      const market = await fetchMarket(publicClient, {
+        slug: TEST_MARKET_SLUG,
+      });
+      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+      const price = expectPresent(market.trading.minimumTickSize);
+      const size = expectPresent(market.trading.minimumOrderSize);
       const secureClient = await createSecureClient({
         signer: signerFrom(wallet),
         wallet: safeWalletAddress,
       });
 
-      await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
-    });
-  });
+      if (!hasCollateralBalance) {
+        return;
+      }
 
-  describe('wallet operations', () => {
-    it.runIf(runMeteredTests)(
-      'places and cancels a limit order',
-      async () => {
-        const market = await fetchMarket(publicClient, {
-          slug: TEST_MARKET_SLUG,
-        });
-        const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
-        const price = expectPresent(market.trading.minimumTickSize);
-        const size = expectPresent(market.trading.minimumOrderSize);
-        const secureClient = await createSecureClient({
-          signer: signerFrom(wallet),
-          wallet: safeWalletAddress,
-        });
+      const response = await secureClient.placeLimitOrder({
+        price,
+        size,
+        side: OrderSide.BUY,
+        tokenId: yesTokenId,
+      });
 
-        if (!hasCollateralBalance) {
-          return;
-        }
+      expect(response.ok).toBe(true);
+      const acceptedResponse = expectAcceptedOrderResponse(response);
 
-        const response = await secureClient.placeLimitOrder({
-          price,
-          size,
-          side: OrderSide.BUY,
-          tokenId: yesTokenId,
-        });
-
-        expect(response.ok).toBe(true);
-        const acceptedResponse = expectAcceptedOrderResponse(response);
-
-        await expect(
-          cancelOrder(secureClient, { orderId: acceptedResponse.orderId }),
-        ).resolves.toEqual(
-          expect.objectContaining({
-            canceled: expect.arrayContaining([acceptedResponse.orderId]),
-          }),
-        );
-      },
-      120_000,
-    );
-  });
+      await expect(
+        cancelOrder(secureClient, { orderId: acceptedResponse.orderId }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          canceled: expect.arrayContaining([acceptedResponse.orderId]),
+        }),
+      );
+    },
+    120_000,
+  );
 });
 
 function expectAcceptedOrderResponse(response: unknown): AcceptedOrderResponse {

--- a/packages/client/src/privy.test.ts
+++ b/packages/client/src/privy.test.ts
@@ -12,16 +12,12 @@ import {
   fetchApiKeys,
   fetchBalanceAllowance,
   fetchMarket,
-  prepareLimitOrderPosting,
-  prepareTradingApprovals,
 } from './actions';
-import { isGaslessReady, prepareGaslessWallet } from './actions/gasless';
+import { isGaslessReady } from './actions/gasless';
+import { createSecureClient } from './clients';
+import { type PrivyWalletConfig, signerFrom } from './privy';
 import {
-  authenticateWith,
-  completeWith,
-  type PrivyWalletConfig,
-} from './privy';
-import {
+  builderAuthorization,
   publicClient,
   publicClientWithBuilderKey,
   runMeteredTests,
@@ -63,18 +59,23 @@ describe.runIf(hasPrivyTestConfig)('privy', () => {
         wallet: safeWalletAddress,
       }))
     ) {
-      const handle = await prepareGaslessWallet(
-        publicClientWithBuilderKey,
-      ).then(completeWith(wallet));
+      const secureClient = await createSecureClient({
+        apiKey: builderAuthorization,
+        signer: signerFrom(wallet),
+        wallet: safeWalletAddress,
+      });
+      const handle = await secureClient.setupGaslessWallet();
 
       expect(handle.wallet).toBe(safeWalletAddress);
       await handle.wait();
     }
 
     if (runMeteredTests) {
-      const secureClient = await publicClientWithBuilderKey
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(wallet));
+      const secureClient = await createSecureClient({
+        apiKey: builderAuthorization,
+        signer: signerFrom(wallet),
+        wallet: safeWalletAddress,
+      });
 
       hasCollateralBalance =
         (
@@ -84,26 +85,25 @@ describe.runIf(hasPrivyTestConfig)('privy', () => {
         ).balance !== '0';
 
       if (hasCollateralBalance) {
-        const handle = await prepareTradingApprovals(secureClient).then(
-          completeWith(wallet),
-        );
+        const handle = await secureClient.setupTradingApprovals();
 
         await handle.wait();
       }
     }
   }, 120_000);
 
-  describe('authenticateWith', () => {
-    it('authenticates a secure client from an authentication workflow', async () => {
-      const secureClient = await publicClient
-        .beginAuthentication({ wallet: safeWalletAddress })
-        .then(authenticateWith(wallet));
+  describe('signerFrom', () => {
+    it('authenticates a secure client', async () => {
+      const secureClient = await createSecureClient({
+        signer: signerFrom(wallet),
+        wallet: safeWalletAddress,
+      });
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
   });
 
-  describe('completeWith', () => {
+  describe('wallet operations', () => {
     it.runIf(runMeteredTests)(
       'places and cancels a limit order',
       async () => {
@@ -113,20 +113,21 @@ describe.runIf(hasPrivyTestConfig)('privy', () => {
         const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
         const price = expectPresent(market.trading.minimumTickSize);
         const size = expectPresent(market.trading.minimumOrderSize);
-        const secureClient = await publicClient
-          .beginAuthentication({ wallet: safeWalletAddress })
-          .then(authenticateWith(wallet));
+        const secureClient = await createSecureClient({
+          signer: signerFrom(wallet),
+          wallet: safeWalletAddress,
+        });
 
         if (!hasCollateralBalance) {
           return;
         }
 
-        const response = await prepareLimitOrderPosting(secureClient, {
+        const response = await secureClient.placeLimitOrder({
           price,
           size,
           side: OrderSide.BUY,
           tokenId: yesTokenId,
-        }).then(completeWith(wallet));
+        });
 
         expect(response.ok).toBe(true);
         const acceptedResponse = expectAcceptedOrderResponse(response);

--- a/packages/client/src/privy.ts
+++ b/packages/client/src/privy.ts
@@ -27,15 +27,12 @@ import {
   TransportError,
 } from './errors';
 import type {
+  Signer,
+  SignerTransactionRequest,
   TransactionHandle,
   TransactionOutcome,
   TypedDataPayload,
 } from './types';
-import type {
-  AuthenticateWith,
-  CompleteWith,
-  SignerTransactionRequest,
-} from './workflow';
 
 invariant(
   process.release.name === 'node',
@@ -54,89 +51,23 @@ export type PrivyWalletConfig = {
 
 const allChains = Object.values(viemChains) as Chain[];
 
-/**
- * Drives an authentication workflow with a Privy Node SDK wallet.
- *
- * @throws {@link AuthenticateWithError}
- * Thrown when the required wallet signature cannot be produced.
- */
-export function authenticateWith(config: PrivyWalletConfig): AuthenticateWith {
-  return async function authenticate(workflow) {
-    let result = await workflow.next();
-
-    while (!result.done) {
-      try {
-        switch (result.value.kind) {
-          case 'requestAddress':
-            result = await workflow.next(await resolveAddress(config));
-            break;
-          case 'signAuthMessage':
-            result = await workflow.next(
-              await signTypedData(config, result.value.payload),
-            );
-            break;
-        }
-      } catch (error) {
-        result = await workflow.throw(error);
-      }
-    }
-
-    return result.value;
-  };
-}
-
-/**
- * Drives a workflow with a Privy Node SDK wallet.
- *
- * Supports the current non-auth workflow set, including order signing,
- * approvals, transfers, redemptions, and gasless wallet preparation.
- *
- * @throws {@link CompleteWithError}
- * Thrown when the required wallet signature or submission cannot be produced.
- */
-export function completeWith(config: PrivyWalletConfig): CompleteWith {
-  return async function complete(workflow) {
-    let result = await workflow.next();
-
-    while (!result.done) {
-      try {
-        switch (result.value.kind) {
-          case 'sendErc20ApprovalTransaction':
-          case 'sendErc1155ApprovalForAllTransaction':
-          case 'sendErc20TransferTransaction':
-          case 'sendMergePositionsTransaction':
-          case 'sendRedeemPositionsTransaction':
-          case 'sendSplitPositionTransaction': {
-            const hash = await sendTransaction(config, result.value.request);
-            result = await workflow.next(
-              new DirectTransactionHandle(hash, result.value.request.chainId),
-            );
-            break;
-          }
-
-          case 'requestAddress':
-            result = await workflow.next(await resolveAddress(config));
-            break;
-
-          case 'signGaslessTypedData':
-          case 'signOrder':
-            result = await workflow.next(
-              await signTypedData(config, result.value.payload),
-            );
-            break;
-
-          case 'signGaslessMessage':
-            result = await workflow.next(
-              await signMessage(config, result.value.payload),
-            );
-            break;
-        }
-      } catch (error) {
-        result = await workflow.throw(error);
-      }
-    }
-
-    return result.value;
+export function signerFrom(config: PrivyWalletConfig): Signer {
+  return {
+    getAddress() {
+      return resolveAddress(config);
+    },
+    signTypedData(payload) {
+      return signTypedData(config, payload);
+    },
+    signMessage(message) {
+      return signMessage(config, message);
+    },
+    async sendTransaction(request) {
+      return new DirectTransactionHandle(
+        await sendTransaction(config, request),
+        request.chainId,
+      );
+    },
   };
 }
 

--- a/packages/client/src/testing.ts
+++ b/packages/client/src/testing.ts
@@ -103,13 +103,11 @@ export const walletClient = createWalletClient({
   transport: http(),
 });
 
-export const signer = signerFrom(walletClient);
-
 export function createTestSecureClient(
   options: Partial<Parameters<typeof createSecureClient>[0]> = {},
 ) {
   return createSecureClient({
-    signer,
+    signer: signerFrom(walletClient),
     wallet: safeWalletAddress,
     ...options,
   });

--- a/packages/client/src/testing.ts
+++ b/packages/client/src/testing.ts
@@ -14,10 +14,11 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { polygon } from 'viem/chains';
 import { deriveProxyWalletAddress } from './account';
 import { relayerApiKey } from './authorization';
-import { createPublicClient } from './clients';
+import { createPublicClient, createSecureClient } from './clients';
 // biome-ignore lint/style/noRestrictedImports: intentional
 import { builderApiKey } from './node';
 import type { Page } from './pagination';
+import { signerFrom } from './viem';
 
 if (process.env.CI !== 'true') {
   try {
@@ -39,15 +40,19 @@ export const builderCredentials = {
   passphrase: expectPresent(process.env.POLYMARKET_BUILDER_PASSPHRASE),
 } as const;
 
+export const builderAuthorization = builderApiKey(builderCredentials);
+
 export const publicClientWithBuilderKey = createPublicClient({
-  apiKey: builderApiKey(builderCredentials),
+  apiKey: builderAuthorization,
+});
+
+export const relayerAuthorization = relayerApiKey({
+  key: expectPresent(process.env.POLYMARKET_RELAYER_API_KEY),
+  address: expectPresent(process.env.POLYMARKET_RELAYER_API_KEY_ADDRESS),
 });
 
 export const publicClientWithRelayerKey = createPublicClient({
-  apiKey: relayerApiKey({
-    key: expectPresent(process.env.POLYMARKET_RELAYER_API_KEY),
-    address: expectPresent(process.env.POLYMARKET_RELAYER_API_KEY_ADDRESS),
-  }),
+  apiKey: relayerAuthorization,
 });
 
 function loadTestPrivateKey(): PrivateKey {
@@ -97,6 +102,18 @@ export const walletClient = createWalletClient({
   chain: polygon,
   transport: http(),
 });
+
+export const signer = signerFrom(walletClient);
+
+export function createTestSecureClient(
+  options: Partial<Parameters<typeof createSecureClient>[0]> = {},
+) {
+  return createSecureClient({
+    signer,
+    wallet: safeWalletAddress,
+    ...options,
+  });
+}
 
 export function createRandomWalletClient() {
   const privateKey = generatePrivateKey();

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,6 +1,7 @@
 import type { TransactionId } from '@polymarket/bindings';
 import {
   type EvmAddress,
+  type EvmSignature,
   type HexString,
   invariant,
   type TxHash,
@@ -41,6 +42,13 @@ export type TypedDataPayload = {
 
 export type TransactionCall = {
   data: HexString;
+  to: EvmAddress;
+  value?: bigint;
+};
+
+export type SignerTransactionRequest = {
+  chainId: number;
+  data?: HexString;
   to: EvmAddress;
   value?: bigint;
 };
@@ -111,6 +119,15 @@ export interface DeployTransactionHandle extends TransactionHandle {
    */
   readonly wallet: EvmAddress;
 }
+
+export type Signer = {
+  getAddress(): Promise<EvmAddress>;
+  signTypedData(payload: TypedDataPayload): Promise<EvmSignature>;
+  signMessage(message: HexString): Promise<EvmSignature>;
+  sendTransaction(
+    request: SignerTransactionRequest,
+  ): Promise<TransactionHandle>;
+};
 
 /** @internal */
 export function expectTransactionHandle(

--- a/packages/client/src/viem.ts
+++ b/packages/client/src/viem.ts
@@ -25,8 +25,7 @@ import {
   TransactionFailedError,
   TransportError,
 } from './errors';
-import type { TransactionHandle } from './types';
-import type { AuthenticateWith, CompleteWith } from './workflow';
+import type { Signer, TransactionHandle } from './types';
 
 function isWalletClientWithAccount(
   walletClient: WalletClient,
@@ -34,13 +33,7 @@ function isWalletClientWithAccount(
   return walletClient.account !== undefined;
 }
 
-/**
- * Drives an authentication workflow with a viem wallet client.
- *
- * @throws {@link AuthenticateWithError}
- * Thrown when the required wallet signature is rejected or cannot be produced.
- */
-export function authenticateWith(walletClient: WalletClient): AuthenticateWith {
+export function signerFrom(walletClient: WalletClient): Signer {
   invariant(
     isWalletClientWithAccount(walletClient),
     'Wallet client with account is required',
@@ -53,114 +46,34 @@ export function authenticateWith(walletClient: WalletClient): AuthenticateWith {
       : walletClient.account.address,
   );
 
-  return async function authenticate(workflow) {
-    let result = await workflow.next();
-
-    while (!result.done) {
-      try {
-        switch (result.value.kind) {
-          case 'requestAddress':
-            result = await workflow.next(address);
-            break;
-          case 'signAuthMessage':
-            result = await workflow.next(
-              expectEvmSignature(
-                await signTypedData(walletClient, {
-                  account,
-                  ...result.value.payload,
-                }),
-              ),
-            );
-            break;
-        }
-      } catch (error) {
-        result = await workflow.throw(error);
-      }
-    }
-
-    return result.value;
-  };
-}
-
-/**
- * Drives a workflow with a viem wallet client.
- *
- * Supports the current non-auth workflow set, including order signing,
- * approvals, transfers, redemptions, and gasless wallet preparation.
- *
- * @throws {@link CompleteWithError}
- * Thrown when the required wallet signature or submission is rejected or cannot be produced.
- */
-export function completeWith(walletClient: WalletClient): CompleteWith {
-  invariant(
-    isWalletClientWithAccount(walletClient),
-    'Wallet client with account is required',
-  );
-
-  const account = walletClient.account;
-  const address = expectEvmAddress(
-    typeof walletClient.account === 'string'
-      ? walletClient.account
-      : walletClient.account.address,
-  );
-
-  return async function complete(workflow) {
-    let result = await workflow.next();
-
-    while (!result.done) {
-      try {
-        switch (result.value.kind) {
-          case 'sendErc20ApprovalTransaction':
-          case 'sendErc1155ApprovalForAllTransaction':
-          case 'sendErc20TransferTransaction':
-          case 'sendMergePositionsTransaction':
-          case 'sendRedeemPositionsTransaction':
-          case 'sendSplitPositionTransaction': {
-            const { chainId, ...request } = result.value.request;
-            await assertChainId(walletClient, chainId);
-            const hash = await sendTransaction(walletClient, {
-              account,
-              ...request,
-            });
-            result = await workflow.next(
-              new DirectTransactionHandle(hash, walletClient),
-            );
-            break;
-          }
-
-          case 'requestAddress':
-            result = await workflow.next(address);
-            break;
-
-          case 'signGaslessTypedData':
-          case 'signOrder':
-            result = await workflow.next(
-              expectEvmSignature(
-                await signTypedData(walletClient, {
-                  account,
-                  ...result.value.payload,
-                }),
-              ),
-            );
-            break;
-
-          case 'signGaslessMessage':
-            result = await workflow.next(
-              expectEvmSignature(
-                await signMessage(walletClient, {
-                  account,
-                  message: { raw: result.value.payload },
-                }),
-              ),
-            );
-            break;
-        }
-      } catch (error) {
-        result = await workflow.throw(error);
-      }
-    }
-
-    return result.value;
+  return {
+    getAddress() {
+      return Promise.resolve(address);
+    },
+    async signTypedData(payload) {
+      return expectEvmSignature(
+        await signTypedData(walletClient, {
+          account,
+          ...payload,
+        }),
+      );
+    },
+    async signMessage(message) {
+      return expectEvmSignature(
+        await signMessage(walletClient, {
+          account,
+          message: { raw: message },
+        }),
+      );
+    },
+    async sendTransaction({ chainId, ...request }) {
+      await assertChainId(walletClient, chainId);
+      const hash = await sendTransaction(walletClient, {
+        account,
+        ...request,
+      });
+      return new DirectTransactionHandle(hash, walletClient);
+    },
   };
 }
 

--- a/packages/client/src/workflow.ts
+++ b/packages/client/src/workflow.ts
@@ -1,17 +1,12 @@
 import type { EvmAddress, EvmSignature, HexString } from '@polymarket/types';
 import { CancelledSigningError, makeErrorGuard, SigningError } from './errors';
 import type {
+  Signer,
+  SignerTransactionRequest,
   TransactionCall,
   TransactionHandle,
   TypedDataPayload,
 } from './types';
-
-export type SignerTransactionRequest = {
-  chainId: number;
-  data?: HexString;
-  to: EvmAddress;
-  value?: bigint;
-};
 
 export type RequestAddressRequest = {
   kind: 'requestAddress';
@@ -112,6 +107,77 @@ export type CompleteWorkflowNext =
 export type CompleteWith = <TRequest extends CompleteWorkflowRequest, TReturn>(
   workflow: AsyncGenerator<TRequest, TReturn, CompleteWorkflowNext>,
 ) => Promise<TReturn>;
+
+/** @internal */
+export function authenticateWith(signer: Signer): AuthenticateWith {
+  return async function authenticate(workflow) {
+    let result = await workflow.next();
+
+    while (!result.done) {
+      try {
+        switch (result.value.kind) {
+          case 'requestAddress':
+            result = await workflow.next(await signer.getAddress());
+            break;
+          case 'signAuthMessage':
+            result = await workflow.next(
+              await signer.signTypedData(result.value.payload),
+            );
+            break;
+        }
+      } catch (error) {
+        result = await workflow.throw(error);
+      }
+    }
+
+    return result.value;
+  };
+}
+
+/** @internal */
+export function completeWith(signer: Signer): CompleteWith {
+  return async function complete(workflow) {
+    let result = await workflow.next();
+
+    while (!result.done) {
+      try {
+        switch (result.value.kind) {
+          case 'requestAddress':
+            result = await workflow.next(await signer.getAddress());
+            break;
+
+          case 'signGaslessTypedData':
+          case 'signOrder':
+            result = await workflow.next(
+              await signer.signTypedData(result.value.payload),
+            );
+            break;
+
+          case 'signGaslessMessage':
+            result = await workflow.next(
+              await signer.signMessage(result.value.payload),
+            );
+            break;
+
+          case 'sendErc20ApprovalTransaction':
+          case 'sendErc1155ApprovalForAllTransaction':
+          case 'sendErc20TransferTransaction':
+          case 'sendMergePositionsTransaction':
+          case 'sendRedeemPositionsTransaction':
+          case 'sendSplitPositionTransaction':
+            result = await workflow.next(
+              await signer.sendTransaction(result.value.request),
+            );
+            break;
+        }
+      } catch (error) {
+        result = await workflow.throw(error);
+      }
+    }
+
+    return result.value;
+  };
+}
 
 export function requestAddress(): RequestAddressRequest {
   return {


### PR DESCRIPTION
## Summary
- Add `createSecureClient` as the public secure-client creation path backed by wallet-agnostic `Signer` primitives.
- Replace bound secure-client prepare workflow methods with direct imperative actions such as `placeLimitOrder`, `setupTradingApprovals`, and `transferErc20`.
- Convert viem, ethers v5, and Privy helpers to `signerFrom(...)` adapters and keep low-level workflow helpers internal.

## Verification
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core client authentication/session handling and changes the primary public API surface for trading and wallet operations, which could introduce breaking changes or signer/credential regression if not fully covered across integrations.
> 
> **Overview**
> Adds a new top-level `createSecureClient` API that authenticates using a wallet-agnostic `Signer` interface, and refactors secure-client construction to carry a signer for wallet-interactive operations.
> 
> Introduces imperative, higher-level secure actions that *complete* workflows internally (e.g. `placeLimitOrder`/`placeMarketOrder`, `approveErc20`, `transferErc20`, `splitPosition`, `setupGaslessWallet`, `setupTradingApprovals`) while re-framing existing `prepare*` functions as low-level workflow builders; updates decorators and exports accordingly and removes public session-snapshot APIs in favor of reusing `credentials`.
> 
> Unifies viem/ethers-v5/Privy integrations to `signerFrom(...)` adapters and moves generic `authenticateWith`/`completeWith` into `workflow` as internal helpers; updates all affected tests to use `createTestSecureClient` + the new action methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab91d37cd147d6443a2b8ee658b786e98dcf35d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->