### PR TITLE
Add secure client gasless wallet setup

### DIFF
--- a/packages/client/src/viem.test.ts
+++ b/packages/client/src/viem.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { UserInputError } from './errors';
+import { privateKey } from './viem';
+
+const TEST_PRIVATE_KEY =
+  '0x0000000000000000000000000000000000000000000000000000000000000001';
+
+describe('viem', () => {
+  describe('privateKey', () => {
+    it('creates a signer from a private key', async () => {
+      const signer = privateKey(TEST_PRIVATE_KEY);
+
+      await expect(signer.getAddress()).resolves.toBe(
+        '0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf',
+      );
+      await expect(signer.signMessage('0x1234')).resolves.toMatch(
+        /^0x[0-9a-f]+$/i,
+      );
+      await expect(
+        signer.signTypedData({
+          domain: {
+            chainId: 137,
+            name: 'Polymarket SDK Test',
+            version: '1',
+          },
+          message: {
+            value: 'hello',
+          },
+          primaryType: 'TestMessage',
+          types: {
+            TestMessage: [{ name: 'value', type: 'string' }],
+          },
+        }),
+      ).resolves.toMatch(/^0x[0-9a-f]+$/i);
+    });
+
+    it('rejects invalid private keys', () => {
+      expect(() => privateKey(undefined)).toThrow(UserInputError);
+      expect(() => privateKey('0x1234')).toThrow(UserInputError);
+    });
+  });
+});

--- a/packages/client/src/viem.ts
+++ b/packages/client/src/viem.ts
@@ -3,12 +3,16 @@ import {
   expectEvmSignature,
   expectTxHash,
   invariant,
+  isPrivateKey,
+  type PrivateKey,
   type TxHash,
 } from '@polymarket/types';
 import {
   type Account,
   type Chain,
+  createWalletClient,
   type Hash,
+  http,
   type SendTransactionParameters,
   type SendTransactionRequest,
   TransactionExecutionError,
@@ -17,15 +21,25 @@ import {
   WaitForTransactionReceiptTimeoutError,
   type WalletClient,
 } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
 import { waitForTransactionReceipt } from 'viem/actions';
+import { polygon } from 'viem/chains';
 import {
   CancelledSigningError,
   SigningError,
   TimeoutError,
   TransactionFailedError,
   TransportError,
+  UserInputError,
 } from './errors';
 import type { Signer, TransactionHandle } from './types';
+
+export type PrivateKeySignerOptions = {
+  /** Chain used when sending direct EOA transactions. */
+  chain?: Chain;
+  /** Transport used when sending direct EOA transactions. */
+  transport?: Transport;
+};
 
 function isWalletClientWithAccount(
   walletClient: WalletClient,
@@ -75,6 +89,34 @@ export function signerFrom(walletClient: WalletClient): Signer {
       return new DirectTransactionHandle(hash, walletClient);
     },
   };
+}
+
+/**
+ * Creates a signer from a private key using viem local account signing.
+ *
+ * @example
+ * ```ts
+ * const secureClient = await createSecureClient({
+ *   signer: privateKey(process.env.PRIVATE_KEY),
+ *   wallet: '0x...',
+ * });
+ * ```
+ */
+export function privateKey(
+  value: PrivateKey | string | undefined,
+  options: PrivateKeySignerOptions = {},
+): Signer {
+  if (!isPrivateKey(value)) {
+    throw new UserInputError('Expected a hex-encoded 32-byte private key.');
+  }
+
+  return signerFrom(
+    createWalletClient({
+      account: privateKeyToAccount(value),
+      chain: options.chain ?? polygon,
+      transport: options.transport ?? http(),
+    }),
+  );
 }
 
 async function sendTransaction<


### PR DESCRIPTION
## Summary
- Add `SecureClient.setupGaslessWallet()` to set up or reuse gasless-capable wallets and return an appropriately bound secure client.
- Support EOA defaults, Safe/proxy account identity, Proxy idempotency, and account identity documentation.
- Add `privateKey(...)` to `@polymarket/client/viem` so private-key server integrations can create secure clients directly.
- Document the upcoming Deposit Wallet direction and transitional gasless-wallet behavior.

## Testing
- `pnpm test:client src/viem.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

Live client tests were not run because the API/Cloudflare path is currently unavailable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new private-key-based signing path (including default chain/transport), which can affect transaction signing/sending behavior if misused, though existing signer flows are unchanged.
> 
> **Overview**
> Adds a new `privateKey(...)` helper in `packages/client/src/viem.ts` to build a `Signer` from a hex-encoded 32-byte private key using viem’s local account, with optional `chain`/`transport` overrides and validation that throws `UserInputError` on bad input.
> 
> Adds `viem.test.ts` coverage to verify address derivation plus `signMessage`/`signTypedData` behavior and to assert invalid keys are rejected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f06885f917e5ac90cc7344e6978384a913ba831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->