### PR TITLE
fix(bindings): tolerate legacy event markets

### DIFF
--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -34,7 +34,7 @@ import {
   InternalUserSchema,
   TagReferenceSchema,
 } from './common';
-import { type Market, MarketSchema } from './market';
+import { GammaMarketSchema, type Market, normalizeMarket } from './market';
 
 const BestLineIdSchema = z.string().transform(toBestLineId);
 const ChatIdSchema = z.string().transform(toChatId);
@@ -221,6 +221,12 @@ export const ListSportsMetadataResponseSchema = z.array(SportsMetadataSchema);
 export const SportsMarketTypesResponseSchema = z.object({
   marketTypes: z.array(z.string()).nullish(),
 });
+const EventMarketSchema = GammaMarketSchema.transform((market) =>
+  market.outcomes.length === 2 ? normalizeMarket(market) : null,
+);
+const EventMarketsSchema = z
+  .array(EventMarketSchema)
+  .transform((markets) => markets.filter((market) => market !== null));
 
 export type EventState = {
   active?: boolean | null;
@@ -446,7 +452,7 @@ export const GammaEventSchema = z.object({
   iconOptimized: ImageOptimizationSchema.nullish(),
   featuredImageOptimized: ImageOptimizationSchema.nullish(),
   subEvents: z.array(z.string()).nullish(),
-  markets: z.array(MarketSchema).nullish(),
+  markets: EventMarketsSchema.nullish(),
   series: z.array(SeriesReferenceSchema).nullish(),
   categories: z.array(CategoryReferenceSchema).nullish(),
   collections: z.array(CollectionReferenceSchema).nullish(),

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -37,49 +37,30 @@ import {
   TagReferenceSchema,
 } from './common';
 
-const StringPairSchema = z.tuple([z.string(), z.string()]);
-const DecimalStringPairSchema = z.tuple([
-  DecimalStringSchema,
-  DecimalStringSchema,
-]);
-const TokenIdPairValueSchema = z.tuple([TokenIdSchema, TokenIdSchema]);
-const EmptyArraySchema = z.tuple([]).transform(() => null);
 const GammaMarketEventSchema = z.object({
   id: EventIdSchema,
   slug: z.string().nullish(),
   title: z.string().nullish(),
 });
 
-const OutcomePairSchema = z.preprocess(parseJsonString, StringPairSchema);
+const OutcomeArraySchema = z
+  .preprocess(parseJsonString, z.array(z.string()).nullish())
+  .transform((value) => value ?? []);
 
-const OutcomePricePairSchema = z
-  .preprocess(
-    parseJsonString,
-    z.union([
-      DecimalStringPairSchema,
-      EmptyArraySchema,
-      z.null(),
-      z.undefined(),
-    ]),
-  )
-  .transform((value) => value ?? null);
+const OutcomePriceArraySchema = z
+  .preprocess(parseJsonString, z.array(DecimalStringSchema).nullish())
+  .transform((value) => value ?? []);
 
-const TokenIdPairSchema = z
-  .preprocess(
-    parseJsonString,
-    z.union([
-      TokenIdPairValueSchema,
-      EmptyArraySchema,
-      z.null(),
-      z.undefined(),
-    ]),
-  )
-  .transform((value) => value ?? null);
+const TokenIdArraySchema = z
+  .preprocess(parseJsonString, z.array(TokenIdSchema).nullish())
+  .transform((value) => value ?? []);
 
 export enum UmaResolutionStatus {
-  Proposed = 'proposed',
   Disputed = 'disputed',
+  Proposed = 'proposed',
+  Requested = 'requested',
   Resolved = 'resolved',
+  Settled = 'settled',
 }
 
 const UmaResolutionStatusSchema = z.enum(UmaResolutionStatus);
@@ -222,8 +203,8 @@ export const GammaMarketSchema = z.object({
   lowerBound: DecimalStringSchema.nullish(),
   upperBound: DecimalStringSchema.nullish(),
   description: z.string().nullish(),
-  outcomes: OutcomePairSchema,
-  outcomePrices: OutcomePricePairSchema,
+  outcomes: OutcomeArraySchema,
+  outcomePrices: OutcomePriceArraySchema,
   volume: DecimalStringSchema.nullish(),
   active: z.boolean().nullish(),
   marketType: z.string().nullish(),
@@ -281,7 +262,7 @@ export const GammaMarketSchema = z.object({
   volume1yr: DecimalishSchema.nullish(),
   gameStartTime: IsoDateTimeStringSchema.nullish(),
   secondsDelay: z.number().int().nullish(),
-  clobTokenIds: TokenIdPairSchema,
+  clobTokenIds: TokenIdArraySchema,
   disqusThread: z.string().nullish(),
   shortOutcomes: z.string().nullish(),
   teamAID: z.string().nullish(),
@@ -399,7 +380,7 @@ export type FetchMarketTagsResponse = z.infer<
   typeof FetchMarketTagsResponseSchema
 >;
 
-function normalizeMarket(market: GammaMarket): Market {
+export function normalizeMarket(market: GammaMarket): Market {
   return {
     id: market.id,
     slug: market.slug,
@@ -498,16 +479,24 @@ function parseJsonString(value: unknown): unknown {
 }
 
 function normalizeOutcomes(market: GammaMarket) {
+  if (market.outcomes.length !== 2) {
+    throw new TypeError(
+      `Expected binary market outcomes, received ${market.outcomes.length}`,
+    );
+  }
+
+  const [yesLabel, noLabel] = market.outcomes as [string, string];
+
   return {
     yes: {
-      label: market.outcomes[0],
-      tokenId: market.clobTokenIds?.[0] ?? null,
-      price: market.outcomePrices?.[0] ?? null,
+      label: yesLabel,
+      tokenId: market.clobTokenIds[0] ?? null,
+      price: market.outcomePrices[0] ?? null,
     },
     no: {
-      label: market.outcomes[1],
-      tokenId: market.clobTokenIds?.[1] ?? null,
-      price: market.outcomePrices?.[1] ?? null,
+      label: noLabel,
+      tokenId: market.clobTokenIds[1] ?? null,
+      price: market.outcomePrices[1] ?? null,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Parse Gamma market outcome-like fields as arrays so legacy multi-outcome payloads validate at the wire-schema layer.
- Keep normalized Market binary-only, while event-embedded legacy non-binary markets are filtered out of Event.markets.
- Accept legacy UMA resolution statuses observed in backend compatibility tests.

## Verification
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Zod wire schemas and normalization behavior for `Market`/`Event.markets`, which can alter what payloads validate and which embedded markets are surfaced to consumers.
> 
> **Overview**
> Updates Gamma market parsing to treat outcome-related fields (e.g. `outcomes`, `outcomePrices`, `clobTokenIds`) as JSON/nullable *arrays* rather than fixed pairs, allowing legacy multi-outcome payloads to validate at the schema layer.
> 
> Keeps normalized `Market` binary-only by making `normalizeOutcomes` throw when outcome count != 2, and updates `Event.markets` to parse via `GammaMarketSchema` and **filter out non-binary markets** when embedded in events.
> 
> Extends `UmaResolutionStatus` to accept additional legacy statuses (`requested`, `settled`) and exports `normalizeMarket` for reuse from `event.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7a5a0b501105a6cdaf14b6911a91c258818f639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->