### PR TITLE
fix(client): avoid doubled URL in RequestRejectedError message

### DIFF
--- a/packages/client/src/ServiceClient.test.ts
+++ b/packages/client/src/ServiceClient.test.ts
@@ -2,7 +2,6 @@ import { unwrap } from '@polymarket/types';
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { RequestRejectedError } from './errors';
 import { ServiceClient } from './ServiceClient';
 
 const root = 'http://localhost:4011';
@@ -114,13 +113,11 @@ describe('ServiceClient', () => {
     );
     const client = new ServiceClient({ root });
 
-    await expect(unwrap(client.get('/html-error'))).rejects.toSatisfy(
-      (error: unknown) =>
-        error instanceof RequestRejectedError &&
-        error.status === 502 &&
-        error.message.includes('blocked by Cloudflare') &&
-        !error.message.includes('Cloudflare error'),
-    );
+    await expect(unwrap(client.get('/html-error'))).rejects.toMatchObject({
+      message: `Request to ${root}/html-error was blocked by Cloudflare with status 502`,
+      name: 'RequestRejectedError',
+      status: 502,
+    });
   });
 
   it('identifies unreadable HTML errors when the server is unknown', async () => {
@@ -136,12 +133,32 @@ describe('ServiceClient', () => {
     );
     const client = new ServiceClient({ root });
 
-    await expect(unwrap(client.get('/generic-html-error'))).rejects.toSatisfy(
-      (error: unknown) =>
-        error instanceof RequestRejectedError &&
-        error.status === 502 &&
-        error.message.includes('unexpected HTML response body') &&
-        !error.message.includes('Gateway error'),
+    await expect(
+      unwrap(client.get('/generic-html-error')),
+    ).rejects.toMatchObject({
+      message: `Request to ${root}/generic-html-error failed with status 502 and an unexpected HTML response body`,
+      name: 'RequestRejectedError',
+      status: 502,
+    });
+  });
+
+  it('falls back to an unreadable-body message for unknown content types', async () => {
+    server.use(
+      http.get(
+        `${root}/binary-error`,
+        () =>
+          new HttpResponse(new Uint8Array([0, 1, 2, 3]), {
+            headers: { 'content-type': 'application/octet-stream' },
+            status: 500,
+          }),
+      ),
     );
+    const client = new ServiceClient({ root });
+
+    await expect(unwrap(client.get('/binary-error'))).rejects.toMatchObject({
+      message: `Request to ${root}/binary-error failed with status 500 and unreadable response body`,
+      name: 'RequestRejectedError',
+      status: 500,
+    });
   });
 });

--- a/packages/client/src/ServiceClient.ts
+++ b/packages/client/src/ServiceClient.ts
@@ -184,7 +184,7 @@ export class ServiceClient {
         }
 
         const message = await this.#extractResponseErrorMessage(response);
-        throw new RequestRejectedError(`${message} (${response.url})`, {
+        throw new RequestRejectedError(message, {
           status: response.status,
         });
       }),
@@ -209,7 +209,7 @@ export class ServiceClient {
         .clone()
         .json()
         .catch(() => ({}));
-      if (error) return String(error);
+      if (error) return `${String(error)} (${response.url})`;
     }
 
     if (contentType?.includes('text/plain')) {
@@ -222,7 +222,7 @@ export class ServiceClient {
         );
 
       if (text) {
-        return text;
+        return `${text} (${response.url})`;
       }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #39. That change unconditionally appended `(${response.url})` at the `throw` site in `ServiceClient`, but `#extractResponseErrorMessage` already embeds `response.url` in three of its fallback branches, producing doubled URLs like:

> `Request to https://api.example.com/foo was blocked by Cloudflare with status 502 (https://api.example.com/foo)`

Only the JSON-error and plain-text branches returned a body-only string that genuinely benefited from the appended URL. The existing tests used `.includes(...)` assertions that didn't catch the duplication.

## Changes

- `ServiceClient.ts`: revert the throw site to `new RequestRejectedError(message, { status })`; append `(${response.url})` only inside the JSON-error and plain-text branches of `#extractResponseErrorMessage`. The Cloudflare, HTML, and unreadable-body branches keep their existing self-contained messages.
- `ServiceClient.test.ts`: tighten the Cloudflare-no-body and HTML fallback assertions from `.includes()` to full-string `toMatchObject`, and add a new test for the unreadable-body branch (`application/octet-stream`) so the doubling can't regress.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:client` (89 tests pass)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error-message formatting in `ServiceClient` plus stricter unit tests, with no impact on request behavior beyond the thrown message text.
> 
> **Overview**
> Fixes `ServiceClient` error reporting to **avoid duplicating `response.url`** by removing URL appending at the `RequestRejectedError` throw site and only including it for JSON/plain-text body-derived errors.
> 
> Updates `ServiceClient.test.ts` to assert full error objects/messages for Cloudflare and HTML fallback cases, and adds coverage for the unreadable-body fallback on unknown/binary content types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc01addc3f059de9e0a0cbf9b40d7ab204ad63a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->