### PR TITLE
Add secure client gasless wallet setup

### DIFF
--- a/docs/sdk-direction.md
+++ b/docs/sdk-direction.md
@@ -28,6 +28,14 @@ The first shipping target is `@polymarket/client`. Its job is to make Polymarket
 - Normalize the CTF position identifier to `tokenId` in the SDK public model, even when upstream services call the same value `assetId`.
 - Standardize SDK identifier naming on JS/TS-style `...Id` forms such as `orderId`, `tradeId`, `tokenId`, and `marketId`, and translate legacy `...ID` and wire-format variants at the service boundary.
 
+## Wallet Direction
+
+- Existing EOA, Poly Proxy, and Poly Safe wallets must continue to authenticate and trade.
+- The next wallet deployment target is the Deposit Wallet. Once introduced, new wallet setup flows should deploy Deposit Wallets rather than the current gasless Safe wallet.
+- Treat the current `SecureClient.setupGaslessWallet` naming as transitional. Future public APIs may become `SecureClient.setupDepositWallet` and, if needed, a separate `SecureClient.upgradeDepositWallet` migration path.
+- During the transitional period, `SecureClient.setupGaslessWallet` should treat Proxy-bound clients as already gasless and preserve the Proxy binding rather than migrating them to Safe.
+- Do not make proxy-to-deposit migration implicit until the migration product behavior is decided. Existing wallet-bound clients should remain usable while migration is introduced over time.
+
 ## Package Direction
 
 - `@polymarket/client` is the main near-term package.

--- a/packages/client/src/account.ts
+++ b/packages/client/src/account.ts
@@ -5,14 +5,18 @@ import {
   type EvmAddress,
   expectEvmAddress,
   expectHexString,
+  isSameEvmAddress,
   never,
 } from '@polymarket/types';
 import { AbiParameters, ContractAddress, Hash } from 'ox';
 import type { EnvironmentConfig, WalletDerivationConfig } from './environments';
 
 export type AccountIdentity = {
+  /** Authenticated EOA that signs API authentication, orders, and wallet operations. */
   signer: EvmAddress;
+  /** Active Polymarket account/funder wallet used for balances, positions, and execution. */
   wallet: EvmAddress;
+  /** Wallet classification used for order signatures and transaction routing. */
   walletType: WalletType;
 };
 
@@ -83,26 +87,22 @@ export function deriveSafeWalletAddress(
   );
 }
 
