### PR TITLE
Align search with SDK pagination

### DIFF
--- a/packages/client/src/actions/account.ts
+++ b/packages/client/src/actions/account.ts
@@ -142,7 +142,7 @@ export const ListOpenOrdersError = makeErrorGuard(
 export function listOpenOrders(
   client: BaseSecureClient,
   request?: ListOpenOrdersRequest,
-): Paginated<OpenOrder> {
+): Paginated<OpenOrder[]> {
   const { cursor, ...params } = parseUserInput(
     request,
     ListOpenOrdersRequestSchema,
@@ -285,7 +285,7 @@ export const ListAccountTradesError = makeErrorGuard(
 export function listAccountTrades(
   client: BaseSecureClient,
   request?: ListAccountTradesRequest,
-): Paginated<ClobTrade> {
+): Paginated<ClobTrade[]> {
   const { cursor, ...params } = parseUserInput(
     request,
     ListAccountTradesRequestSchema,
@@ -689,7 +689,7 @@ export const ListUserEarningsForDayError = makeErrorGuard(
 export function listUserEarningsForDay(
   client: BaseSecureClient,
   request: ListUserEarningsForDayRequest,
-): Paginated<UserEarning> {
+): Paginated<UserEarning[]> {
   const { cursor, ...params } = parseUserInput(
     request,
     ListUserEarningsForDayRequestSchema,
@@ -839,7 +839,7 @@ export const ListUserEarningsAndMarketsConfigError = makeErrorGuard(
 export function listUserEarningsAndMarketsConfig(
   client: BaseSecureClient,
   request: ListUserEarningsAndMarketsConfigRequest,
-): Paginated<UserRewardsEarning> {
+): Paginated<UserRewardsEarning[]> {
   const { cursor, ...params } = parseUserInput(
     request,
     ListUserEarningsAndMarketsConfigRequestSchema,

--- a/packages/client/src/actions/activity.ts
+++ b/packages/client/src/actions/activity.ts
@@ -131,7 +131,7 @@ export const ListTradesError = makeErrorGuard(
 export function listTrades(
   client: BaseClient,
   request: ListTradesRequest = {},
-): Paginated<Trade> {
+): Paginated<Trade[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListTradesRequestSchema,
@@ -218,7 +218,7 @@ export const ListActivityError = makeErrorGuard(
 export function listActivity(
   client: BaseClient,
   request: ListActivityRequest,
-): Paginated<Activity> {
+): Paginated<Activity[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListActivityRequestSchema,

--- a/packages/client/src/actions/builders.ts
+++ b/packages/client/src/actions/builders.ts
@@ -83,7 +83,7 @@ export const ListBuilderTradesError = makeErrorGuard(
 export function listBuilderTrades(
   client: BaseClient,
   request: ListBuilderTradesRequest,
-): Paginated<BuilderTrade> {
+): Paginated<BuilderTrade[]> {
   const { cursor, ...params } = parseUserInput(
     request,
     ListBuilderTradesRequestSchema,

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -898,7 +898,7 @@ export const ListCurrentRewardsError = makeErrorGuard(
 export function listCurrentRewards(
   client: BaseClient,
   request: ListCurrentRewardsRequest = {},
-): Paginated<CurrentReward> {
+): Paginated<CurrentReward[]> {
   const { cursor, ...params } = parseUserInput(
     request,
     ListCurrentRewardsRequestSchema,
@@ -992,7 +992,7 @@ export const ListMarketRewardsError = makeErrorGuard(
 export function listMarketRewards(
   client: BaseClient,
   request: ListMarketRewardsRequest,
-): Paginated<MarketReward> {
+): Paginated<MarketReward[]> {
   const { cursor, ...params } = parseUserInput(
     request,
     ListMarketRewardsRequestSchema,

--- a/packages/client/src/actions/comments.ts
+++ b/packages/client/src/actions/comments.ts
@@ -117,7 +117,7 @@ export const ListCommentsError = makeErrorGuard(
 export function listComments(
   client: BaseClient,
   request: ListCommentsRequest,
-): Paginated<Comment> {
+): Paginated<Comment[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListCommentsRequestSchema,
@@ -264,7 +264,7 @@ export const ListCommentsByUserAddressError = makeErrorGuard(
 export function listCommentsByUserAddress(
   client: BaseClient,
   request: ListCommentsByUserAddressRequest,
-): Paginated<Comment> {
+): Paginated<Comment[]> {
   const { address, cursor, pageSize, ...params } = parseUserInput(
     request,
     ListCommentsByUserAddressRequestSchema,

--- a/packages/client/src/actions/events.ts
+++ b/packages/client/src/actions/events.ts
@@ -170,7 +170,7 @@ export const ListEventsError = makeErrorGuard(
 export function listEvents(
   client: BaseClient,
   request: ListEventsRequest = {},
-): Paginated<Event> {
+): Paginated<Event[]> {
   const params = parseUserInput(request, ListEventsRequestSchema);
 
   return paginate(

--- a/packages/client/src/actions/leaderboards.ts
+++ b/packages/client/src/actions/leaderboards.ts
@@ -114,7 +114,7 @@ export const ListBuilderLeaderboardError = makeErrorGuard(
 export function listBuilderLeaderboard(
   client: BaseClient,
   request: ListBuilderLeaderboardRequest = {},
-): Paginated<LeaderboardEntry> {
+): Paginated<LeaderboardEntry[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListBuilderLeaderboardRequestSchema,
@@ -247,7 +247,7 @@ export const ListTraderLeaderboardError = makeErrorGuard(
 export function listTraderLeaderboard(
   client: BaseClient,
   request: ListTraderLeaderboardRequest = {},
-): Paginated<TraderLeaderboardEntry> {
+): Paginated<TraderLeaderboardEntry[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListTraderLeaderboardRequestSchema,

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -204,7 +204,7 @@ export const ListMarketsError = makeErrorGuard(
 export function listMarkets(
   client: BaseClient,
   request: ListMarketsRequest = {},
-): Paginated<Market> {
+): Paginated<Market[]> {
   const params = parseUserInput(request, ListMarketsRequestSchema);
 
   return paginate(
@@ -467,7 +467,7 @@ export const ListMarketPositionsError = makeErrorGuard(
 export function listMarketPositions(
   client: BaseClient,
   request: ListMarketPositionsRequest,
-): Paginated<MetaMarketPosition> {
+): Paginated<MetaMarketPosition[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListMarketPositionsRequestSchema,

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -167,7 +167,7 @@ export const ListPositionsError = makeErrorGuard(
 export function listPositions(
   client: BaseClient,
   request: ListPositionsRequest,
-): Paginated<Position> {
+): Paginated<Position[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListPositionsRequestSchema,
@@ -254,7 +254,7 @@ export const ListClosedPositionsError = makeErrorGuard(
 export function listClosedPositions(
   client: BaseClient,
   request: ListClosedPositionsRequest,
-): Paginated<ClosedPosition> {
+): Paginated<ClosedPosition[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListClosedPositionsRequestSchema,

--- a/packages/client/src/actions/search.test.ts
+++ b/packages/client/src/actions/search.test.ts
@@ -4,29 +4,33 @@ import { publicClient } from '../testing';
 describe('Search', () => {
   describe('search', () => {
     it('fetches public search results', async () => {
-      const result = await publicClient.search({
+      const paginator = publicClient.search({
         q: 'trump',
-        limitPerType: 1,
+        pageSize: 1,
       });
+      const firstPage = await paginator.firstPage();
 
-      expect(result).toEqual(
+      expect(firstPage).toEqual(
         expect.objectContaining({
-          pagination: expect.objectContaining({
-            hasMore: expect.any(Boolean),
+          hasMore: expect.any(Boolean),
+          items: expect.objectContaining({
+            events: expect.any(Array),
+            profiles: expect.any(Array),
+            tags: expect.any(Array),
           }),
         }),
       );
 
-      if (result.events) {
-        expect(result.events).toEqual(expect.any(Array));
-      }
+      if (firstPage.hasMore) {
+        const nextPage = await paginator.from(firstPage.nextCursor).firstPage();
 
-      if (result.tags) {
-        expect(result.tags).toEqual(expect.any(Array));
-      }
-
-      if (result.profiles) {
-        expect(result.profiles).toEqual(expect.any(Array));
+        expect(nextPage.items).toEqual(
+          expect.objectContaining({
+            events: expect.any(Array),
+            profiles: expect.any(Array),
+            tags: expect.any(Array),
+          }),
+        );
       }
     });
   });

--- a/packages/client/src/actions/search.ts
+++ b/packages/client/src/actions/search.ts
@@ -1,8 +1,11 @@
+import { PaginationCursorSchema } from '@polymarket/bindings';
 import {
+  type Event,
+  type Profile,
   type PublicSearchResponse,
   PublicSearchResponseSchema,
+  type SearchTag,
 } from '@polymarket/bindings/gamma';
-import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
 import {
@@ -14,6 +17,13 @@ import {
   UserInputError,
 } from '../errors';
 import { parseUserInput } from '../input';
+import {
+  decodeOffsetCursor,
+  encodeOffsetCursor,
+  PageSizeSchema,
+  type Paginated,
+  paginate,
+} from '../pagination';
 import { validateWith } from '../response';
 import { snakeCase, toSearchParams } from './params';
 
@@ -21,13 +31,13 @@ const SearchRequestSchema = z.object({
   q: z.string().min(1),
   ascending: z.boolean().optional(),
   cache: z.boolean().optional(),
+  cursor: PaginationCursorSchema.optional(),
   eventsStatus: z.string().min(1).optional(),
   eventsTag: z.array(z.string()).optional(),
   excludeTagIds: z.array(z.number().int()).optional(),
   keepClosedMarkets: z.number().int().optional(),
-  limitPerType: z.number().int().optional(),
   optimized: z.boolean().optional(),
-  page: z.number().int().optional(),
+  pageSize: PageSizeSchema.default(10),
   presets: z.array(z.string()).optional(),
   recurrence: z.enum(['daily', 'weekly', 'monthly']).optional(),
   searchProfiles: z.boolean().optional(),
@@ -38,6 +48,17 @@ const SearchRequestSchema = z.object({
 export type SearchRequest = z.input<typeof SearchRequestSchema>;
 
 type SearchParams = z.output<typeof SearchRequestSchema>;
+
+type PublicSearchParams = Omit<SearchParams, 'cursor' | 'pageSize'> & {
+  limitPerType: number;
+  page: number;
+};
+
+export type SearchResults = {
+  events: Event[];
+  profiles: Profile[];
+  tags: SearchTag[];
+};
 
 export type SearchError =
   | RateLimitError
@@ -60,31 +81,71 @@ export const SearchError = makeErrorGuard(
  * Thrown on failure.
  *
  * @example
+ * Fetch the first page of results:
  * ```ts
- * const result = await search(client, {
+ * const result = search(client, {
  *   q: 'trump',
- *   limitPerType: 3,
+ *   pageSize: 10,
  * });
  *
- * // result === PublicSearchResponse
+ * const firstPage = await result.firstPage();
+ *
+ * // Optionally, fetch additional pages:
+ * for await (const page of result.from(firstPage.nextCursor)) {
+ *   // page.items.events: Event[]
+ *   // page.items.tags: SearchTag[]
+ *   // page.items.profiles: Profile[]
+ * }
  * ```
  */
-export async function search(
+export function search(
   client: BaseClient,
   request: SearchRequest,
-): Promise<PublicSearchResponse> {
-  const params = parseUserInput(request, SearchRequestSchema);
-
-  return unwrap(
-    client.gamma
-      .get('/public-search', {
-        params: toSearchParams(
-          params,
-          snakeCase<SearchParams>({
-            excludeTagIds: 'exclude_tag_id',
-          }),
-        ),
-      })
-      .andThen(validateWith(PublicSearchResponseSchema)),
+): Paginated<SearchResults> {
+  const { cursor, pageSize, ...params } = parseUserInput(
+    request,
+    SearchRequestSchema,
   );
+
+  return paginate(
+    (cursor) => {
+      const decoded = decodeOffsetCursor(cursor, pageSize);
+
+      return client.gamma
+        .get('/public-search', {
+          params: toSearchParams(
+            {
+              ...params,
+              limitPerType: decoded.pageSize,
+              page: decoded.offset,
+            },
+            snakeCase<PublicSearchParams>({
+              excludeTagIds: 'exclude_tag_id',
+            }),
+          ),
+        })
+        .andThen(validateWith(PublicSearchResponseSchema))
+        .map((response) => ({
+          items: toSearchResults(response),
+          hasMore: response.pagination?.hasMore ?? false,
+          totalCount: response.pagination?.totalResults ?? undefined,
+          nextCursor: response.pagination?.hasMore
+            ? encodeOffsetCursor({
+                offset: decoded.offset + 1,
+                pageSize: decoded.pageSize,
+              })
+            : undefined,
+        }));
+    },
+    cursor ?? encodeOffsetCursor({ offset: 1, pageSize }),
+    { events: [], profiles: [], tags: [] },
+  );
+}
+
+function toSearchResults(response: PublicSearchResponse): SearchResults {
+  return {
+    events: response.events ?? [],
+    profiles: response.profiles ?? [],
+    tags: response.tags ?? [],
+  };
 }

--- a/packages/client/src/actions/series.ts
+++ b/packages/client/src/actions/series.ts
@@ -103,7 +103,7 @@ export const ListSeriesError = makeErrorGuard(
 export function listSeries(
   client: BaseClient,
   request: ListSeriesRequest = {},
-): Paginated<Series> {
+): Paginated<Series[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListSeriesRequestSchema,

--- a/packages/client/src/actions/tags.ts
+++ b/packages/client/src/actions/tags.ts
@@ -138,7 +138,7 @@ export const ListTagsError = makeErrorGuard(
 export function listTags(
   client: BaseClient,
   request: ListTagsRequest = {},
-): Paginated<Tag> {
+): Paginated<Tag[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListTagsRequestSchema,

--- a/packages/client/src/actions/teams.ts
+++ b/packages/client/src/actions/teams.ts
@@ -86,7 +86,7 @@ export const ListTeamsError = makeErrorGuard(
 export function listTeams(
   client: BaseClient,
   request: ListTeamsRequest = {},
-): Paginated<Team> {
+): Paginated<Team[]> {
   const { cursor, pageSize, ...params } = parseUserInput(
     request,
     ListTeamsRequestSchema,

--- a/packages/client/src/backend-compat.test.ts
+++ b/packages/client/src/backend-compat.test.ts
@@ -117,12 +117,14 @@ describe.runIf(runBackendCompatTests)('backend compatibility', () => {
   });
 
   it('validates search responses against the response schema', async () => {
-    await publicClient.search({
-      limitPerType: 10,
-      q: 'polymarket',
-      searchProfiles: true,
-      searchTags: true,
-    });
+    await publicClient
+      .search({
+        pageSize: 10,
+        q: 'polymarket',
+        searchProfiles: true,
+        searchTags: true,
+      })
+      .firstPage();
   });
 
   it('validates sports metadata against the response schema', async () => {

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -76,7 +76,7 @@ export type AccountPublicActions = {
    * }
    * ```
    */
-  listPositions(request: ListPositionsRequest): Paginated<Position>;
+  listPositions(request: ListPositionsRequest): Paginated<Position[]>;
   /**
    * Lists closed positions for a wallet.
    *
@@ -114,7 +114,7 @@ export type AccountPublicActions = {
    */
   listClosedPositions(
     request: ListClosedPositionsRequest,
-  ): Paginated<ClosedPosition>;
+  ): Paginated<ClosedPosition[]>;
   /**
    * Fetches the total value for a wallet's positions.
    *
@@ -198,7 +198,7 @@ export type AccountPublicActions = {
    */
   listMarketPositions(
     request: ListMarketPositionsRequest,
-  ): Paginated<MetaMarketPosition>;
+  ): Paginated<MetaMarketPosition[]>;
   /**
    * Lists wallet activity.
    *
@@ -234,7 +234,7 @@ export type AccountPublicActions = {
    * }
    * ```
    */
-  listActivity(request: ListActivityRequest): Paginated<Activity>;
+  listActivity(request: ListActivityRequest): Paginated<Activity[]>;
 };
 
 export type AccountActions = Prettify<
@@ -272,7 +272,9 @@ export type AccountActions = Prettify<
      * }
      * ```
      */
-    listAccountTrades(request?: ListAccountTradesRequest): Paginated<ClobTrade>;
+    listAccountTrades(
+      request?: ListAccountTradesRequest,
+    ): Paginated<ClobTrade[]>;
     /**
      * Fetches notifications for the authenticated account.
      *

--- a/packages/client/src/decorators/analytics.ts
+++ b/packages/client/src/decorators/analytics.ts
@@ -55,7 +55,9 @@ export type AnalyticsActions = {
    * }
    * ```
    */
-  listBuilderTrades(request: ListBuilderTradesRequest): Paginated<BuilderTrade>;
+  listBuilderTrades(
+    request: ListBuilderTradesRequest,
+  ): Paginated<BuilderTrade[]>;
 
   /**
    * Lists builder leaderboard rankings.
@@ -94,7 +96,7 @@ export type AnalyticsActions = {
    */
   listBuilderLeaderboard(
     request?: ListBuilderLeaderboardRequest,
-  ): Paginated<LeaderboardEntry>;
+  ): Paginated<LeaderboardEntry[]>;
 
   /**
    * Lists daily builder volume entries.
@@ -152,7 +154,7 @@ export type AnalyticsActions = {
    */
   listTraderLeaderboard(
     request?: ListTraderLeaderboardRequest,
-  ): Paginated<TraderLeaderboardEntry>;
+  ): Paginated<TraderLeaderboardEntry[]>;
 };
 
 export function analyticsActions(client: BasePublicClient): AnalyticsActions;

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -290,7 +290,7 @@ export type DataActions = {
    * }
    * ```
    */
-  listTrades(request?: ListTradesRequest): Paginated<Trade>;
+  listTrades(request?: ListTradesRequest): Paginated<Trade[]>;
 };
 
 export function dataActions(client: BasePublicClient): DataActions;

--- a/packages/client/src/decorators/discovery.ts
+++ b/packages/client/src/decorators/discovery.ts
@@ -3,7 +3,6 @@ import type {
   Event,
   Market,
   PublicProfile,
-  PublicSearchResponse,
   RelatedTag,
   Series,
   SportsMarketTypesResponse,
@@ -50,6 +49,7 @@ import {
   listTags,
   listTeams,
   type SearchRequest,
+  type SearchResults,
   search,
 } from '../actions';
 import type {
@@ -93,7 +93,7 @@ export type DiscoveryActions = {
    * }
    * ```
    */
-  listEvents(request?: ListEventsRequest): Paginated<Event>;
+  listEvents(request?: ListEventsRequest): Paginated<Event[]>;
 
   /**
    * Fetches an event.
@@ -168,7 +168,7 @@ export type DiscoveryActions = {
    * }
    * ```
    */
-  listMarkets(request?: ListMarketsRequest): Paginated<Market>;
+  listMarkets(request?: ListMarketsRequest): Paginated<Market[]>;
 
   /**
    * Fetches a market.
@@ -241,7 +241,7 @@ export type DiscoveryActions = {
    * }
    * ```
    */
-  listSeries(request?: ListSeriesRequest): Paginated<Series>;
+  listSeries(request?: ListSeriesRequest): Paginated<Series[]>;
 
   /**
    * Fetches a series.
@@ -291,7 +291,7 @@ export type DiscoveryActions = {
    * }
    * ```
    */
-  listTags(request?: ListTagsRequest): Paginated<Tag>;
+  listTags(request?: ListTagsRequest): Paginated<Tag[]>;
 
   /**
    * Fetches a tag by id or slug.
@@ -347,13 +347,24 @@ export type DiscoveryActions = {
    * Thrown on failure.
    *
    * @example
+   * Fetch the first page of results:
    * ```ts
-   * const results = await client.search({
-   *   query: 'election',
+   * const paginator = client.search({
+   *   q: 'election',
+   *   pageSize: 10,
    * });
+   *
+   * const firstPage = await paginator.firstPage();
+   *
+   * // Optionally, fetch additional pages:
+   * for await (const page of paginator.from(firstPage.nextCursor)) {
+   *   // page.items.events: Event[]
+   *   // page.items.tags: SearchTag[]
+   *   // page.items.profiles: Profile[]
+   * }
    * ```
    */
-  search(request: SearchRequest): Promise<PublicSearchResponse>;
+  search(request: SearchRequest): Paginated<SearchResults>;
 
   /**
    * Lists available sports metadata.
@@ -414,7 +425,7 @@ export type DiscoveryActions = {
    * }
    * ```
    */
-  listTeams(request?: ListTeamsRequest): Paginated<Team>;
+  listTeams(request?: ListTeamsRequest): Paginated<Team[]>;
 
   /**
    * Fetches a public profile by wallet address.
@@ -470,7 +481,7 @@ export type DiscoveryActions = {
    * }
    * ```
    */
-  listComments(request: ListCommentsRequest): Paginated<Comment>;
+  listComments(request: ListCommentsRequest): Paginated<Comment[]>;
 
   /**
    * Fetches a comment thread by comment id.
@@ -527,7 +538,7 @@ export type DiscoveryActions = {
    */
   listCommentsByUserAddress(
     request: ListCommentsByUserAddressRequest,
-  ): Paginated<Comment>;
+  ): Paginated<Comment[]>;
 };
 
 export function discoveryActions(client: BasePublicClient): DiscoveryActions;

--- a/packages/client/src/decorators/rewards.ts
+++ b/packages/client/src/decorators/rewards.ts
@@ -64,7 +64,7 @@ export type RewardsPublicActions = {
    */
   listCurrentRewards(
     request?: ListCurrentRewardsRequest,
-  ): Paginated<CurrentReward>;
+  ): Paginated<CurrentReward[]>;
   /**
    * Lists reward configurations for a market.
    *
@@ -100,7 +100,9 @@ export type RewardsPublicActions = {
    * }
    * ```
    */
-  listMarketRewards(request: ListMarketRewardsRequest): Paginated<MarketReward>;
+  listMarketRewards(
+    request: ListMarketRewardsRequest,
+  ): Paginated<MarketReward[]>;
 };
 
 export type RewardsActions = Prettify<
@@ -170,7 +172,7 @@ export type RewardsActions = Prettify<
      */
     listUserEarningsForDay(
       request: ListUserEarningsForDayRequest,
-    ): Paginated<UserEarning>;
+    ): Paginated<UserEarning[]>;
     /**
      * Fetches total earnings for the authenticated account on a given day.
      *
@@ -222,7 +224,7 @@ export type RewardsActions = Prettify<
      */
     listUserEarningsAndMarketsConfig(
       request: ListUserEarningsAndMarketsConfigRequest,
-    ): Paginated<UserRewardsEarning>;
+    ): Paginated<UserRewardsEarning[]>;
     /**
      * Fetches reward percentages for the authenticated account.
      *

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -223,7 +223,7 @@ export type TradingActions = {
    * }
    * ```
    */
-  listOpenOrders(request?: ListOpenOrdersRequest): Paginated<OpenOrder>;
+  listOpenOrders(request?: ListOpenOrdersRequest): Paginated<OpenOrder[]>;
   /**
    * Fetches a single order for the authenticated account.
    *

--- a/packages/client/src/pagination.ts
+++ b/packages/client/src/pagination.ts
@@ -9,7 +9,7 @@ import { UserInputError } from './errors';
 export const PageSizeSchema = z.number().int().positive();
 
 export type Page<T> = {
-  items: T[];
+  items: T;
   hasMore: boolean;
   nextCursor?: PaginationCursor;
   totalCount?: number;
@@ -36,12 +36,13 @@ const OffsetCursorStateSchema = z.object({
 export function paginate<T, TError>(
   fetchPage: (cursor?: PaginationCursor) => ResultAsync<Page<T>, TError>,
   initialCursor?: PaginationCursor,
+  emptyItems: T = [] as T,
 ): Paginated<T> {
   function createEmptyPaginator(): Paginated<T> {
     return {
       async firstPage() {
         return {
-          items: [],
+          items: emptyItems,
           hasMore: false,
         };
       },

--- a/packages/client/src/testing.ts
+++ b/packages/client/src/testing.ts
@@ -214,8 +214,8 @@ async function hasLiveOrderBook(candidate: Market) {
 }
 
 export function expectNonEmptyPage<T>(
-  page: Page<T>,
-): Omit<Page<T>, 'items'> & { items: NonEmptyArray<T> } {
+  page: Page<T[]>,
+): Omit<Page<T[]>, 'items'> & { items: NonEmptyArray<T> } {
   return {
     ...page,
     items: expectNonEmptyArray(page.items),


### PR DESCRIPTION
## Summary
- Updates the shared paginator page shape so `items` can hold grouped payloads while existing list APIs continue exposing arrays.
- Converts `search` to return a paginator with grouped `events`, `tags`, and `profiles` results.
- Updates decorator signatures and search/backend compatibility tests for the paginated search API.

## Verification
- `pnpm vitest --project client packages/client/src/actions/search.test.ts`
- `pnpm typecheck`
- `pnpm lint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public SDK types and behavior change: `Page.items` is no longer always an array and `search` now returns a paginator, which can break downstream consumers expecting the old response shapes.
> 
> **Overview**
> Aligns the SDK paginator to support non-array payloads by changing `Page.items` to be generic (`T`) and adding an `emptyItems` default to `paginate` for empty iterators.
> 
> Updates all existing list-style endpoints to explicitly return `Paginated<X[]>` to preserve their array semantics, and converts `search` from a one-shot `Promise<PublicSearchResponse>` into a `Paginated<SearchResults>` API with `pageSize`/cursor-based paging and grouped `events`/`profiles`/`tags` results.
> 
> Adjusts decorator method signatures and tests (`search.test.ts`, `backend-compat.test.ts`) to use the new paginated search flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9338336663799c2ef6e7fbe0e39f1c18a7078df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->