### PR TITLE
test(client): use builder auth for gasless Safe deploy

### DIFF
--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { fetchApiKeys } from './actions';
 import { createSecureClient } from './clients';
 import {
+  builderAuthorization,
   createRandomWalletClient,
   createSecureClientWithSafeWallet,
   deriveProxyAddress,
@@ -176,7 +177,7 @@ describe('clients', () => {
         const walletClient = createRandomWalletClient();
 
         const secureClient = await createSecureClient({
-          apiKey: relayerAuthorization,
+          apiKey: builderAuthorization,
           signer: signerFrom(walletClient),
         });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk test-only change: swaps the API key used in a metered `setupGaslessWallet` deployment test, which may affect CI only if the builder credentials are misconfigured.
> 
> **Overview**
> Updates the `SecureClient.setupGaslessWallet` metered test to deploy a signer Safe using `builderAuthorization` instead of `relayerAuthorization`, and imports `builderAuthorization` in `clients.test.ts` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32996dcb0979111c75a4ea1a4557ec0b376dc38d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->