### PR TITLE
Add auto-redeem to trading approvals

### DIFF
--- a/docs/sdk-direction.md
+++ b/docs/sdk-direction.md
@@ -26,6 +26,7 @@ The first shipping target is `@polymarket/client`. Its job is to make Polymarket
 - Do not add `simplified-markets`, `sampling-markets`, or `sampling-simplified-markets` actions unless a concrete SDK workflow needs those legacy market listing variants.
 - Do not add heartbeat actions to `@polymarket/client`; the current heartbeat endpoint is expected to be removed in v2.
 - Normalize the CTF position identifier to `tokenId` in the SDK public model, even when upstream services call the same value `assetId`.
+- Auto-redeem is an ERC-1155 operator approval on the Conditional Tokens position contract. `setupTradingApprovals` includes it for integrators who want a fully ready account.
 - Standardize SDK identifier naming on JS/TS-style `...Id` forms such as `orderId`, `tradeId`, `tokenId`, and `marketId`, and translate legacy `...ID` and wire-format variants at the service boundary.
 
 ## Wallet Direction

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -1,0 +1,52 @@
+import { WalletType } from '@polymarket/bindings/gamma';
+import { expectTxHash } from '@polymarket/types';
+import { describe, expect, it } from 'vitest';
+import { erc1155ApprovalForAllCall } from '../abis';
+import type { BaseSecureClient } from '../clients';
+import { production } from '../environments';
+import type { TransactionHandle } from '../types';
+import { prepareTradingApprovals } from './approvals';
+
+const TRANSACTION_HANDLE: TransactionHandle = {
+  transactionHash: null,
+  transactionId: null,
+  async wait() {
+    return {
+      transactionHash: expectTxHash(
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+      ),
+      transactionId: null,
+    };
+  },
+};
+
+describe('prepareTradingApprovals', () => {
+  it('includes auto-redeem approval in account setup', async () => {
+    const client = {
+      account: { walletType: WalletType.EOA },
+      environment: production,
+    } as BaseSecureClient;
+    const workflow = await prepareTradingApprovals(client);
+    let result = await workflow.next();
+
+    for (let index = 0; index < 6; index += 1) {
+      expect(result.done).toBe(false);
+      result = await workflow.next(TRANSACTION_HANDLE);
+    }
+
+    expect(result).toEqual({
+      done: false,
+      value: {
+        kind: 'sendErc1155ApprovalForAllTransaction',
+        request: {
+          chainId: production.chainId,
+          ...erc1155ApprovalForAllCall(
+            production.conditionalTokens,
+            production.autoRedeemOperator,
+            true,
+          ),
+        },
+      },
+    });
+  });
+});

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -262,7 +262,8 @@ export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
  * Prepares all approvals required for trading, including collateral and
  * position token approvals for both standard and neg-risk market flows.
  * The neg-risk adapter approvals cover split, merge, and redemption workflows
- * on neg-risk markets.
+ * on neg-risk markets. Auto-redeem approval is included so accounts are ready
+ * for supported position lifecycle workflows.
  *
  * @example
  * ```ts
@@ -306,6 +307,11 @@ export async function prepareTradingApprovals(
       client.environment.negRiskAdapter,
       true,
     ),
+    erc1155ApprovalForAllCall(
+      client.environment.conditionalTokens,
+      client.environment.autoRedeemOperator,
+      true,
+    ),
   ] as const;
 
   return async function* (): TradingApprovalsWorkflow {
@@ -345,9 +351,16 @@ export async function prepareTradingApprovals(
       );
       await conditionalNegRiskApproval.wait();
 
-      return expectTransactionHandle(
+      const conditionalNegRiskAdapterApproval = expectTransactionHandle(
         yield sendErc1155ApprovalForAllTransaction(
           signerTransactionRequest(client.environment.chainId, calls[5]),
+        ),
+      );
+      await conditionalNegRiskAdapterApproval.wait();
+
+      return expectTransactionHandle(
+        yield sendErc1155ApprovalForAllTransaction(
+          signerTransactionRequest(client.environment.chainId, calls[6]),
         ),
       );
     }

--- a/packages/client/src/decorators/wallet.ts
+++ b/packages/client/src/decorators/wallet.ts
@@ -31,7 +31,7 @@ export type WalletActions = {
    */
   isGaslessReady(): Promise<boolean>;
   /**
-   * Sets up the approvals required for trading.
+   * Sets up the approvals required for trading and supported position lifecycle workflows.
    *
    * @throws {@link SetupTradingApprovalsError}
    * Thrown on failure.

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -26,6 +26,8 @@ export type EnvironmentConfig = {
   /** @internal */
   negRiskExchange: EvmAddress;
   /** @internal */
+  autoRedeemOperator: EvmAddress;
+  /** @internal */
   safeMultisend: EvmAddress;
   /** @internal */
   relayHub: EvmAddress;
@@ -88,6 +90,9 @@ export const production: EnvironmentConfig = {
   ),
   negRiskExchange: expectEvmAddress(
     '0xe2222d279d744050d28e00520010520000310F59',
+  ),
+  autoRedeemOperator: expectEvmAddress(
+    '0x05cD9922A5d37faE921Fc5Dee280A9dBc4C3b393',
   ),
   safeMultisend: expectEvmAddress('0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761'),
   relayHub: expectEvmAddress('0xD216153c06E857cD7f72665E0aF1d7D82172F494'),


### PR DESCRIPTION
## Summary
- Include the auto-redeem ERC-1155 operator approval in `setupTradingApprovals`.
- Add the auto-redeem operator to the client environment config.
- Cover the setup workflow so it emits the auto-redeem approval call.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:client`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an additional ERC-1155 operator approval to the default `setupTradingApprovals` flow, expanding the on-chain permissions granted during account setup. Risk is moderate because incorrect operator address/config could over-approve or break downstream position lifecycle workflows.
> 
> **Overview**
> `setupTradingApprovals` / `prepareTradingApprovals` now also grants an ERC-1155 `setApprovalForAll` to the configured auto-redeem operator on Conditional Tokens, and ensures the EOA flow waits for the prior adapter approval before emitting the new step.
> 
> The client `EnvironmentConfig` adds a new `autoRedeemOperator` address (wired into `production`), docs clarify the intent, and a new `approvals.test.ts` covers that the workflow emits the auto-redeem approval call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25608b89d0a6a14a012c773b68cde32b1b495e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->