### PR TITLE
Support Polymarket URLs in fetch actions

### DIFF
--- a/packages/client/src/actions/events.test.ts
+++ b/packages/client/src/actions/events.test.ts
@@ -1,5 +1,6 @@
 import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
+import { UserInputError } from '../errors';
 import { expectNonEmptyPage, publicClient } from '../testing';
 
 describe('Events', () => {
@@ -48,6 +49,44 @@ describe('Events', () => {
 
       expect(eventById.id).toBe(event.id);
       expect(eventBySlug.id).toBe(event.id);
+    });
+
+    it('fetches an event by URL', async () => {
+      const {
+        items: [event],
+      } = await publicClient
+        .listEvents({
+          closed: false,
+          pageSize: 1,
+        })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      const eventByUrl = await publicClient.fetchEvent({
+        url: `https://polymarket.com/event/${expectPresent(event.slug)}`,
+      });
+
+      expect(eventByUrl.id).toBe(event.id);
+    });
+
+    it('rejects invalid and non-event URLs', async () => {
+      await expect(
+        publicClient.fetchEvent({
+          url: 'not-a-url',
+        }),
+      ).rejects.toThrow(UserInputError);
+
+      await expect(
+        publicClient.fetchEvent({
+          url: 'https://example.com/event/presidential-election-2028',
+        }),
+      ).rejects.toThrow(UserInputError);
+
+      await expect(
+        publicClient.fetchEvent({
+          url: 'https://polymarket.com/market/some-market-slug',
+        }),
+      ).rejects.toThrow(UserInputError);
     });
   });
 

--- a/packages/client/src/actions/events.ts
+++ b/packages/client/src/actions/events.ts
@@ -27,6 +27,7 @@ import {
 } from '../errors';
 import { parseUserInput } from '../input';
 import { PageSizeSchema, type Paginated, paginate } from '../pagination';
+import { parsePolymarketSlugUrl } from '../polymarket-url';
 import { validateWith } from '../response';
 import { snakeCase, toDataSearchParams, toSearchParams } from './params';
 
@@ -85,6 +86,13 @@ const FetchEventRequestSchema = z.union([
   }),
   z.object({
     slug: z.string(),
+    includeBestLines: z.boolean().optional(),
+    includeChat: z.boolean().optional(),
+    includeTemplate: z.boolean().optional(),
+    locale: z.string().optional(),
+  }),
+  z.object({
+    url: z.string(),
     includeBestLines: z.boolean().optional(),
     includeChat: z.boolean().optional(),
     includeTemplate: z.boolean().optional(),
@@ -210,6 +218,14 @@ export const FetchEventError = makeErrorGuard(
  *   id: '12345',
  * });
  *
+ * const eventBySlug = await fetchEvent(client, {
+ *   slug: 'presidential-election-2028',
+ * });
+ *
+ * const eventByUrl = await fetchEvent(client, {
+ *   url: 'https://polymarket.com/event/presidential-election-2028',
+ * });
+ *
  * // event === Event
  * ```
  */
@@ -229,9 +245,12 @@ export async function fetchEvent(
     );
   }
 
+  const slug =
+    'url' in params ? parsePolymarketSlugUrl(params.url, 'event') : params.slug;
+
   return unwrap(
     client.gamma
-      .get(`events/slug/${params.slug}`, {
+      .get(`events/slug/${slug}`, {
         params: toFetchEventBySlugSearchParams(params),
       })
       .andThen(validateWith(EventSchema)),
@@ -354,7 +373,10 @@ function toFetchEventByIdSearchParams(
 }
 
 function toFetchEventBySlugSearchParams(
-  params: Extract<z.output<typeof FetchEventRequestSchema>, { slug: string }>,
+  params: Extract<
+    z.output<typeof FetchEventRequestSchema>,
+    { slug: string } | { url: string }
+  >,
 ): URLSearchParams {
   return toSearchParams(
     {

--- a/packages/client/src/actions/markets.test.ts
+++ b/packages/client/src/actions/markets.test.ts
@@ -1,5 +1,6 @@
 import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from 'vitest';
+import { UserInputError } from '../errors';
 import { expectNonEmptyPage, publicClient } from '../testing';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
@@ -64,6 +65,44 @@ describe('Markets', () => {
 
       expect(marketById.id).toBe(market.id);
       expect(marketBySlug.id).toBe(market.id);
+    });
+
+    it('fetches a market by URL', async () => {
+      const {
+        items: [market],
+      } = await publicClient
+        .listMarkets({
+          closed: false,
+          pageSize: 1,
+        })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      const marketByUrl = await publicClient.fetchMarket({
+        url: `https://polymarket.com/market/${expectPresent(market.slug)}`,
+      });
+
+      expect(marketByUrl.id).toBe(market.id);
+    });
+
+    it('rejects invalid and non-market URLs', async () => {
+      await expect(
+        publicClient.fetchMarket({
+          url: 'not-a-url',
+        }),
+      ).rejects.toThrow(UserInputError);
+
+      await expect(
+        publicClient.fetchMarket({
+          url: 'https://example.com/market/some-market-slug',
+        }),
+      ).rejects.toThrow(UserInputError);
+
+      await expect(
+        publicClient.fetchMarket({
+          url: 'https://polymarket.com/event/presidential-election-2028',
+        }),
+      ).rejects.toThrow(UserInputError);
     });
   });
 

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -36,6 +36,7 @@ import {
   type Paginated,
   paginate,
 } from '../pagination';
