### PR TITLE
Replace loose Zod object schemas

### DIFF
--- a/packages/bindings/src/clob/builder.ts
+++ b/packages/bindings/src/clob/builder.ts
@@ -7,7 +7,7 @@ import {
 } from '../shared';
 
 export const BuilderTradeSchema = z
-  .looseObject({
+  .object({
     id: z.string(),
     tradeType: z.string(),
     takerOrderHash: z.string(),

--- a/packages/bindings/src/clob/neg-risk.ts
+++ b/packages/bindings/src/clob/neg-risk.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const NegRiskSchema = z
-  .looseObject({
+  .object({
     neg_risk: z.boolean(),
   })
   .transform(({ neg_risk, ...rest }) => ({

--- a/packages/bindings/src/clob/order-book.ts
+++ b/packages/bindings/src/clob/order-book.ts
@@ -11,7 +11,7 @@ export const OrderBookLevelSchema = z.object({
 });
 
 export const OrderBookSchema = z
-  .looseObject({
+  .object({
     market: z.string(),
     asset_id: TokenIdSchema,
     timestamp: EpochMillisecondsStringSchema.nullish(),

--- a/packages/bindings/src/clob/rewards.ts
+++ b/packages/bindings/src/clob/rewards.ts
@@ -7,7 +7,7 @@ import {
 } from '../shared';
 
 const CurrentRewardConfigSchema = z
-  .looseObject({
+  .object({
     id: z.number().int().optional(),
     asset_address: z.string(),
     start_date: EpochMillisecondsToIsoDateTimeStringSchema,
@@ -35,7 +35,7 @@ const CurrentRewardConfigSchema = z
 export type CurrentRewardConfig = z.infer<typeof CurrentRewardConfigSchema>;
 
 export const CurrentRewardSchema = z
-  .looseObject({
+  .object({
     condition_id: ConditionIdSchema,
     rewards_max_spread: z.number().optional(),
     rewards_min_size: DecimalishSchema.optional(),
@@ -98,7 +98,7 @@ const RewardTokenSchema = z
 export type RewardToken = z.infer<typeof RewardTokenSchema>;
 
 const RewardConfigSchema = z
-  .looseObject({
+  .object({
     asset_address: z.string(),
     start_date: EpochMillisecondsToIsoDateTimeStringSchema,
     end_date: EpochMillisecondsToIsoDateTimeStringSchema.optional(),
@@ -125,7 +125,7 @@ const RewardConfigSchema = z
 export type RewardConfig = z.infer<typeof RewardConfigSchema>;
 
 export const MarketRewardSchema = z
-  .looseObject({
+  .object({
     condition_id: ConditionIdSchema,
     question: z.string(),
     market_slug: z.string().optional(),

--- a/packages/bindings/src/clob/tick-size.ts
+++ b/packages/bindings/src/clob/tick-size.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { TickSizeValueSchema } from '../shared';
 
 export const TickSizeSchema = z
-  .looseObject({
+  .object({
     minimum_tick_size: TickSizeValueSchema,
   })
   .transform(({ minimum_tick_size, ...rest }) => ({

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -180,7 +180,7 @@ const OptionalTextSchema = z.preprocess(
 );
 
 export const TradeSchema = z
-  .looseObject({
+  .object({
     proxyWallet: AddressSchema.nullish(),
     side: SideSchema.nullish(),
     asset: TokenIdSchema.nullish(),
@@ -207,7 +207,7 @@ export const TradeSchema = z
     tokenId: asset,
   }));
 
-const RawActivitySchema = z.looseObject({
+const RawActivitySchema = z.object({
   proxyWallet: AddressSchema.nullish(),
   timestamp: EpochSecondsToMillisecondsSchema.nullish(),
   conditionId: z.preprocess(

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -3,7 +3,7 @@ import { DecimalishSchema, TokenIdSchema } from '../shared';
 import { AddressSchema, Hash64Schema } from './common';
 
 export const HolderSchema = z
-  .looseObject({
+  .object({
     proxyWallet: AddressSchema.nullish(),
     bio: z.string().nullish(),
     asset: TokenIdSchema.nullish(),

--- a/packages/bindings/src/data/leaderboard.ts
+++ b/packages/bindings/src/data/leaderboard.ts
@@ -12,7 +12,7 @@ export const LeaderboardEntrySchema = z.object({
 });
 
 export const BuilderVolumeEntrySchema = z
-  .looseObject({
+  .object({
     dt: IsoDateTimeStringSchema.nullish(),
     builder: z.string().nullish(),
     builderLogo: z.string().nullish(),

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -10,7 +10,7 @@ import {
 import { AddressSchema } from './common';
 
 export const PositionSchema = z
-  .looseObject({
+  .object({
     proxyWallet: AddressSchema.nullish(),
     asset: TokenIdSchema.nullish(),
     conditionId: ConditionIdSchema,
@@ -46,7 +46,7 @@ export const PositionSchema = z
   }));
 
 export const ClosedPositionSchema = z
-  .looseObject({
+  .object({
     proxyWallet: AddressSchema.nullish(),
     asset: TokenIdSchema.nullish(),
     conditionId: ConditionIdSchema.nullish(),
@@ -78,7 +78,7 @@ export const ValueSchema = z.object({
 });
 
 export const MarketPositionSchema = z
-  .looseObject({
+  .object({
     proxyWallet: AddressSchema.nullish(),
     name: z.string().nullish(),
     profileImage: z.string().nullish(),

--- a/packages/bindings/src/gamma/search.ts
+++ b/packages/bindings/src/gamma/search.ts
@@ -4,7 +4,7 @@ import { EventSchema } from './event';
 import { ProfileSchema } from './profile';
 
 export const SearchTagSchema = z
-  .looseObject({
+  .object({
     id: TagIdSchema,
     event_count: z.number().int().nullish(),
     label: z.string().nullish(),

--- a/packages/bindings/src/subscriptions/clob.ts
+++ b/packages/bindings/src/subscriptions/clob.ts
@@ -61,7 +61,7 @@ const ExpirationToIsoDateTimeStringSchema = z
 export type OrderBookLevel = z.infer<typeof OrderBookLevelSchema>;
 
 export const MarketBookEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('book'),
     market: z.string(),
     asset_id: TokenIdSchema,
@@ -103,7 +103,7 @@ export const MarketBookEventSchema = z
 export type MarketBookEvent = z.infer<typeof MarketBookEventSchema>;
 
 const PriceChangeSchema = z
-  .looseObject({
+  .object({
     asset_id: TokenIdSchema,
     price: DecimalStringSchema,
     size: DecimalStringSchema,
@@ -122,7 +122,7 @@ const PriceChangeSchema = z
 export type PriceChange = z.infer<typeof PriceChangeSchema>;
 
 export const MarketPriceChangeEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('price_change'),
     market: z.string(),
     price_changes: z.array(PriceChangeSchema),
@@ -145,7 +145,7 @@ export type MarketPriceChangeEvent = z.infer<
 >;
 
 export const MarketLastTradePriceEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('last_trade_price'),
     market: z.string(),
     asset_id: TokenIdSchema,
@@ -177,7 +177,7 @@ export type MarketLastTradePriceEvent = z.infer<
 >;
 
 export const MarketTickSizeChangeEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('tick_size_change'),
     market: z.string(),
     asset_id: TokenIdSchema,
@@ -206,7 +206,7 @@ export type MarketTickSizeChangeEvent = z.infer<
 >;
 
 export const MarketBestBidAskEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('best_bid_ask'),
     market: z.string(),
     asset_id: TokenIdSchema,
@@ -242,7 +242,7 @@ const MarketEventMessageSchema = z.object({
 export type MarketEventMessage = z.infer<typeof MarketEventMessageSchema>;
 
 export const NewMarketEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('new_market'),
     id: z.string(),
     question: z.string().nullish(),
@@ -307,7 +307,7 @@ export const NewMarketEventSchema = z
 export type NewMarketEvent = z.infer<typeof NewMarketEventSchema>;
 
 export const MarketResolvedEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('market_resolved'),
     id: z.string(),
     market: z.string(),
@@ -353,7 +353,7 @@ export enum UserOrderEventType {
 const UserOrderEventTypeSchema = z.enum(UserOrderEventType);
 
 export const UserOrderEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('order'),
     id: z.string(),
     owner: z.string(),
@@ -413,7 +413,7 @@ export const UserOrderEventSchema = z
 export type UserOrderEvent = z.infer<typeof UserOrderEventSchema>;
 
 const TradeMakerOrderSchema = z
-  .looseObject({
+  .object({
     order_id: z.string(),
     owner: z.string(),
     maker_address: z.string().nullish(),
@@ -448,7 +448,7 @@ const TradeMakerOrderSchema = z
 export type TradeMakerOrder = z.infer<typeof TradeMakerOrderSchema>;
 
 export const UserTradeEventSchema = z
-  .looseObject({
+  .object({
     event_type: z.literal('trade'),
     type: z.literal('TRADE'),
     id: z.string(),

--- a/packages/bindings/src/subscriptions/rtds.ts
+++ b/packages/bindings/src/subscriptions/rtds.ts
@@ -130,7 +130,7 @@ export const CryptoPricesEventSchema = z.discriminatedUnion('topic', [
 export type CryptoPricesEvent = z.infer<typeof CryptoPricesEventSchema>;
 
 const EquityPriceUpdatePayloadSchema = z
-  .looseObject({
+  .object({
     symbol: z.string(),
     value: DecimalishSchema,
     full_accuracy_value: DecimalStringSchema.nullish(),

--- a/packages/bindings/src/subscriptions/sports.ts
+++ b/packages/bindings/src/subscriptions/sports.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { EpochMillisecondsToIsoDateTimeStringSchema } from '../shared';
 
 const SportsResultPayloadSchema = z
-  .looseObject({
+  .object({
     gameId: z.number().int(),
     sportradarGameId: z.string().nullish(),
     slug: z.string().nullish(),


### PR DESCRIPTION
## Summary
- Replace all `z.looseObject` usages in bindings schemas with `z.object`.
- Keep existing normalization transforms and public field names unchanged.

## Verification
- Not run: local environment is missing `node`, `pnpm`, and `corepack`, so `pnpm test:bindings`, `pnpm lint`, and `pnpm typecheck` could not be executed.

Linear: DEV-81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switching from `z.looseObject` to `z.object` makes schema validation stricter and may reject API responses that include unexpected/extra fields, potentially causing runtime parse failures in consumers.
> 
> **Overview**
> Updates the bindings’ Zod schemas to use `z.object(...)` instead of `z.looseObject(...)` across CLOB, data, gamma, and subscription payloads.
> 
> All existing `.transform(...)` normalizations and the public output field shapes are intended to remain the same; the primary behavior change is stricter input validation (unknown keys no longer accepted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4897a1789b516b0fb03b5eee43c6aa016dae78c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->