-function sameAddress(left: EvmAddress, right: EvmAddress): boolean {
-  return left.toLowerCase() === right.toLowerCase();
-}
-
 function classifyWalletType(
   environment: EnvironmentConfig,
   signer: EvmAddress,
   wallet: EvmAddress,
 ): WalletType {
-  if (sameAddress(wallet, signer)) {
+  if (isSameEvmAddress(wallet, signer)) {
     return WalletType.EOA;
   }
 
   const config = environment.walletDerivation;
 
-  if (sameAddress(wallet, deriveProxyWalletAddress(signer, config))) {
+  if (isSameEvmAddress(wallet, deriveProxyWalletAddress(signer, config))) {
     return WalletType.POLY_PROXY;
   }
 
-  if (sameAddress(wallet, deriveSafeWalletAddress(signer, config))) {
+  if (isSameEvmAddress(wallet, deriveSafeWalletAddress(signer, config))) {
     return WalletType.POLY_GNOSIS_SAFE;
   }
 

--- a/packages/client/src/actions/account.test.ts
+++ b/packages/client/src/actions/account.test.ts
@@ -1,13 +1,13 @@
 import { AssetType } from '@polymarket/bindings/clob';
 import { describe, expect, it } from 'vitest';
 import type { AccountActions } from '../decorators';
-import { createTestSecureClient } from '../testing';
+import { createSecureClientWithSafeWallet } from '../testing';
 import { fetchBalanceAllowance } from './account';
 
 describe('Account', () => {
   describe('authenticated reads', () => {
     it('fetches authenticated account state', async () => {
-      const secureClient = await createTestSecureClient();
+      const secureClient = await createSecureClientWithSafeWallet();
 
       const [closedOnly, openOrders, trades, notifications, balanceAllowance] =
         await Promise.all([
@@ -35,7 +35,7 @@ describe('Account', () => {
 
   describe('dropNotifications', () => {
     it('marks notifications as read by id', async () => {
-      const secureClient = await createTestSecureClient();
+      const secureClient = await createSecureClientWithSafeWallet();
 
       const notifications = await secureClient.fetchNotifications();
 

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -5,7 +5,7 @@ import { createSecureClient } from '../clients';
 import { SigningError } from '../errors';
 import {
   createRandomWalletClient,
-  createTestSecureClient,
+  createSecureClientWithSafeWallet,
   relayerAuthorization,
 } from '../testing';
 import { signerFrom } from '../viem';
@@ -13,7 +13,7 @@ import { signerFrom } from '../viem';
 describe('Approvals', () => {
   describe('prepareErc20Approval', () => {
     it('submits a collateral approval for the standard exchange', async () => {
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
       });
 
@@ -31,7 +31,6 @@ describe('Approvals', () => {
     it('supports EOA approvals as traditional transactions', async () => {
       const walletClient = createRandomWalletClient();
       const secureClient = await createSecureClient({
-        wallet: walletClient.account.address,
         signer: signerFrom(walletClient),
       });
 
@@ -51,7 +50,7 @@ describe('Approvals', () => {
 
   describe('prepareErc1155ApprovalForAll', () => {
     it('submits a Conditional Tokens approval for the standard exchange', async () => {
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
       });
 
@@ -68,7 +67,7 @@ describe('Approvals', () => {
 
   describe('prepareTradingApprovals', () => {
     it('submits a combined trading-setup approval workflow', async () => {
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
       });
 

--- a/packages/client/src/actions/auth.ts
+++ b/packages/client/src/actions/auth.ts
@@ -60,7 +60,7 @@ export async function createApiKey(
 ): Promise<ApiKeyCreds> {
   return unwrap(
     client.clob
-      .post('auth/api-key', {
+      .post('/auth/api-key', {
         headers: toL1Headers(request),
       })
       .andThen(validateWith(ApiKeyCredsSchema)),

--- a/packages/client/src/actions/builders.test.ts
+++ b/packages/client/src/actions/builders.test.ts
@@ -3,7 +3,7 @@ import { delay, expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import {
   builderAuthorization,
-  createTestSecureClient,
+  createSecureClientWithSafeWallet,
   expectNonEmptyPage,
   findHighVolumeLowPriceMarket,
   publicClientWithBuilderKey,
@@ -30,7 +30,7 @@ describe('Builders', () => {
         return;
       }
 
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: builderAuthorization,
       });
 

--- a/packages/client/src/actions/gasless.test.ts
+++ b/packages/client/src/actions/gasless.test.ts
@@ -2,42 +2,34 @@ import { WalletType } from '@polymarket/bindings/gamma';
 import { expectEvmAddress } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
 import { erc20ApprovalCall } from '../abis';
-import { deriveSafeWalletAddress } from '../account';
-import { createPublicClient, createSecureClient } from '../clients';
+import { createSecureClient } from '../clients';
 import {
-  builderAuthorization,
   createRandomWalletClient,
-  createTestSecureClient,
+  createSecureClientWithSafeWallet,
   deriveProxyAddress,
-  publicClientWithBuilderKey,
   publicClientWithRelayerKey,
   relayerAuthorization,
-  runMeteredTests,
   safeWalletAddress,
   walletClient,
 } from '../testing';
 import { signerFrom } from '../viem';
-import { prepareGaslessTransaction } from './gasless';
+import { isGaslessReady, prepareGaslessTransaction } from './gasless';
 
 describe('Gasless', () => {
   describe('isGaslessReady', () => {
     it('returns true for a deployed safe-backed account', async () => {
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
       });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_GNOSIS_SAFE);
 
-      await expect(
-        secureClient.isGaslessReady({
-          wallet: secureClient.account.wallet,
-        }),
-      ).resolves.toBe(true);
+      await expect(secureClient.isGaslessReady()).resolves.toBe(true);
     });
 
     it('supports checking readiness from a public client with a wallet address', async () => {
       await expect(
-        publicClientWithRelayerKey.isGaslessReady({
+        isGaslessReady(publicClientWithRelayerKey, {
           wallet: safeWalletAddress,
         }),
       ).resolves.toBe(true);
@@ -46,25 +38,19 @@ describe('Gasless', () => {
     it('returns false for an EOA wallet type', async () => {
       const walletClient = createRandomWalletClient();
       const secureClient = await createSecureClient({
-        wallet: walletClient.account.address,
         signer: signerFrom(walletClient),
       });
 
       expect(secureClient.account.walletType).toBe(WalletType.EOA);
 
-      await expect(
-        secureClient.isGaslessReady({
-          wallet: secureClient.account.wallet,
-        }),
-      ).resolves.toBe(false);
+      await expect(secureClient.isGaslessReady()).resolves.toBe(false);
     });
 
     it('supports checking readiness from a public client for an EOA wallet', async () => {
-      const publicClient = createPublicClient();
       const walletClient = createRandomWalletClient();
 
       await expect(
-        publicClient.isGaslessReady({
+        isGaslessReady(publicClientWithRelayerKey, {
           wallet: walletClient.account.address,
         }),
       ).resolves.toBe(false);
@@ -73,7 +59,7 @@ describe('Gasless', () => {
 
   describe('prepareGaslessTransaction', () => {
     it('prepares a single-call workflow without multisend aggregation', async () => {
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
       });
 
@@ -113,7 +99,7 @@ describe('Gasless', () => {
     });
 
     it('prepares a multisend workflow when given multiple calls', async () => {
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
       });
 
@@ -157,7 +143,7 @@ describe('Gasless', () => {
       const signerAddress = expectEvmAddress(walletClient.account.address);
       const proxyWallet = deriveProxyAddress(signerAddress);
 
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
         wallet: proxyWallet,
       });
@@ -199,7 +185,6 @@ describe('Gasless', () => {
     it('rejects for EOA wallet type', async () => {
       const eoaClient = createRandomWalletClient();
       const secureClient = await createSecureClient({
-        wallet: eoaClient.account.address,
         signer: signerFrom(eoaClient),
       });
 
@@ -218,44 +203,5 @@ describe('Gasless', () => {
         }),
       ).rejects.toThrow();
     });
-  });
-
-  describe('prepareGaslessWallet', () => {
-    it.runIf(runMeteredTests)(
-      'deploys a Safe wallet for a new signer',
-      async ({ annotate }) => {
-        const walletClient = createRandomWalletClient();
-        const safeWallet = deriveSafeWalletAddress(
-          expectEvmAddress(walletClient.account.address),
-          publicClientWithBuilderKey.environment.walletDerivation,
-        );
-
-        await expect(
-          publicClientWithBuilderKey.isGaslessReady({
-            wallet: safeWallet,
-          }),
-        ).resolves.toBe(false);
-
-        const secureClient = await createSecureClient({
-          apiKey: builderAuthorization,
-          signer: signerFrom(walletClient),
-          wallet: safeWallet,
-        });
-        const handle = await secureClient.setupGaslessWallet();
-
-        expect(handle.wallet).toBe(safeWallet);
-
-        annotate(`Deployment transaction: ${handle.transactionHash}`);
-
-        await expect(handle.wait()).resolves.toBeTruthy();
-
-        await expect(
-          publicClientWithBuilderKey.isGaslessReady({
-            wallet: safeWallet,
-          }),
-        ).resolves.toBe(true);
-      },
-      20_000,
-    );
   });
 });

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -290,11 +290,11 @@ export async function prepareGaslessWallet(
   }.call(null);
 }
 
-export type SetupGaslessWalletError =
+export type DeployGaslessWalletError =
   | PrepareGaslessWalletError
   | CancelledSigningError
   | SigningError;
-export const SetupGaslessWalletError = makeErrorGuard(
+export const DeployGaslessWalletError = makeErrorGuard(
   CancelledSigningError,
   RateLimitError,
   RequestRejectedError,
@@ -305,12 +305,15 @@ export const SetupGaslessWalletError = makeErrorGuard(
 );
 
 /**
- * Sets up a wallet for gasless transactions.
+ * Deploys a wallet for gasless transactions.
  *
- * @throws {@link SetupGaslessWalletError}
+ * @remarks
+ * This is a low-level action that most SDK consumers will not need.
+ *
+ * @throws {@link DeployGaslessWalletError}
  * Thrown on failure.
  */
-export function setupGaslessWallet(
+export function deployGaslessWallet(
   client: BaseSecureClient,
 ): Promise<DeployTransactionHandle> {
   return prepareGaslessWallet(client).then(completeWith(client.signer));

--- a/packages/client/src/actions/orders.test.ts
+++ b/packages/client/src/actions/orders.test.ts
@@ -8,7 +8,7 @@ import { expectPresent } from '@polymarket/types';
 import { afterAll, describe, expect, it } from 'vitest';
 import { InsufficientLiquidityError } from '../errors';
 import {
-  createTestSecureClient,
+  createSecureClientWithSafeWallet,
   findHighVolumeLowPriceMarket,
   publicClient,
   relayerAuthorization,
@@ -19,7 +19,7 @@ import { fetchNegRisk } from './clob';
 
 const market = await findHighVolumeLowPriceMarket();
 
-const secureClient = await createTestSecureClient();
+const secureClient = await createSecureClientWithSafeWallet();
 
 describe('Orders', { timeout: 60_000 }, () => {
   describe('estimateMarketPrice', () => {
@@ -171,7 +171,7 @@ describe('Orders', { timeout: 60_000 }, () => {
     });
 
     it('requests a collateral approval if necessary', async () => {
-      const gaslessClient = await createTestSecureClient({
+      const gaslessClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
       });
       const exchangeAddress = await resolveExchangeAddressForToken(

--- a/packages/client/src/actions/orders/allowance.ts
+++ b/packages/client/src/actions/orders/allowance.ts
@@ -1,6 +1,6 @@
 import { OrderSide, type TokenId } from '@polymarket/bindings';
 import { AssetType } from '@polymarket/bindings/clob';
-import type { EvmAddress } from '@polymarket/types';
+import { type EvmAddress, isSameEvmAddress } from '@polymarket/types';
 import type { BaseSecureClient } from '../../clients';
 import { fetchBalanceAllowance } from '../account';
 
@@ -38,8 +38,8 @@ function resolveAllowanceAmount(
   allowances: Record<EvmAddress, bigint>,
   spender: EvmAddress,
 ): bigint {
-  const match = Object.entries(allowances).find(
-    ([key]) => key.toLowerCase() === spender.toLowerCase(),
+  const match = (Object.entries(allowances) as [EvmAddress, bigint][]).find(
+    ([key]) => isSameEvmAddress(key, spender),
   );
 
   return match?.[1] ?? 0n;

--- a/packages/client/src/actions/positions.test.ts
+++ b/packages/client/src/actions/positions.test.ts
@@ -2,7 +2,7 @@ import { WalletType } from '@polymarket/bindings/gamma';
 import { expectPresent, invariant } from '@polymarket/types';
 import { describe, expect, it, vi } from 'vitest';
 import {
-  createTestSecureClient,
+  createSecureClientWithSafeWallet,
   publicClient,
   relayerAuthorization,
 } from '../testing';
@@ -14,7 +14,7 @@ const market = await publicClient.fetchMarket({
 });
 const conditionId = expectPresent(market.conditionId);
 
-const secureClient = await createTestSecureClient({
+const secureClient = await createSecureClientWithSafeWallet({
   apiKey: relayerAuthorization,
 });
 

--- a/packages/client/src/actions/subscriptions.test.ts
+++ b/packages/client/src/actions/subscriptions.test.ts
@@ -1,7 +1,7 @@
 import { expectPresent } from '@polymarket/types';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
-  createTestSecureClient,
+  createSecureClientWithSafeWallet,
   findHighVolumeLowPriceMarket,
   publicClient,
 } from '../testing';
@@ -66,7 +66,7 @@ describe('subscribe', () => {
   it('routes secure-only subscriptions when the client supports them', {
     timeout: 20_000,
   }, async () => {
-    const secureClient = await createTestSecureClient();
+    const secureClient = await createSecureClientWithSafeWallet();
 
     try {
       const handle = await secureClient.subscribe([{ topic: 'user' }]);

--- a/packages/client/src/actions/transfers.test.ts
+++ b/packages/client/src/actions/transfers.test.ts
@@ -1,11 +1,14 @@
 import { WalletType } from '@polymarket/bindings/gamma';
 import { describe, expect, it } from 'vitest';
-import { createTestSecureClient, relayerAuthorization } from '../testing';
+import {
+  createSecureClientWithSafeWallet,
+  relayerAuthorization,
+} from '../testing';
 
 describe('Transfers', () => {
   describe('prepareErc20Transfer', () => {
     it('submits a self-transfer for the collateral token', async () => {
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClientWithSafeWallet({
         apiKey: relayerAuthorization,
       });
 

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -5,8 +5,11 @@ import { fetchApiKeys } from './actions';
 import { createSecureClient } from './clients';
 import {
   createRandomWalletClient,
-  createTestSecureClient,
+  createSecureClientWithSafeWallet,
   deriveProxyAddress,
+  relayerAuthorization,
+  runMeteredTests,
+  safeWalletAddress,
   walletClient,
 } from './testing';
 import { signerFrom } from './viem';
@@ -14,23 +17,38 @@ import { signerFrom } from './viem';
 describe('clients', () => {
   describe('createSecureClient', () => {
     it('authenticates a secure client from an authentication workflow', async () => {
-      const secureClient = await createTestSecureClient();
+      const secureClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+      });
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
     it('authenticates with a non-zero nonce', async () => {
-      const secureClient = await createTestSecureClient({ nonce: 1 });
+      const secureClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+        nonce: 1,
+      });
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
     it('authenticates twice with the same nonce', async () => {
-      const firstClient = await createTestSecureClient({ nonce: 2 });
+      const firstClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+        nonce: 2,
+      });
 
       await expect(fetchApiKeys(firstClient)).resolves.toBeDefined();
 
-      const secondClient = await createTestSecureClient({ nonce: 2 });
+      const secondClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+        nonce: 2,
+      });
 
       await expect(fetchApiKeys(secondClient)).resolves.toBeDefined();
     });
@@ -39,7 +57,8 @@ describe('clients', () => {
       const signerAddress = expectEvmAddress(walletClient.account.address);
       const proxyWallet = deriveProxyAddress(signerAddress);
 
-      const secureClient = await createTestSecureClient({
+      const secureClient = await createSecureClient({
+        signer: signerFrom(walletClient),
         wallet: proxyWallet,
       });
 
@@ -50,12 +69,14 @@ describe('clients', () => {
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
-    it('authenticates as EOA when wallet equals signer address', async () => {
-      const signerAddress = walletClient.account.address;
-      const secureClient = await createTestSecureClient({
-        wallet: signerAddress,
+    it('authenticates as EOA when wallet is omitted', async () => {
+      const secureClient = await createSecureClient({
+        signer: signerFrom(walletClient),
       });
 
+      expect(secureClient.account.signer).toBe(walletClient.account.address);
+      expect(secureClient.account.wallet).toBe(walletClient.account.address);
+      expect(secureClient.account.walletType).toBe(WalletType.EOA);
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
@@ -71,17 +92,31 @@ describe('clients', () => {
     });
 
     it('reuses stored credentials during authentication when they remain valid', async () => {
-      const initialClient = await createTestSecureClient();
-      const { credentials } = initialClient;
+      const initialClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+      });
 
-      const secureClient = await createTestSecureClient({ credentials });
+      const secureClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+        credentials: initialClient.credentials,
+      });
 
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
     it('falls back to fresh authentication when stored credentials have been revoked', async () => {
-      const controlClient = await createTestSecureClient({ nonce: 1997 });
-      const secureClient = await createTestSecureClient({ nonce: 1998 });
+      const controlClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+        nonce: 1997,
+      });
+      const secureClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+        nonce: 1998,
+      });
       const { credentials } = secureClient;
       const revokedKey = credentials.key;
 
@@ -89,7 +124,11 @@ describe('clients', () => {
 
       await secureClient.endAuthentication();
 
-      const resumedClient = await createTestSecureClient({ credentials });
+      const resumedClient = await createSecureClient({
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+        credentials,
+      });
       const remainingApiKeys = await fetchApiKeys(controlClient);
 
       expect(resumedClient.credentials.key).not.toBe(revokedKey);
@@ -99,10 +138,50 @@ describe('clients', () => {
     });
   });
 
+  describe('SecureClient.setupGaslessWallet', () => {
+    it('returns a secure client for an already deployed Safe wallet', async () => {
+      const secureClient = await createSecureClient({
+        apiKey: relayerAuthorization,
+        signer: signerFrom(walletClient),
+        wallet: safeWalletAddress,
+      });
+      await expect(secureClient.isGaslessReady()).resolves.toBe(true);
+
+      const gaslessClient = await secureClient.setupGaslessWallet();
+
+      expect(gaslessClient.account.walletType).toBe(
+        WalletType.POLY_GNOSIS_SAFE,
+      );
+    });
+
+    it.runIf(runMeteredTests)(
+      'deploys the signer Safe and returns a secure client bound to it',
+      async () => {
+        const walletClient = createRandomWalletClient();
+
+        const secureClient = await createSecureClient({
+          apiKey: relayerAuthorization,
+          signer: signerFrom(walletClient),
+        });
+
+        await expect(secureClient.isGaslessReady()).resolves.toBe(false);
+
+        const gaslessClient = await secureClient.setupGaslessWallet();
+
+        await expect(gaslessClient.isGaslessReady()).resolves.toBe(true);
+      },
+      20_000,
+    );
+  });
+
   describe('SecureClient.endAuthentication', () => {
     it('returns a public client and invalidates the secure client', async () => {
-      const controlClient = await createTestSecureClient({ nonce: 997 });
-      const secureClient = await createTestSecureClient({ nonce: 998 });
+      const controlClient = await createSecureClientWithSafeWallet({
+        nonce: 997,
+      });
+      const secureClient = await createSecureClientWithSafeWallet({
+        nonce: 998,
+      });
       const revokedKey = secureClient.credentials.key;
       const signer = secureClient.account.signer;
 
@@ -122,7 +201,9 @@ describe('clients', () => {
     });
 
     it('closes active subscription iterators before ending authentication', async () => {
-      const secureClient = await createTestSecureClient({ nonce: 999 });
+      const secureClient = await createSecureClientWithSafeWallet({
+        nonce: 999,
+      });
       const handle = await secureClient.subscribe([{ topic: 'user' }]);
 
       await secureClient.endAuthentication();

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -154,6 +154,22 @@ describe('clients', () => {
       );
     });
 
+    it('returns a secure client bound to the same Proxy wallet', async () => {
+      const signerAddress = expectEvmAddress(walletClient.account.address);
+      const proxyWallet = deriveProxyAddress(signerAddress);
+      const secureClient = await createSecureClient({
+        apiKey: relayerAuthorization,
+        signer: signerFrom(walletClient),
+        wallet: proxyWallet,
+      });
+
+      const gaslessClient = await secureClient.setupGaslessWallet();
+
+      expect(gaslessClient.account.signer).toBe(signerAddress);
+      expect(gaslessClient.account.wallet).toBe(proxyWallet);
+      expect(gaslessClient.account.walletType).toBe(WalletType.POLY_PROXY);
+    });
+
     it.runIf(runMeteredTests)(
       'deploys the signer Safe and returns a secure client bound to it',
       async () => {

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -1,5 +1,6 @@
 import { ApiKeySchema, EvmAddressSchema } from '@polymarket/bindings';
 import type { ApiKeyCreds } from '@polymarket/bindings/clob';
+import { WalletType } from '@polymarket/bindings/gamma';
 import {
   expectEvmAddress,
   expectEvmSignature,
@@ -557,6 +558,13 @@ class BaseSecureClient<
       isSameEvmAddress(signerAddress, this.account.signer),
       'The current signer address does not match the authenticated signer for this client.',
     );
+
+    if (this.account.walletType === WalletType.POLY_PROXY) {
+      return this.#createSecureClientForWallet(
+        this.account.wallet,
+        signerAddress,
+      );
+    }
 
     const safeWallet = deriveSafeWalletAddress(
       signerAddress,

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -8,12 +8,19 @@ import {
 } from '@polymarket/types';
 import { z } from 'zod';
 import type { AccountIdentity } from './account';
-import { resolveAccountIdentity } from './account';
+import { deriveSafeWalletAddress, resolveAccountIdentity } from './account';
 import {
   createOrDeriveApiKey,
   deleteApiKey,
   fetchApiKeys,
 } from './actions/auth';
+import {
+  type DeployGaslessWalletError,
+  deployGaslessWallet,
+  type IsGaslessReadyError,
+  isGaslessReady,
+  type WaitForGaslessTransactionError,
+} from './actions/gasless';
 import { createApiKeyAuthTypedDataPayload } from './authentication';
 import {
   allActions,
@@ -27,6 +34,8 @@ import {
   RateLimitError,
   RequestRejectedError,
   SigningError,
+  TimeoutError,
+  TransactionFailedError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
@@ -509,6 +518,7 @@ class BaseSecureClient<
     return this.context.credentials;
   }
 
+  // TODO remove
   /**
    * The authenticated account identity associated with this client, including the signer and wallet addresses and wallet type.
    */
@@ -524,6 +534,62 @@ class BaseSecureClient<
     );
 
     return this.context.signer;
+  }
+
+  /**
+   * Sets up the authenticated signer's gasless wallet and returns a secure client bound to it.
+   *
+   * @remarks
+   * If the deterministic Safe wallet is already deployed, this reuses the
+   * current credentials and returns a new `SecureClient` for that wallet. If it
+   * is not deployed, this deploys the wallet, waits for settlement, and returns
+   * the new `SecureClient` after deployment.
+   *
+   * @throws {@link SetupGaslessWalletError}
+   * Thrown on failure.
+   */
+  async setupGaslessWallet(): Promise<
+    SecureClient<TPublicActions, TSecureActions>
+  > {
+    const signerAddress = expectEvmAddress(await this.signer.getAddress());
+
+    invariant(
+      signerAddress.toLowerCase() === this.account.signer.toLowerCase(),
+      'Wallet client address does not match the authenticated signer',
+    );
+
+    const safeWallet = deriveSafeWalletAddress(
+      signerAddress,
+      this.environment.walletDerivation,
+    );
+
+    if (await isGaslessReady(this, { wallet: safeWallet })) {
+      return this.#createSecureClientForWallet(safeWallet, signerAddress);
+    }
+
+    const handle = await deployGaslessWallet(this);
+    await handle.wait();
+
+    return this.#createSecureClientForWallet(handle.wallet, signerAddress);
+  }
+
+  #createSecureClientForWallet(
+    wallet: AccountIdentity['wallet'],
+    signerAddress: AccountIdentity['signer'],
+  ): SecureClient<TPublicActions, TSecureActions> {
+    const client = new BaseSecureClient<TPublicActions, TSecureActions>({
+      account: resolveAccountIdentity(this.environment, signerAddress, wallet),
+      apiKey: this.context.apiKey,
+      credentials: this.credentials,
+      environment: this.environment,
+      signer: this.context.signer,
+    });
+
+    for (const decorator of this.decorators) {
+      client.extend(decorator);
+    }
+
+    return client as SecureClient<TPublicActions, TSecureActions>;
   }
 
   /** @internal */
@@ -725,11 +791,16 @@ export type PublicClientOptions = {
 
 export type SecureClientOptions = PublicClientOptions & {
   /**
-   * Wallet address to authenticate as.
+   * Wallet address to use as the account wallet.
    *
-   * Pass the signer address itself to authenticate as an EOA account.
+   * If omitted, the client uses the signer address as the account wallet and
+   * operates as an EOA account. EOA clients do not use gasless relayer flows:
+   * approvals, transfers, and other wallet operations are submitted directly by
+   * the signer and require the signer wallet to hold gas. Pass a supported Poly Safe
+   * or Poly Proxy wallet address to use that wallet as the account/funder and enable
+   * gasless wallet operations when an API key strategy supports them.
    */
-  wallet: string;
+  wallet?: string;
 
   /**
    * Wallet-library adapter used to authenticate and complete wallet operations.
@@ -789,6 +860,22 @@ export const CreateSecureClientError = makeErrorGuard(
   UserInputError,
 );
 
+export type SetupGaslessWalletError =
+  | DeployGaslessWalletError
+  | IsGaslessReadyError
+  | WaitForGaslessTransactionError;
+export const SetupGaslessWalletError = makeErrorGuard(
+  CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
+  SigningError,
+  TimeoutError,
+  TransactionFailedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
 /**
  * Creates a new authenticated `SecureClient` instance.
  *
@@ -796,7 +883,6 @@ export const CreateSecureClientError = makeErrorGuard(
  * ```ts
  * const secureClient = await createSecureClient({
  *   signer,
- *   wallet,
  * });
  * ```
  *
@@ -810,11 +896,12 @@ export async function createSecureClient(
     environment: options.environment,
     apiKey: options.apiKey,
   });
+  const wallet = options.wallet ?? (await options.signer.getAddress());
 
   return client
     .beginAuthentication(
       {
-        wallet: options.wallet,
+        wallet,
         credentials: options.credentials,
         nonce: options.nonce,
       },

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -4,6 +4,7 @@ import {
   expectEvmAddress,
   expectEvmSignature,
   invariant,
+  isSameEvmAddress,
   type Prettify,
 } from '@polymarket/types';
 import { z } from 'zod';
@@ -518,7 +519,6 @@ class BaseSecureClient<
     return this.context.credentials;
   }
 
-  // TODO remove
   /**
    * The authenticated account identity associated with this client, including the signer and wallet addresses and wallet type.
    */
@@ -554,8 +554,8 @@ class BaseSecureClient<
     const signerAddress = expectEvmAddress(await this.signer.getAddress());
 
     invariant(
-      signerAddress.toLowerCase() === this.account.signer.toLowerCase(),
-      'Wallet client address does not match the authenticated signer',
+      isSameEvmAddress(signerAddress, this.account.signer),
+      'The current signer address does not match the authenticated signer for this client.',
     );
 
     const safeWallet = deriveSafeWalletAddress(

--- a/packages/client/src/decorators/index.ts
+++ b/packages/client/src/decorators/index.ts
@@ -23,11 +23,7 @@ import {
   subscriptionsActions,
 } from './subscriptions';
 import { type TradingActions, tradingActions } from './trading';
-import {
-  type PublicWalletActions,
-  type SecureWalletActions,
-  walletActions,
-} from './wallet';
+import { type WalletActions, walletActions } from './wallet';
 
 export type PublicActions = Prettify<
   DiscoveryActions &
@@ -35,8 +31,7 @@ export type PublicActions = Prettify<
     AnalyticsActions &
     AccountPublicActions &
     RewardsPublicActions &
-    PublicSubscriptionsActions &
-    PublicWalletActions
+    PublicSubscriptionsActions
 >;
 
 export type SecureActions = Prettify<
@@ -46,7 +41,7 @@ export type SecureActions = Prettify<
     AccountActions &
     RewardsActions &
     SecureSubscriptionsActions &
-    SecureWalletActions &
+    WalletActions &
     TradingActions
 >;
 
@@ -73,7 +68,6 @@ export function allActions(client: BaseClient): PublicActions | SecureActions {
     ...discoveryActions(client),
     ...rewardsActions(client),
     ...subscriptionsActions(client),
-    ...walletActions(client),
   };
 }
 

--- a/packages/client/src/decorators/wallet.ts
+++ b/packages/client/src/decorators/wallet.ts
@@ -1,8 +1,7 @@
-import type { Prettify } from '@polymarket/types';
+import { deriveSafeWalletAddress } from '../account';
 import {
   approveErc20,
   approveErc1155ForAll,
-  type IsGaslessReadyRequest,
   isGaslessReady,
   mergePositions,
   type PrepareErc20ApprovalRequest,
@@ -12,212 +11,183 @@ import {
   type PrepareRedeemPositionsRequest,
   type PrepareSplitPositionRequest,
   redeemPositions,
-  setupGaslessWallet,
   setupTradingApprovals,
   splitPosition,
   transferErc20,
 } from '../actions';
-import type {
-  BaseClient,
-  BasePublicClient,
-  BaseSecureClient,
-} from '../clients';
-import type { DeployTransactionHandle, TransactionHandle } from '../types';
+import type { BaseSecureClient } from '../clients';
+import type { TransactionHandle } from '../types';
 
-export type PublicWalletActions = {
+export type WalletActions = {
   /**
-   * Checks whether a wallet is ready for gasless transactions.
+   * Checks whether the authenticated signer's Safe wallet is ready for gasless transactions.
    *
    * @throws {@link IsGaslessReadyError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const ready = await client.isGaslessReady({
-   *   wallet: '0x1234...',
-   * });
+   * const ready = await client.isGaslessReady();
    * ```
    */
-  isGaslessReady(request: IsGaslessReadyRequest): Promise<boolean>;
+  isGaslessReady(): Promise<boolean>;
+  /**
+   * Sets up the approvals required for trading.
+   *
+   * @throws {@link SetupTradingApprovalsError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const handle = await client.setupTradingApprovals();
+   *
+   * const outcome = await handle.wait();
+   *
+   * // outcome.transactionHash: TxHash
+   * ```
+   */
+  setupTradingApprovals(): Promise<TransactionHandle>;
+  /**
+   * Approves ERC-20 token spending for the authenticated account.
+   *
+   * @throws {@link ApproveErc20Error}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const handle = await client.approveErc20({
+   *   amount: 'max',
+   *   spenderAddress: '0x1234…',
+   *   tokenAddress: '0x5678…',
+   * });
+   *
+   * const outcome = await handle.wait();
+   *
+   * // outcome.transactionHash: TxHash
+   * ```
+   */
+  approveErc20(
+    request: PrepareErc20ApprovalRequest,
+  ): Promise<TransactionHandle>;
+  /**
+   * Approves or revokes ERC-1155 operator access for the authenticated account.
+   *
+   * @throws {@link ApproveErc1155ForAllError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const handle = await client.approveErc1155ForAll({
+   *   operatorAddress: '0x1234…',
+   *   tokenAddress: '0x5678…',
+   * });
+   *
+   * const outcome = await handle.wait();
+   *
+   * // outcome.transactionHash: TxHash
+   * ```
+   */
+  approveErc1155ForAll(
+    request: PrepareErc1155ApprovalForAllRequest,
+  ): Promise<TransactionHandle>;
+  /**
+   * Transfers ERC-20 tokens from the authenticated account.
+   *
+   * @throws {@link TransferErc20Error}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const handle = await client.transferErc20({
+   *   amount: 1n,
+   *   recipientAddress: client.account.signer,
+   *   tokenAddress: client.environment.collateralToken,
+   * });
+   *
+   * const outcome = await handle.wait();
+   *
+   * // outcome.transactionHash: TxHash
+   * ```
+   */
+  transferErc20(
+    request: PrepareErc20TransferRequest,
+  ): Promise<TransactionHandle>;
+  /**
+   * Splits collateral into market positions.
+   *
+   * @throws {@link SplitPositionError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const handle = await client.splitPosition({
+   *   amount: 1n,
+   *   conditionId:
+   *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+   * });
+   *
+   * const outcome = await handle.wait();
+   *
+   * // outcome.transactionHash: TxHash
+   * ```
+   */
+  splitPosition(
+    request: PrepareSplitPositionRequest,
+  ): Promise<TransactionHandle>;
+  /**
+   * Merges complementary market positions back into collateral.
+   *
+   * @throws {@link MergePositionsError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const handle = await client.mergePositions({
+   *   amount: 'max',
+   *   conditionId:
+   *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+   * });
+   *
+   * const outcome = await handle.wait();
+   *
+   * // outcome.transactionHash: TxHash
+   * ```
+   */
+  mergePositions(
+    request: PrepareMergePositionsRequest,
+  ): Promise<TransactionHandle>;
+  /**
+   * Redeems resolved market positions.
+   *
+   * @throws {@link RedeemPositionsError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const handle = await client.redeemPositions({
+   *   conditionId:
+   *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+   * });
+   *
+   * const outcome = await handle.wait();
+   *
+   * // outcome.transactionHash: TxHash
+   * ```
+   */
+  redeemPositions(
+    request: PrepareRedeemPositionsRequest,
+  ): Promise<TransactionHandle>;
 };
 
-export type SecureWalletActions = Prettify<
-  PublicWalletActions & {
-    /**
-     * Sets up the approvals required for trading.
-     *
-     * @throws {@link SetupTradingApprovalsError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const handle = await client.setupTradingApprovals();
-     *
-     * const outcome = await handle.wait();
-     *
-     * // outcome.transactionHash: TxHash
-     * ```
-     */
-    setupTradingApprovals(): Promise<TransactionHandle>;
-    /**
-     * Approves ERC-20 token spending for the authenticated account.
-     *
-     * @throws {@link ApproveErc20Error}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const handle = await client.approveErc20({
-     *   amount: 'max',
-     *   spenderAddress: '0x1234…',
-     *   tokenAddress: '0x5678…',
-     * });
-     *
-     * const outcome = await handle.wait();
-     *
-     * // outcome.transactionHash: TxHash
-     * ```
-     */
-    approveErc20(
-      request: PrepareErc20ApprovalRequest,
-    ): Promise<TransactionHandle>;
-    /**
-     * Approves or revokes ERC-1155 operator access for the authenticated account.
-     *
-     * @throws {@link ApproveErc1155ForAllError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const handle = await client.approveErc1155ForAll({
-     *   operatorAddress: '0x1234…',
-     *   tokenAddress: '0x5678…',
-     * });
-     *
-     * const outcome = await handle.wait();
-     *
-     * // outcome.transactionHash: TxHash
-     * ```
-     */
-    approveErc1155ForAll(
-      request: PrepareErc1155ApprovalForAllRequest,
-    ): Promise<TransactionHandle>;
-    /**
-     * Transfers ERC-20 tokens from the authenticated account.
-     *
-     * @throws {@link TransferErc20Error}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const handle = await client.transferErc20({
-     *   amount: 1n,
-     *   recipientAddress: client.account.signer,
-     *   tokenAddress: client.environment.collateralToken,
-     * });
-     *
-     * const outcome = await handle.wait();
-     *
-     * // outcome.transactionHash: TxHash
-     * ```
-     */
-    transferErc20(
-      request: PrepareErc20TransferRequest,
-    ): Promise<TransactionHandle>;
-    /**
-     * Splits collateral into market positions.
-     *
-     * @throws {@link SplitPositionError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const handle = await client.splitPosition({
-     *   amount: 1n,
-     *   conditionId:
-     *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-     * });
-     *
-     * const outcome = await handle.wait();
-     *
-     * // outcome.transactionHash: TxHash
-     * ```
-     */
-    splitPosition(
-      request: PrepareSplitPositionRequest,
-    ): Promise<TransactionHandle>;
-    /**
-     * Merges complementary market positions back into collateral.
-     *
-     * @throws {@link MergePositionsError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const handle = await client.mergePositions({
-     *   amount: 'max',
-     *   conditionId:
-     *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-     * });
-     *
-     * const outcome = await handle.wait();
-     *
-     * // outcome.transactionHash: TxHash
-     * ```
-     */
-    mergePositions(
-      request: PrepareMergePositionsRequest,
-    ): Promise<TransactionHandle>;
-    /**
-     * Redeems resolved market positions.
-     *
-     * @throws {@link RedeemPositionsError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const handle = await client.redeemPositions({
-     *   conditionId:
-     *     '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
-     * });
-     *
-     * const outcome = await handle.wait();
-     *
-     * // outcome.transactionHash: TxHash
-     * ```
-     */
-    redeemPositions(
-      request: PrepareRedeemPositionsRequest,
-    ): Promise<TransactionHandle>;
-    /**
-     * Sets up a wallet for gasless transactions.
-     *
-     * @throws {@link SetupGaslessWalletError}
-     * Thrown on failure.
-     */
-    setupGaslessWallet(): Promise<DeployTransactionHandle>;
-  }
->;
-
-function publicWalletActions(client: BaseClient): PublicWalletActions {
+export function walletActions(client: BaseSecureClient): WalletActions {
   return {
-    isGaslessReady: isGaslessReady.bind(null, client),
-  };
-}
-
-export function walletActions(client: BasePublicClient): PublicWalletActions;
-export function walletActions(client: BaseSecureClient): SecureWalletActions;
-export function walletActions(
-  client: BaseClient,
-): PublicWalletActions | SecureWalletActions {
-  const actions = publicWalletActions(client);
-
-  if (client.isPublicClient()) {
-    return actions;
-  }
-
-  return {
-    ...actions,
+    isGaslessReady: () =>
+      isGaslessReady(client, {
+        wallet: deriveSafeWalletAddress(
+          client.account.signer,
+          client.environment.walletDerivation,
+        ),
+      }),
     setupTradingApprovals: setupTradingApprovals.bind(null, client),
     approveErc20: approveErc20.bind(null, client),
     approveErc1155ForAll: approveErc1155ForAll.bind(null, client),
@@ -225,20 +195,18 @@ export function walletActions(
     splitPosition: splitPosition.bind(null, client),
     mergePositions: mergePositions.bind(null, client),
     redeemPositions: redeemPositions.bind(null, client),
-    setupGaslessWallet: setupGaslessWallet.bind(null, client),
   };
 }
 
 // Error unions and runtime `isError` guards for every action bound above.
 // Surfaced at the root entry point through `export * from './decorators'`.
-// Keep this list in sync with the methods on PublicWalletActions / SecureWalletActions.
+// Keep this list in sync with the methods on SecureWalletActions.
 export {
   ApproveErc20Error,
   ApproveErc1155ForAllError,
   IsGaslessReadyError,
   MergePositionsError,
   RedeemPositionsError,
-  SetupGaslessWalletError,
   SetupTradingApprovalsError,
   SplitPositionError,
   TransferErc20Error,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -18,6 +18,7 @@ export {
   CreateSecureClientError,
   createPublicClient,
   createSecureClient,
+  SetupGaslessWalletError,
 } from './clients';
 export * from './decorators';
 export * from './environments';

--- a/packages/client/src/privy.test.ts
+++ b/packages/client/src/privy.test.ts
@@ -13,7 +13,6 @@ import {
   fetchBalanceAllowance,
   fetchMarket,
 } from './actions';
-import { isGaslessReady } from './actions/gasless';
 import { createSecureClient } from './clients';
 import { type PrivyWalletConfig, signerFrom } from './privy';
 import {
@@ -33,7 +32,7 @@ const hasPrivyTestConfig =
 describe.runIf(hasPrivyTestConfig)('privy', () => {
   let hasCollateralBalance = false;
   let wallet: PrivyWalletConfig;
-  let safeWalletAddress: `0x${string}`;
+  let walletAddress: `0x${string}`;
 
   beforeAll(async () => {
     const privy = new PrivyClient({
@@ -49,32 +48,28 @@ describe.runIf(hasPrivyTestConfig)('privy', () => {
       privy,
       walletId,
     };
-    safeWalletAddress = deriveSafeWalletAddress(
+    walletAddress = deriveSafeWalletAddress(
       signerAddress,
       publicClientWithBuilderKey.environment.walletDerivation,
     );
 
-    if (
-      !(await isGaslessReady(publicClientWithBuilderKey, {
-        wallet: safeWalletAddress,
-      }))
-    ) {
-      const secureClient = await createSecureClient({
-        apiKey: builderAuthorization,
-        signer: signerFrom(wallet),
-        wallet: safeWalletAddress,
-      });
-      const handle = await secureClient.setupGaslessWallet();
+    const secureClient = await createSecureClient({
+      apiKey: builderAuthorization,
+      signer: signerFrom(wallet),
+      wallet: walletAddress,
+    });
 
-      expect(handle.wallet).toBe(safeWalletAddress);
-      await handle.wait();
+    if (!(await secureClient.isGaslessReady())) {
+      const gaslessClient = await secureClient.setupGaslessWallet();
+
+      expect(gaslessClient.account.wallet).toBe(walletAddress);
     }
 
     if (runMeteredTests) {
       const secureClient = await createSecureClient({
         apiKey: builderAuthorization,
         signer: signerFrom(wallet),
-        wallet: safeWalletAddress,
+        wallet: walletAddress,
       });
 
       hasCollateralBalance =
@@ -95,7 +90,7 @@ describe.runIf(hasPrivyTestConfig)('privy', () => {
   it('authenticates a secure client', async () => {
     const secureClient = await createSecureClient({
       signer: signerFrom(wallet),
-      wallet: safeWalletAddress,
+      wallet: walletAddress,
     });
 
     await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
@@ -112,7 +107,7 @@ describe.runIf(hasPrivyTestConfig)('privy', () => {
       const size = expectPresent(market.trading.minimumOrderSize);
       const secureClient = await createSecureClient({
         signer: signerFrom(wallet),
-        wallet: safeWalletAddress,
+        wallet: walletAddress,
       });
 
       if (!hasCollateralBalance) {

--- a/packages/client/src/testing.ts
+++ b/packages/client/src/testing.ts
@@ -14,7 +14,11 @@ import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { polygon } from 'viem/chains';
 import { deriveProxyWalletAddress } from './account';
 import { relayerApiKey } from './authorization';
-import { createPublicClient, createSecureClient } from './clients';
+import {
+  createPublicClient,
+  createSecureClient,
+  type SecureClientOptions,
+} from './clients';
 // biome-ignore lint/style/noRestrictedImports: intentional
 import { builderApiKey } from './node';
 import type { Page } from './pagination';
@@ -103,8 +107,8 @@ export const walletClient = createWalletClient({
   transport: http(),
 });
 
-export function createTestSecureClient(
-  options: Partial<Parameters<typeof createSecureClient>[0]> = {},
+export function createSecureClientWithSafeWallet(
+  options: Partial<SecureClientOptions> = {},
 ) {
   return createSecureClient({
     signer: signerFrom(walletClient),

--- a/packages/types/src/hex.ts
+++ b/packages/types/src/hex.ts
@@ -33,6 +33,13 @@ export function isHexString(value: unknown): value is HexString {
 }
 
 /**
+ * Returns `true` when two EVM addresses are equal, ignoring checksum casing.
+ */
+export function isSameEvmAddress(left: EvmAddress, right: EvmAddress): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+/**
  * Checks whether a value is a hex-encoded 32-byte private key.
  */
 export function isPrivateKey(value: unknown): value is PrivateKey {


### PR DESCRIPTION
## Summary
- Add `SecureClient.setupGaslessWallet()` to set up the authenticated signer’s gasless wallet and return an appropriately bound secure client.
- Make secure client wallet handling support EOA defaults, Safe/proxy account identity, and Proxy idempotency for transitional gasless setup.
- Update SDK direction notes for upcoming Deposit Wallet migration and clarify account identity/address comparison helpers.

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

Live client tests were not run because the API/Cloudflare path is currently unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes secure-client wallet identity defaults and adds a new gasless wallet setup flow that can deploy wallets/submit relayer transactions, affecting auth and transaction routing behavior.
> 
> **Overview**
> Adds `SecureClient.setupGaslessWallet()` to ensure the authenticated signer has a deployed gasless Safe and returns a *new* secure client bound to the correct wallet (idempotent for already-deployed Safes and *preserves Proxy-bound clients*).
> 
> Updates `createSecureClient` to make `wallet` optional (defaulting to the signer address for EOA mode), consolidates address equality via new `isSameEvmAddress`, and refactors wallet decorators so gasless readiness is a secure-only method (`client.isGaslessReady()` with no parameters). Renames the low-level gasless wallet action to `deployGaslessWallet`, fixes the API key creation path (`/auth/api-key`), and updates tests/docs to match the new wallet/setup semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56f3ab463d2e685d1812f2b214c971fb97eb9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->