### PR TITLE
Normalize proxy wallet response fields

### DIFF
--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -201,8 +201,9 @@ export const TradeSchema = z
     profileImageOptimized: z.string().nullish(),
     transactionHash: z.string().nullish(),
   })
-  .transform(({ asset, ...rest }) => ({
+  .transform(({ asset, proxyWallet, ...rest }) => ({
     ...rest,
+    wallet: proxyWallet,
     tokenId: asset,
   }));
 

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -15,8 +15,9 @@ export const HolderSchema = z
     profileImage: z.string().nullish(),
     profileImageOptimized: z.string().nullish(),
   })
-  .transform(({ asset, ...rest }) => ({
+  .transform(({ asset, proxyWallet, ...rest }) => ({
     ...rest,
+    wallet: proxyWallet,
     tokenId: asset,
   }));
 

--- a/packages/bindings/src/data/leaderboard.ts
+++ b/packages/bindings/src/data/leaderboard.ts
@@ -26,16 +26,21 @@ export const BuilderVolumeEntrySchema = z
     bucketAt: dt,
   }));
 
-export const TraderLeaderboardEntrySchema = z.object({
-  rank: z.string().nullish(),
-  proxyWallet: AddressSchema.nullish(),
-  userName: z.string().nullish(),
-  vol: DecimalishSchema.nullish(),
-  pnl: DecimalishSchema.nullish(),
-  profileImage: z.string().nullish(),
-  xUsername: z.string().nullish(),
-  verifiedBadge: z.boolean().nullish(),
-});
+export const TraderLeaderboardEntrySchema = z
+  .object({
+    rank: z.string().nullish(),
+    proxyWallet: AddressSchema.nullish(),
+    userName: z.string().nullish(),
+    vol: DecimalishSchema.nullish(),
+    pnl: DecimalishSchema.nullish(),
+    profileImage: z.string().nullish(),
+    xUsername: z.string().nullish(),
+    verifiedBadge: z.boolean().nullish(),
+  })
+  .transform(({ proxyWallet, ...rest }) => ({
+    ...rest,
+    wallet: proxyWallet,
+  }));
 
 export const ListBuilderLeaderboardResponseSchema = z.array(
   LeaderboardEntrySchema,

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -38,8 +38,9 @@ export const PositionSchema = z
     endDate: IsoCalendarDateStringSchema.nullish(),
     negativeRisk: z.boolean().nullish(),
   })
