### PR TITLE
Fix decimalPlaces handling for scientific notation

### DIFF
--- a/packages/client/src/actions/orders/math.test.ts
+++ b/packages/client/src/actions/orders/math.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { decimalPlaces } from './math';
+
+describe('decimalPlaces', () => {
+  it.each([
+    [1, 0],
+    [1.2, 1],
+    [1.23, 2],
+    ['1.23', 2],
+    [0.000001, 6],
+    ['0.000001', 6],
+  ])('counts ordinary decimal places for %s', (value, expected) => {
+    expect(decimalPlaces(value)).toBe(expected);
+  });
+
+  it.each([
+    [1e-7, 7],
+    ['1e-7', 7],
+    [1.23e-7, 9],
+    ['1.23E-7', 9],
+    [1.234e-7, 10],
+  ])(
+    'counts negative scientific notation decimal places for %s',
+    (value, expected) => {
+      expect(decimalPlaces(value)).toBe(expected);
+    },
+  );
+
+  it.each([
+    [1e3, 0],
+    ['1e+3', 0],
+    [1.23e3, 0],
+    [1.23e1, 1],
+    ['1.23e+1', 1],
+    [1.234e2, 1],
+  ])(
+    'counts positive scientific notation decimal places for %s',
+    (value, expected) => {
+      expect(decimalPlaces(value)).toBe(expected);
+    },
+  );
+});

--- a/packages/client/src/actions/orders/math.ts
+++ b/packages/client/src/actions/orders/math.ts
@@ -28,12 +28,20 @@ export function roundNormal(value: number, decimals: number): number {
   return Math.round(value * 10 ** decimals) / 10 ** decimals;
 }
 
-export function decimalPlaces(value: number): number {
-  if (Number.isInteger(value)) {
+export function decimalPlaces(value: number | string): number {
+  if (typeof value === 'number' && Number.isInteger(value)) {
     return 0;
   }
 
-  const parts = value.toString().split('.');
+  const [mantissa = '', exponent] = value.toString().toLowerCase().split('e');
+  const [, fractionalPart = ''] = mantissa.split('.');
+  const fractionalPlaces = fractionalPart.length;
 
-  return parts.length <= 1 ? 0 : (parts[1]?.length ?? 0);
+  if (exponent === undefined) {
+    return fractionalPlaces;
+  }
+
+  const exponentValue = Number.parseInt(exponent, 10);
+
+  return Math.max(0, fractionalPlaces - exponentValue);
 }


### PR DESCRIPTION
## Summary
- Update `decimalPlaces` to account for exponent notation when counting effective fractional digits.
- Support decimal strings as well as numbers for the helper.
- Add focused coverage for ordinary decimals, negative exponents, positive exponents, and uppercase exponent strings.

## Testing
- `git diff --check -- packages/client/src/actions/orders/math.ts packages/client/src/actions/orders/math.test.ts`
- Not run: `pnpm test:client`, `pnpm lint`, `pnpm typecheck` because `node`, `npm`, `corepack`, and `pnpm` are unavailable on PATH in this environment.

Linear: DEV-83

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches rounding/validation helpers used in order amount/price calculations, so miscounting decimal places could impact order construction; changes are localized with added test coverage.
> 
> **Overview**
> Fixes `decimalPlaces` to correctly compute effective decimal places for numbers expressed in scientific notation (including uppercase `E`), and expands it to accept `string` inputs.
> 
> Adds a new `math.test.ts` suite covering ordinary decimals plus positive/negative exponent cases to prevent regressions in rounding/validation paths that rely on `decimalPlaces`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ae1ea10429a9bcfb149cbbe27e2d4608624193c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->