### PR TITLE
refactor(bindings): remove market position V1 suffix

### DIFF
--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -74,7 +74,7 @@ export const ValueSchema = z.object({
   value: z.number().nullish(),
 });
 
-export const MarketPositionV1Schema = z
+export const MarketPositionSchema = z
   .looseObject({
     proxyWallet: AddressSchema.nullish(),
     name: z.string().nullish(),
@@ -98,23 +98,23 @@ export const MarketPositionV1Schema = z
     tokenId: asset,
   }));
 
-export const MetaMarketPositionV1Schema = z.object({
+export const MetaMarketPositionSchema = z.object({
   token: z.string().nullish(),
-  positions: z.array(MarketPositionV1Schema).nullish(),
+  positions: z.array(MarketPositionSchema).nullish(),
 });
 
 export const ListPositionsResponseSchema = z.array(PositionSchema);
 export const ListClosedPositionsResponseSchema = z.array(ClosedPositionSchema);
 export const FetchPortfolioValueResponseSchema = z.array(ValueSchema);
 export const ListMarketPositionsResponseSchema = z.array(
-  MetaMarketPositionV1Schema,
+  MetaMarketPositionSchema,
 );
 
 export type Position = z.infer<typeof PositionSchema>;
 export type ClosedPosition = z.infer<typeof ClosedPositionSchema>;
 export type Value = z.infer<typeof ValueSchema>;
-export type MarketPositionV1 = z.infer<typeof MarketPositionV1Schema>;
-export type MetaMarketPositionV1 = z.infer<typeof MetaMarketPositionV1Schema>;
+export type MarketPosition = z.infer<typeof MarketPositionSchema>;
+export type MetaMarketPosition = z.infer<typeof MetaMarketPositionSchema>;
 export type ListPositionsResponse = z.infer<typeof ListPositionsResponseSchema>;
 export type ListClosedPositionsResponse = z.infer<
   typeof ListClosedPositionsResponseSchema

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -7,7 +7,7 @@ import {
   ListMarketPositionsResponseSchema,
   ListOpenInterestResponseSchema,
   type MetaHolder,
-  type MetaMarketPositionV1,
+  type MetaMarketPosition,
   type OpenInterest,
 } from '@polymarket/bindings/data';
 import {
@@ -423,7 +423,7 @@ export const ListMarketPositionsError = makeErrorGuard(
  *
  * // Optionally, fetch additional pages:
  * for await (const page of result.from(firstPage.nextCursor)) {
- *   // page.items: MetaMarketPositionV1[]
+ *   // page.items: MetaMarketPosition[]
  * }
  * ```
  *
@@ -436,14 +436,14 @@ export const ListMarketPositionsError = makeErrorGuard(
  * });
  *
  * for await (const page of result) {
- *   // page.items: MetaMarketPositionV1[]
+ *   // page.items: MetaMarketPosition[]
  * }
  * ```
  */
 export function listMarketPositions(
   client: BaseClient,
   request: ListMarketPositionsRequest,
-): Paginated<MetaMarketPositionV1> {
+): Paginated<MetaMarketPosition> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListMarketPositionsRequestSchema,

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -5,7 +5,7 @@ import type {
 import type {
   Activity,
   ClosedPosition,
-  MetaMarketPositionV1,
+  MetaMarketPosition,
   Position,
   Traded,
   Value,
@@ -179,7 +179,7 @@ export type AccountPublicActions = {
    *
    * // Optionally, fetch additional pages:
    * for await (const page of paginator.from(firstPage.nextCursor)) {
-   *   // page.items: MetaMarketPositionV1[]
+   *   // page.items: MetaMarketPosition[]
    * }
    * ```
    *
@@ -192,13 +192,13 @@ export type AccountPublicActions = {
    * });
    *
    * for await (const page of paginator) {
-   *   // page.items: MetaMarketPositionV1[]
+   *   // page.items: MetaMarketPosition[]
    * }
    * ```
    */
   listMarketPositions(
     request: ListMarketPositionsRequest,
-  ): Paginated<MetaMarketPositionV1>;
+  ): Paginated<MetaMarketPosition>;
   /**
    * Lists wallet activity.
    *


### PR DESCRIPTION
## Summary
- Rename market-position binding schemas/types to remove the inconsistent `V1` suffix.
- Update client return types and TSDoc examples to use `MetaMarketPosition`.

## Verification
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low implementation risk (pure rename), but it is a potentially breaking API change for downstream TypeScript consumers importing the old `*V1` types/schemas.
> 
> **Overview**
> Renames market position bindings by dropping the `V1` suffix (`MarketPositionV1Schema`/`MetaMarketPositionV1Schema` and inferred types become `MarketPositionSchema`/`MetaMarketPositionSchema` and `MarketPosition`/`MetaMarketPosition`).
> 
> Updates `listMarketPositions` in the client action and account decorator to return `Paginated<MetaMarketPosition>` and adjusts TSDoc examples accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a052147b588a82300df334c54e11ed04caf6ece5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->