+import { parsePolymarketSlugUrl } from '../polymarket-url';
 import { validateWith } from '../response';
 import { snakeCase, toDataSearchParams, toSearchParams } from './params';
 
@@ -88,9 +89,16 @@ const FetchMarketBySlugRequestSchema = z.object({
   locale: z.string().optional(),
 });
 
+const FetchMarketByUrlRequestSchema = z.object({
+  url: z.string(),
+  includeTag: z.boolean().optional(),
+  locale: z.string().optional(),
+});
+
 const FetchMarketRequestSchema = z.union([
   FetchMarketByIdRequestSchema,
   FetchMarketBySlugRequestSchema,
+  FetchMarketByUrlRequestSchema,
 ]);
 
 export type FetchMarketRequest = z.input<typeof FetchMarketRequestSchema>;
@@ -244,6 +252,14 @@ export const FetchMarketError = makeErrorGuard(
  *   id: '12345',
  * });
  *
+ * const marketBySlug = await fetchMarket(client, {
+ *   slug: 'some-market-slug',
+ * });
+ *
+ * const marketByUrl = await fetchMarket(client, {
+ *   url: 'https://polymarket.com/market/some-market-slug',
+ * });
+ *
  * // market === Market
  * ```
  */
@@ -255,6 +271,14 @@ export async function fetchMarket(
 
   if ('id' in params) {
     return fetchMarketById(client, params);
+  }
+
+  if ('url' in params) {
+    return fetchMarketBySlug(client, {
+      includeTag: params.includeTag,
+      locale: params.locale,
+      slug: parsePolymarketSlugUrl(params.url, 'market'),
+    });
   }
 
   return fetchMarketBySlug(client, params);

--- a/packages/client/src/decorators/discovery.ts
+++ b/packages/client/src/decorators/discovery.ts
@@ -106,6 +106,14 @@ export type DiscoveryActions = {
    * const event = await client.fetchEvent({
    *   id: '123',
    * });
+   *
+   * const eventBySlug = await client.fetchEvent({
+   *   slug: 'presidential-election-2028',
+   * });
+   *
+   * const eventByUrl = await client.fetchEvent({
+   *   url: 'https://polymarket.com/event/presidential-election-2028',
+   * });
    * ```
    */
   fetchEvent(request: FetchEventRequest): Promise<Event>;
@@ -172,6 +180,14 @@ export type DiscoveryActions = {
    * ```ts
    * const market = await client.fetchMarket({
    *   id: '12345',
+   * });
+   *
+   * const marketBySlug = await client.fetchMarket({
+   *   slug: 'some-market-slug',
+   * });
+   *
+   * const marketByUrl = await client.fetchMarket({
+   *   url: 'https://polymarket.com/market/some-market-slug',
    * });
    * ```
    */

--- a/packages/client/src/polymarket-url.ts
+++ b/packages/client/src/polymarket-url.ts
@@ -1,0 +1,37 @@
+import { UserInputError } from './errors';
+
+type PolymarketUrlResource = 'event' | 'market';
+
+export function parsePolymarketSlugUrl(
+  rawUrl: string,
+  resource: PolymarketUrlResource,
+): string {
+  let url: URL;
+
+  try {
+    url = new URL(rawUrl);
+  } catch (cause) {
+    throw new UserInputError('Expected a valid Polymarket URL.', { cause });
+  }
+
+  if (
+    url.protocol !== 'https:' ||
+    (url.hostname !== 'polymarket.com' && url.hostname !== 'www.polymarket.com')
+  ) {
+    throw new UserInputError('Expected a valid Polymarket URL.');
+  }
+
+  const [actualResource, slug, ...extraSegments] = url.pathname
+    .split('/')
+    .filter(Boolean);
+
+  if (
+    actualResource !== resource ||
+    slug === undefined ||
+    extraSegments.length > 0
+  ) {
+    throw new UserInputError(`Expected a Polymarket ${resource} URL.`);
+  }
+
+  return slug;
+}


### PR DESCRIPTION
## Summary
- Add URL request support for `fetchEvent` and `fetchMarket` while preserving existing return types.
- Parse Polymarket event and market URLs into slugs and reject malformed, external, or wrong-resource URLs with `UserInputError`.
- Cover URL fetch and validation behavior in focused client action tests, and update public TSDoc examples.

## Verification
- `pnpm vitest --project client packages/client/src/actions/events.test.ts packages/client/src/actions/markets.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an additional `url` input path that is parsed/validated into an existing slug fetch, plus new tests; main risk is overly-strict URL parsing rejecting some previously acceptable inputs.
> 
> **Overview**
> Adds `url` as a supported request variant for `fetchEvent` and `fetchMarket`, extracting the slug from `https://polymarket.com/(event|market)/:slug` and then reusing the existing slug-based Gamma fetch.
> 
> Introduces `parsePolymarketSlugUrl` to validate protocol/host/path and throw `UserInputError` for malformed, external, or wrong-resource URLs, and updates TSDoc examples and action tests to cover URL fetching and rejection cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a8a43985d64cd887641d4fb1d34a861f9953a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->