### PR TITLE
fix(client): suppress HTML error bodies

### DIFF
--- a/packages/client/src/ServiceClient.test.ts
+++ b/packages/client/src/ServiceClient.test.ts
@@ -1,0 +1,147 @@
+import { unwrap } from '@polymarket/types';
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { RequestRejectedError } from './errors';
+import { ServiceClient } from './ServiceClient';
+
+const root = 'http://localhost:4011';
+const server = setupServer();
+
+describe('ServiceClient', () => {
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'bypass' });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('uses JSON error fields as rejected request messages', async () => {
+    server.use(
+      http.get(`${root}/json-error`, () =>
+        HttpResponse.json({ error: 'structured failure' }, { status: 400 }),
+      ),
+    );
+    const client = new ServiceClient({ root });
+
+    await expect(unwrap(client.get('/json-error'))).rejects.toMatchObject({
+      message: 'structured failure',
+      name: 'RequestRejectedError',
+      status: 400,
+    });
+  });
+
+  it('prefers JSON error fields over Cloudflare response detection', async () => {
+    server.use(
+      http.get(`${root}/cloudflare-json-error`, () =>
+        HttpResponse.json(
+          { error: 'structured cloudflare failure' },
+          { headers: { server: 'cloudflare' }, status: 400 },
+        ),
+      ),
+    );
+    const client = new ServiceClient({ root });
+
+    await expect(
+      unwrap(client.get('/cloudflare-json-error')),
+    ).rejects.toMatchObject({
+      message: 'structured cloudflare failure',
+      name: 'RequestRejectedError',
+      status: 400,
+    });
+  });
+
+  it('uses plain text response bodies as rejected request messages', async () => {
+    server.use(
+      http.get(
+        `${root}/text-error`,
+        () =>
+          new HttpResponse('plain failure', {
+            headers: { 'content-type': 'text/plain' },
+            status: 400,
+          }),
+      ),
+    );
+    const client = new ServiceClient({ root });
+
+    await expect(unwrap(client.get('/text-error'))).rejects.toMatchObject({
+      message: 'plain failure',
+      name: 'RequestRejectedError',
+      status: 400,
+    });
+  });
+
+  it('prefers plain text response bodies over Cloudflare response detection', async () => {
+    server.use(
+      http.get(
+        `${root}/cloudflare-text-error`,
+        () =>
+          new HttpResponse('plain cloudflare failure', {
+            headers: { 'content-type': 'text/plain', server: 'cloudflare' },
+            status: 400,
+          }),
+      ),
+    );
+    const client = new ServiceClient({ root });
+
+    await expect(
+      unwrap(client.get('/cloudflare-text-error')),
+    ).rejects.toMatchObject({
+      message: 'plain cloudflare failure',
+      name: 'RequestRejectedError',
+      status: 400,
+    });
+  });
+
+  it('identifies Cloudflare-blocked responses without reading the body', async () => {
+    server.use(
+      http.get(
+        `${root}/html-error`,
+        () =>
+          new HttpResponse('<!doctype html><html>Cloudflare error</html>', {
+            headers: {
+              'content-type': 'text/html; charset=utf-8',
+              server: 'cloudflare',
+            },
+            status: 502,
+          }),
+      ),
+    );
+    const client = new ServiceClient({ root });
+
+    await expect(unwrap(client.get('/html-error'))).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof RequestRejectedError &&
+        error.status === 502 &&
+        error.message.includes('blocked by Cloudflare') &&
+        !error.message.includes('Cloudflare error'),
+    );
+  });
+
+  it('identifies unreadable HTML errors when the server is unknown', async () => {
+    server.use(
+      http.get(
+        `${root}/generic-html-error`,
+        () =>
+          new HttpResponse('<!doctype html><html>Gateway error</html>', {
+            headers: { 'content-type': 'text/html; charset=utf-8' },
+            status: 502,
+          }),
+      ),
+    );
+    const client = new ServiceClient({ root });
+
+    await expect(unwrap(client.get('/generic-html-error'))).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof RequestRejectedError &&
+        error.status === 502 &&
+        error.message.includes('unexpected HTML response body') &&
+        !error.message.includes('Gateway error'),
+    );
+  });
+});

--- a/packages/client/src/ServiceClient.ts
+++ b/packages/client/src/ServiceClient.ts
@@ -202,7 +202,9 @@ export class ServiceClient {
   }
 
   async #extractResponseErrorMessage(response: Response) {
-    if (response.headers.get('content-type')?.includes('application/json')) {
+    const contentType = response.headers.get('content-type')?.toLowerCase();
+
+    if (contentType?.includes('application/json')) {
       const { error } = await response
         .clone()
         .json()
@@ -210,16 +212,30 @@ export class ServiceClient {
       if (error) return String(error);
     }
 
-    const text = await response
-      .clone()
-      .text()
-      .then(
-        (body) => body.trim(),
-        () => '',
-      );
+    if (contentType?.includes('text/plain')) {
+      const text = await response
+        .clone()
+        .text()
+        .then(
+          (body) => body.trim(),
+          () => '',
+        );
 
-    if (text) {
-      return text;
+      if (text) {
+        return text;
+      }
+    }
+
+    const server = response.headers.get('server')?.toLowerCase();
+    if (server?.includes('cloudflare')) {
+      return `Request to ${response.url} was blocked by Cloudflare with status ${response.status}`;
+    }
+
+    if (
+      contentType?.includes('text/html') ||
+      contentType?.includes('application/xhtml+xml')
+    ) {
+      return `Request to ${response.url} failed with status ${response.status} and an unexpected HTML response body`;
     }
 
     return `Request to ${response.url} failed with status ${response.status} and unreadable response body`;


### PR DESCRIPTION
## Summary
- Preserve structured JSON errors and explicit plain text error bodies as the preferred SDK messages.
- Avoid logging HTML response bodies; report Cloudflare blocks and unexpected HTML responses with concise messages.
- Add ServiceClient coverage for JSON, text, Cloudflare, HTML, and fallback ordering.

## Verification
- pnpm exec vitest run packages/client/src/ServiceClient.test.ts --project client
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the SDK surfaces error messages for non-2xx responses, which can affect downstream error handling and observability. Logic is straightforward and covered by new tests, reducing regression risk.
> 
> **Overview**
> Updates `ServiceClient`’s error-message extraction to **prefer structured JSON `error` fields and explicit `text/plain` bodies**, and to **avoid reading/returning HTML response bodies**.
> 
> Adds detection for Cloudflare-served failures (using the `server` header) and a generic “unexpected HTML response body” message for HTML/XHTML content types, plus a new `ServiceClient.test.ts` suite covering JSON/text precedence, Cloudflare handling, and HTML suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56437ab73650ba920cc003c3f95ce24d78bd4d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->