### PR TITLE
fix(client): cap order salt to safe integer range

### DIFF
--- a/packages/client/src/actions/orders/orders.test.ts
+++ b/packages/client/src/actions/orders/orders.test.ts
@@ -63,7 +63,7 @@ describe('createUnsignedOrder', () => {
     );
   });
 
-  it('generates a cryptographically random positive int64 salt', () => {
+  it('generates a cryptographically random salt that fits in a safe integer', () => {
     vi.stubGlobal('crypto', {
       getRandomValues<T extends ArrayBufferView | null>(values: T): T {
         if (!(values instanceof Uint8Array)) {
@@ -82,7 +82,9 @@ describe('createUnsignedOrder', () => {
       walletType: WalletType.DEPOSIT_WALLET,
     });
 
-    expect(order.salt).toBe((2n ** 63n - 1n).toString());
+    expect(order.salt).toBe((2n ** 53n - 1n).toString());
+    expect(Number(order.salt)).toBeLessThanOrEqual(Number.MAX_SAFE_INTEGER);
+    expect(Number.parseInt(order.salt, 10).toString()).toBe(order.salt);
   });
 });
 

--- a/packages/client/src/actions/orders/orders.ts
+++ b/packages/client/src/actions/orders/orders.ts
@@ -58,5 +58,17 @@ function generateOrderSalt(): bigint {
     `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`,
   );
 
-  return value & ((1n << 63n) - 1n);
+  // Cap the salt to 53 bits (Number.MAX_SAFE_INTEGER == 2^53 - 1).
+  //
+  // The CLOB wire contract expects `salt` as a JSON number, so the post
+  // pipeline coerces this string through `Number.parseInt` before sending.
+  // JavaScript `number` is an IEEE-754 double and can only represent integers
+  // exactly up to 2^53 - 1; anything larger is silently rounded. The signature,
+  // however, is produced over the original (un-rounded) salt via `BigInt`, so
+  // any rounding on the wire side causes the server to reconstruct a different
+  // EIP-712 hash and reject the order with "invalid signature".
+  //
+  // 53 bits is still ~9.0e15 of collision space (vastly more than the legacy
+  // `Math.random() * Date.now()` salt), and keeps the wire round-trip lossless.
+  return value & ((1n << 53n) - 1n);
 }


### PR DESCRIPTION
## Summary

- Cap the cryptographically-random order salt to 53 bits so it survives a lossless round-trip through a JavaScript `number` on the wire payload.
- Fixes the `invalid signature` failures currently seen on integration tests on `main` (e.g. `placeLimitOrder`, `cancelOrders`, `cancelAll`, user-subscription order event).

## Root cause

The recent salt change introduced two related edits:

- `orders.ts` now generates a 63-bit unsigned salt via `crypto.getRandomValues`.
- `post.ts` coerces the salt onto the wire with `Number.parseInt(order.salt, 10)`, matching the CLOB contract which expects a JSON number.

`Number.parseInt` returns an IEEE-754 `number`, which can only represent integers exactly up to `Number.MAX_SAFE_INTEGER` (`2^53 - 1`). Salts above that ceiling — the vast majority of 63-bit values — are silently rounded before being sent.

The signature, however, is produced over the original salt via `BigInt(order.salt)` in `typed-data.ts`. The server reconstructs the EIP-712 hash from the rounded salt it received on the wire, recovers a different address, and rejects the order with `invalid signature`.

```
salt string : 9223372036854775807
parseInt →  : 9223372036854776000   (rounded, off by 193)
```

## Fix

Mask the generated salt with `(1n << 53n) - 1n` so `Number.parseInt` is lossless. Collision space stays at ~9.0e15, which is still ~2^12× more than the legacy `Math.random() * Date.now()` salt (~2^41), and the CSPRNG / unpredictability properties of the new approach are preserved.

A clear comment in `generateOrderSalt` documents the constraint and the failure mode it prevents, so the next person touching this code doesn't widen the range without also updating the wire shape.

## Test plan

- Unit: updated `orders.test.ts` to assert the salt fits in `Number.MAX_SAFE_INTEGER` and round-trips losslessly through `Number.parseInt`.
- `pnpm lint` ✅
- Reproduced the original `invalid signature` failures on `main` against the limit-order integration tests in `packages/client/tests/integration/orders.test.ts` before the fix; want to re-run them on this branch to confirm green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order creation by changing `salt` generation, which can impact signature validity and order acceptance if incorrect, but the change is small and covered by updated unit tests.
> 
> **Overview**
> Caps `generateOrderSalt()` output from 63 bits to **53 bits** so `salt` remains lossless when coerced to a JSON `number` (via `Number.parseInt` in the posting pipeline), preventing wire-side rounding that can cause **"invalid signature"** rejections.
> 
> Updates the unit test to assert the salt equals `2^53 - 1` under a fixed RNG stub and that it round-trips cleanly through `Number`/`Number.parseInt` while staying `<= Number.MAX_SAFE_INTEGER`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea8641af508c0e5c3eb1cdbb8c6e366a10b84d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->