### PR TITLE
fix(client): include request URL in RequestRejectedError message

### DIFF
--- a/packages/client/src/ServiceClient.test.ts
+++ b/packages/client/src/ServiceClient.test.ts
@@ -30,7 +30,7 @@ describe('ServiceClient', () => {
     const client = new ServiceClient({ root });
 
     await expect(unwrap(client.get('/json-error'))).rejects.toMatchObject({
-      message: 'structured failure',
+      message: `structured failure (${root}/json-error)`,
       name: 'RequestRejectedError',
       status: 400,
     });
@@ -50,7 +50,7 @@ describe('ServiceClient', () => {
     await expect(
       unwrap(client.get('/cloudflare-json-error')),
     ).rejects.toMatchObject({
-      message: 'structured cloudflare failure',
+      message: `structured cloudflare failure (${root}/cloudflare-json-error)`,
       name: 'RequestRejectedError',
       status: 400,
     });
@@ -70,7 +70,7 @@ describe('ServiceClient', () => {
     const client = new ServiceClient({ root });
 
     await expect(unwrap(client.get('/text-error'))).rejects.toMatchObject({
-      message: 'plain failure',
+      message: `plain failure (${root}/text-error)`,
       name: 'RequestRejectedError',
       status: 400,
     });
@@ -92,7 +92,7 @@ describe('ServiceClient', () => {
     await expect(
       unwrap(client.get('/cloudflare-text-error')),
     ).rejects.toMatchObject({
-      message: 'plain cloudflare failure',
+      message: `plain cloudflare failure (${root}/cloudflare-text-error)`,
       name: 'RequestRejectedError',
       status: 400,
     });

--- a/packages/client/src/ServiceClient.ts
+++ b/packages/client/src/ServiceClient.ts
@@ -184,7 +184,7 @@ export class ServiceClient {
         }
 
         const message = await this.#extractResponseErrorMessage(response);
-        throw new RequestRejectedError(message, {
+        throw new RequestRejectedError(`${message} (${response.url})`, {
           status: response.status,
         });
       }),


### PR DESCRIPTION
## Summary
- Append the resolved request URL (in parens) to `RequestRejectedError` messages so the failing URL surfaces alongside the server-supplied error body when the error is logged or rendered.
- Resulting format: `RequestRejectedError: <server message> (<url>)`.
- Updates the four exact-match assertions in `ServiceClient.test.ts`; the substring-based Cloudflare/HTML tests are unaffected.

## Test plan
- [x] `pnpm test:client -- ServiceClient` (87 passed, no type errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts error message formatting for non-OK HTTP responses and updates corresponding unit tests; no request/response behavior changes.
> 
> **Overview**
> `ServiceClient` now appends `(${response.url})` to `RequestRejectedError` messages so logs include the failing URL alongside any server-provided error text.
> 
> Updates `ServiceClient.test.ts` expectations for JSON and plain-text error cases to match the new message format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e510907aa05aa034129c72e8786dc19b39bfabc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->