-  .transform(({ asset, oppositeAsset, ...rest }) => ({
+  .transform(({ asset, oppositeAsset, proxyWallet, ...rest }) => ({
     ...rest,
+    wallet: proxyWallet,
     tokenId: asset,
     oppositeTokenId: oppositeAsset,
   }));
@@ -64,8 +65,9 @@ export const ClosedPositionSchema = z
     oppositeAsset: TokenIdSchema.nullish(),
     endDate: MixedDateTimeStringSchema.nullish(),
   })
-  .transform(({ asset, oppositeAsset, ...rest }) => ({
+  .transform(({ asset, oppositeAsset, proxyWallet, ...rest }) => ({
     ...rest,
+    wallet: proxyWallet,
     tokenId: asset,
     oppositeTokenId: oppositeAsset,
   }));
@@ -94,8 +96,9 @@ export const MarketPositionSchema = z
     outcome: z.string().nullish(),
     outcomeIndex: z.number().int().nullish(),
   })
-  .transform(({ asset, ...rest }) => ({
+  .transform(({ asset, proxyWallet, ...rest }) => ({
     ...rest,
+    wallet: proxyWallet,
     tokenId: asset,
   }));
 

--- a/packages/bindings/src/gamma/comment.ts
+++ b/packages/bindings/src/gamma/comment.ts
@@ -15,19 +15,24 @@ export const CommentPositionSchema = z.object({
   positionSize: BaseUnitsSchema.nullish(),
 });
 
-export const CommentProfileSchema = z.object({
-  name: z.string().nullish(),
-  pseudonym: z.string().nullish(),
-  displayUsernamePublic: z.boolean().nullish(),
-  bio: z.string().nullish(),
-  isMod: z.boolean().nullish(),
-  isCreator: z.boolean().nullish(),
-  proxyWallet: z.string().nullish(),
-  baseAddress: z.string().nullish(),
-  profileImage: z.string().nullish(),
-  profileImageOptimized: ImageOptimizationSchema.nullish(),
-  positions: z.array(CommentPositionSchema).nullish(),
-});
+export const CommentProfileSchema = z
+  .object({
+    name: z.string().nullish(),
+    pseudonym: z.string().nullish(),
+    displayUsernamePublic: z.boolean().nullish(),
+    bio: z.string().nullish(),
+    isMod: z.boolean().nullish(),
+    isCreator: z.boolean().nullish(),
+    proxyWallet: z.string().nullish(),
+    baseAddress: z.string().nullish(),
+    profileImage: z.string().nullish(),
+    profileImageOptimized: ImageOptimizationSchema.nullish(),
+    positions: z.array(CommentPositionSchema).nullish(),
+  })
+  .transform(({ proxyWallet, ...rest }) => ({
+    ...rest,
+    wallet: proxyWallet,
+  }));
 
 export enum ReactionType {
   Heart = 'HEART',

--- a/packages/bindings/src/gamma/profile.ts
+++ b/packages/bindings/src/gamma/profile.ts
@@ -9,51 +9,61 @@ export const PublicProfileUserSchema = z.object({
   mod: z.boolean().nullish(),
 });
 
-export const ProfileSchema = z.object({
-  id: z.string().nullish(),
-  name: z.string().nullish(),
-  user: z.number().int().nullish(),
-  referral: z.string().nullish(),
-  createdBy: z.number().int().nullish(),
-  updatedBy: z.number().int().nullish(),
-  createdAt: IsoDateTimeStringSchema.nullish(),
-  updatedAt: IsoDateTimeStringSchema.nullish(),
-  utmSource: z.string().nullish(),
-  utmMedium: z.string().nullish(),
-  utmCampaign: z.string().nullish(),
-  utmContent: z.string().nullish(),
-  utmTerm: z.string().nullish(),
-  walletActivated: z.boolean().nullish(),
-  pseudonym: z.string().nullish(),
-  displayUsernamePublic: z.boolean().nullish(),
-  profileImage: z.string().nullish(),
-  bio: z.string().nullish(),
-  proxyWallet: z.string().nullish(),
-  profileImageOptimized: ImageOptimizationSchema.nullish(),
-  isCloseOnly: z.boolean().nullish(),
-  isCertReq: z.boolean().nullish(),
-  certReqDate: IsoDateTimeStringSchema.nullish(),
-  discordUsername: z.string().nullish(),
-  xUsername: z.string().nullish(),
-  verifiedBadge: z.boolean().nullish(),
-  dubPartnerId: z.string().nullish(),
-  termsAcceptedAt: IsoDateTimeStringSchema.nullish(),
-  viewOnlyAcknowledgedAt: IsoDateTimeStringSchema.nullish(),
-  isReferralRestricted: z.boolean().nullish(),
-});
+export const ProfileSchema = z
+  .object({
+    id: z.string().nullish(),
+    name: z.string().nullish(),
+    user: z.number().int().nullish(),
+    referral: z.string().nullish(),
+    createdBy: z.number().int().nullish(),
+    updatedBy: z.number().int().nullish(),
+    createdAt: IsoDateTimeStringSchema.nullish(),
+    updatedAt: IsoDateTimeStringSchema.nullish(),
+    utmSource: z.string().nullish(),
+    utmMedium: z.string().nullish(),
+    utmCampaign: z.string().nullish(),
+    utmContent: z.string().nullish(),
+    utmTerm: z.string().nullish(),
+    walletActivated: z.boolean().nullish(),
+    pseudonym: z.string().nullish(),
+    displayUsernamePublic: z.boolean().nullish(),
+    profileImage: z.string().nullish(),
+    bio: z.string().nullish(),
+    proxyWallet: z.string().nullish(),
+    profileImageOptimized: ImageOptimizationSchema.nullish(),
+    isCloseOnly: z.boolean().nullish(),
+    isCertReq: z.boolean().nullish(),
+    certReqDate: IsoDateTimeStringSchema.nullish(),
+    discordUsername: z.string().nullish(),
+    xUsername: z.string().nullish(),
+    verifiedBadge: z.boolean().nullish(),
+    dubPartnerId: z.string().nullish(),
+    termsAcceptedAt: IsoDateTimeStringSchema.nullish(),
+    viewOnlyAcknowledgedAt: IsoDateTimeStringSchema.nullish(),
+    isReferralRestricted: z.boolean().nullish(),
+  })
+  .transform(({ proxyWallet, ...rest }) => ({
+    ...rest,
+    wallet: proxyWallet,
+  }));
 
-export const PublicProfileSchema = z.object({
-  createdAt: IsoDateTimeStringSchema.nullish(),
-  proxyWallet: EvmAddressSchema.nullish(),
-  profileImage: z.string().nullish(),
-  displayUsernamePublic: z.boolean().nullish(),
-  bio: z.string().nullish(),
-  pseudonym: z.string().nullish(),
-  name: z.string().nullish(),
-  users: z.array(PublicProfileUserSchema).nullish(),
-  xUsername: z.string().nullish(),
-  verifiedBadge: z.boolean().nullish(),
-});
+export const PublicProfileSchema = z
+  .object({
+    createdAt: IsoDateTimeStringSchema.nullish(),
+    proxyWallet: EvmAddressSchema.nullish(),
+    profileImage: z.string().nullish(),
+    displayUsernamePublic: z.boolean().nullish(),
+    bio: z.string().nullish(),
+    pseudonym: z.string().nullish(),
+    name: z.string().nullish(),
+    users: z.array(PublicProfileUserSchema).nullish(),
+    xUsername: z.string().nullish(),
+    verifiedBadge: z.boolean().nullish(),
+  })
+  .transform(({ proxyWallet, ...rest }) => ({
+    ...rest,
+    wallet: proxyWallet,
+  }));
 
 export type PublicProfile = z.infer<typeof PublicProfileSchema>;
 export type Profile = z.infer<typeof ProfileSchema>;

--- a/packages/client/src/actions/activity.test.ts
+++ b/packages/client/src/actions/activity.test.ts
@@ -18,7 +18,7 @@ describe('Activity', () => {
       expect(result.items[0]).toEqual(
         expect.objectContaining({
           conditionId: expect.any(String),
-          proxyWallet: TEST_USER,
+          wallet: TEST_USER,
         }),
       );
     });

--- a/packages/client/src/actions/leaderboards.test.ts
+++ b/packages/client/src/actions/leaderboards.test.ts
@@ -14,8 +14,8 @@ describe('Leaderboards', () => {
       expect(result.items).toHaveLength(1);
       expect(result.items[0]).toEqual(
         expect.objectContaining({
-          proxyWallet: expect.any(String),
           rank: expect.any(String),
+          wallet: expect.any(String),
         }),
       );
     });

--- a/packages/client/src/actions/portfolio.test.ts
+++ b/packages/client/src/actions/portfolio.test.ts
@@ -18,7 +18,7 @@ describe('Portfolio', () => {
       expect(result.items[0]).toEqual(
         expect.objectContaining({
           conditionId: expect.any(String),
-          proxyWallet: TEST_USER,
+          wallet: TEST_USER,
         }),
       );
     });
@@ -38,7 +38,7 @@ describe('Portfolio', () => {
       expect(result.items[0]).toEqual(
         expect.objectContaining({
           conditionId: expect.any(String),
-          proxyWallet: TEST_USER,
+          wallet: TEST_USER,
         }),
       );
     });

--- a/packages/client/src/actions/profiles.test.ts
+++ b/packages/client/src/actions/profiles.test.ts
@@ -10,7 +10,7 @@ describe('Profiles', () => {
 
       expect(result).toEqual(
         expect.objectContaining({
-          proxyWallet: expect.any(String),
+          wallet: expect.any(String),
         }),
       );
     });


### PR DESCRIPTION
## Summary
- Normalize Data and Gamma response schemas from `proxyWallet` to public `wallet` fields.
- Update client expectations for activity, portfolio, profile, and leaderboard responses.
- Preserve backend-facing `proxyWallet` parsing while keeping latest decimal precision schema changes from main.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @polymarket/bindings build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a consumer-facing response shape change: several bindings schemas now expose `wallet` instead of `proxyWallet`, which can break downstream code relying on the old field. Risk is otherwise limited to schema/typing transformations and related client test updates.
> 
> **Overview**
> Normalizes public response shapes in `@polymarket/bindings` by mapping backend `proxyWallet` fields to a consistent `wallet` field across activity, portfolio, analytics holders, trader leaderboard entries, and Gamma profile/comment profile schemas.
> 
> Updates client action tests to assert `wallet` instead of `proxyWallet` for activity, portfolio, profiles, and leaderboards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 018c9ad802115b2db352b01112e354662ee623db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->