### PR TITLE
Default secure account methods to wallet

### DIFF
--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -40,127 +40,31 @@ import type {
 } from '../clients';
 import type { Paginated } from '../pagination';
 
-export type AccountPublicActions = {
-  /**
-   * Lists current positions for a wallet.
-   *
-   * @throws {@link ListPositionsError}
-   * Thrown on failure.
-   *
-   * @example
-   * Fetch the first page of results:
-   * ```ts
-   * const paginator = client.listPositions({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   *   pageSize: 10,
-   * });
-   *
-   * const firstPage = await paginator.firstPage();
-   *
-   * // Optionally, fetch additional pages:
-   * for await (const page of paginator.from(firstPage.nextCursor)) {
-   *   // page.items: Position[]
-   * }
-   * ```
-   *
-   * @example
-   * Loop through all pages with `for await`:
-   * ```ts
-   * const paginator = client.listPositions({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   *   pageSize: 10,
-   * });
-   *
-   * for await (const page of paginator) {
-   *   // page.items: Position[]
-   * }
-   * ```
-   */
-  listPositions(request: ListPositionsRequest): Paginated<Position[]>;
-  /**
-   * Lists closed positions for a wallet.
-   *
-   * @throws {@link ListClosedPositionsError}
-   * Thrown on failure.
-   *
-   * @example
-   * Fetch the first page of results:
-   * ```ts
-   * const paginator = client.listClosedPositions({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   *   pageSize: 10,
-   * });
-   *
-   * const firstPage = await paginator.firstPage();
-   *
-   * // Optionally, fetch additional pages:
-   * for await (const page of paginator.from(firstPage.nextCursor)) {
-   *   // page.items: ClosedPosition[]
-   * }
-   * ```
-   *
-   * @example
-   * Loop through all pages with `for await`:
-   * ```ts
-   * const paginator = client.listClosedPositions({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   *   pageSize: 10,
-   * });
-   *
-   * for await (const page of paginator) {
-   *   // page.items: ClosedPosition[]
-   * }
-   * ```
-   */
-  listClosedPositions(
-    request: ListClosedPositionsRequest,
-  ): Paginated<ClosedPosition[]>;
-  /**
-   * Fetches the total value for a wallet's positions.
-   *
-   * @throws {@link FetchPortfolioValueError}
-   * Thrown on failure.
-   *
-   * @example
-   * ```ts
-   * const value = await client.fetchPortfolioValue({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   * });
-   * ```
-   */
-  fetchPortfolioValue(request: FetchPortfolioValueRequest): Promise<Value[]>;
-  /**
-   * Fetches the total number of markets a wallet has traded.
-   *
-   * @throws {@link FetchTradedMarketCountError}
-   * Thrown on failure.
-   *
-   * @example
-   * ```ts
-   * const traded = await client.fetchTradedMarketCount({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   * });
-   * ```
-   */
-  fetchTradedMarketCount(
-    request: FetchTradedMarketCountRequest,
-  ): Promise<Traded>;
-  /**
-   * Downloads an accounting snapshot archive for a wallet.
-   *
-   * @throws {@link DownloadAccountingSnapshotError}
-   * Thrown on failure.
-   *
-   * @example
-   * ```ts
-   * const snapshot = await client.downloadAccountingSnapshot({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   * });
-   * ```
-   */
-  downloadAccountingSnapshot(
-    request: DownloadAccountingSnapshotRequest,
-  ): Promise<Blob>;
+type DefaultAccountWallet<TRequest extends { user: string }> = Prettify<
+  Omit<TRequest, 'user'> & {
+    /**
+     * Wallet address to use.
+     *
+     * @defaultValue `client.account.wallet`
+     */
+    user?: TRequest['user'];
+  }
+>;
+
+export type SecureListPositionsRequest =
+  DefaultAccountWallet<ListPositionsRequest>;
+export type SecureListClosedPositionsRequest =
+  DefaultAccountWallet<ListClosedPositionsRequest>;
+export type SecureFetchPortfolioValueRequest =
+  DefaultAccountWallet<FetchPortfolioValueRequest>;
+export type SecureFetchTradedMarketCountRequest =
+  DefaultAccountWallet<FetchTradedMarketCountRequest>;
+export type SecureDownloadAccountingSnapshotRequest =
+  DefaultAccountWallet<DownloadAccountingSnapshotRequest>;
+export type SecureListActivityRequest =
+  DefaultAccountWallet<ListActivityRequest>;
+
+type CommonAccountActions = {
   /**
    * Lists positions for a market.
    *
@@ -199,46 +103,243 @@ export type AccountPublicActions = {
   listMarketPositions(
     request: ListMarketPositionsRequest,
   ): Paginated<MetaMarketPosition[]>;
-  /**
-   * Lists wallet activity.
-   *
-   * @throws {@link ListActivityError}
-   * Thrown on failure.
-   *
-   * @example
-   * Fetch the first page of results:
-   * ```ts
-   * const paginator = client.listActivity({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   *   pageSize: 10,
-   * });
-   *
-   * const firstPage = await paginator.firstPage();
-   *
-   * // Optionally, fetch additional pages:
-   * for await (const page of paginator.from(firstPage.nextCursor)) {
-   *   // page.items: Activity[]
-   * }
-   * ```
-   *
-   * @example
-   * Loop through all pages with `for await`:
-   * ```ts
-   * const paginator = client.listActivity({
-   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
-   *   pageSize: 10,
-   * });
-   *
-   * for await (const page of paginator) {
-   *   // page.items: Activity[]
-   * }
-   * ```
-   */
-  listActivity(request: ListActivityRequest): Paginated<Activity[]>;
 };
 
-export type AccountActions = Prettify<
-  AccountPublicActions & {
+export type PublicAccountActions = Prettify<
+  CommonAccountActions & {
+    /**
+     * Lists current positions for a wallet.
+     *
+     * @throws {@link ListPositionsError}
+     * Thrown on failure.
+     *
+     * @example
+     * Fetch the first page of results:
+     * ```ts
+     * const paginator = client.listPositions({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     *   pageSize: 10,
+     * });
+     *
+     * const firstPage = await paginator.firstPage();
+     *
+     * // Optionally, fetch additional pages:
+     * for await (const page of paginator.from(firstPage.nextCursor)) {
+     *   // page.items: Position[]
+     * }
+     * ```
+     *
+     * @example
+     * Loop through all pages with `for await`:
+     * ```ts
+     * const paginator = client.listPositions({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     *   pageSize: 10,
+     * });
+     *
+     * for await (const page of paginator) {
+     *   // page.items: Position[]
+     * }
+     * ```
+     */
+    listPositions(request: ListPositionsRequest): Paginated<Position[]>;
+    /**
+     * Lists closed positions for a wallet.
+     *
+     * @throws {@link ListClosedPositionsError}
+     * Thrown on failure.
+     *
+     * @example
+     * Fetch the first page of results:
+     * ```ts
+     * const paginator = client.listClosedPositions({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     *   pageSize: 10,
+     * });
+     *
+     * const firstPage = await paginator.firstPage();
+     *
+     * // Optionally, fetch additional pages:
+     * for await (const page of paginator.from(firstPage.nextCursor)) {
+     *   // page.items: ClosedPosition[]
+     * }
+     * ```
+     *
+     * @example
+     * Loop through all pages with `for await`:
+     * ```ts
+     * const paginator = client.listClosedPositions({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     *   pageSize: 10,
+     * });
+     *
+     * for await (const page of paginator) {
+     *   // page.items: ClosedPosition[]
+     * }
+     * ```
+     */
+    listClosedPositions(
+      request: ListClosedPositionsRequest,
+    ): Paginated<ClosedPosition[]>;
+    /**
+     * Fetches the total value for a wallet's positions.
+     *
+     * @throws {@link FetchPortfolioValueError}
+     * Thrown on failure.
+     *
+     * @example
+     * ```ts
+     * const value = await client.fetchPortfolioValue({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     * });
+     * ```
+     */
+    fetchPortfolioValue(request: FetchPortfolioValueRequest): Promise<Value[]>;
+    /**
+     * Fetches the total number of markets a wallet has traded.
+     *
+     * @throws {@link FetchTradedMarketCountError}
+     * Thrown on failure.
+     *
+     * @example
+     * ```ts
+     * const traded = await client.fetchTradedMarketCount({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     * });
+     * ```
+     */
+    fetchTradedMarketCount(
+      request: FetchTradedMarketCountRequest,
+    ): Promise<Traded>;
+    /**
+     * Downloads an accounting snapshot archive for a wallet.
+     *
+     * @throws {@link DownloadAccountingSnapshotError}
+     * Thrown on failure.
+     *
+     * @example
+     * ```ts
+     * const snapshot = await client.downloadAccountingSnapshot({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     * });
+     * ```
+     */
+    downloadAccountingSnapshot(
+      request: DownloadAccountingSnapshotRequest,
+    ): Promise<Blob>;
+    /**
+     * Lists wallet activity.
+     *
+     * @throws {@link ListActivityError}
+     * Thrown on failure.
+     *
+     * @example
+     * Fetch the first page of results:
+     * ```ts
+     * const paginator = client.listActivity({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     *   pageSize: 10,
+     * });
+     *
+     * const firstPage = await paginator.firstPage();
+     *
+     * // Optionally, fetch additional pages:
+     * for await (const page of paginator.from(firstPage.nextCursor)) {
+     *   // page.items: Activity[]
+     * }
+     * ```
+     *
+     * @example
+     * Loop through all pages with `for await`:
+     * ```ts
+     * const paginator = client.listActivity({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     *   pageSize: 10,
+     * });
+     *
+     * for await (const page of paginator) {
+     *   // page.items: Activity[]
+     * }
+     * ```
+     */
+    listActivity(request: ListActivityRequest): Paginated<Activity[]>;
+  }
+>;
+
+export type SecureAccountActions = Prettify<
+  CommonAccountActions & {
+    /**
+     * Lists current positions for a wallet.
+     *
+     * Defaults to the authenticated account's wallet when `user` is omitted.
+     *
+     * @throws {@link ListPositionsError}
+     * Thrown on failure.
+     *
+     * @example
+     * Fetch the first page of results for the authenticated account:
+     * ```ts
+     * const paginator = client.listPositions({
+     *   pageSize: 10,
+     * });
+     *
+     * const firstPage = await paginator.firstPage();
+     * ```
+     */
+    listPositions(request?: SecureListPositionsRequest): Paginated<Position[]>;
+    /**
+     * Lists closed positions for a wallet.
+     *
+     * Defaults to the authenticated account's wallet when `user` is omitted.
+     *
+     * @throws {@link ListClosedPositionsError}
+     * Thrown on failure.
+     */
+    listClosedPositions(
+      request?: SecureListClosedPositionsRequest,
+    ): Paginated<ClosedPosition[]>;
+    /**
+     * Fetches the total value for a wallet's positions.
+     *
+     * Defaults to the authenticated account's wallet when `user` is omitted.
+     *
+     * @throws {@link FetchPortfolioValueError}
+     * Thrown on failure.
+     */
+    fetchPortfolioValue(
+      request?: SecureFetchPortfolioValueRequest,
+    ): Promise<Value[]>;
+    /**
+     * Fetches the total number of markets a wallet has traded.
+     *
+     * Defaults to the authenticated account's wallet when `user` is omitted.
+     *
+     * @throws {@link FetchTradedMarketCountError}
+     * Thrown on failure.
+     */
+    fetchTradedMarketCount(
+      request?: SecureFetchTradedMarketCountRequest,
+    ): Promise<Traded>;
+    /**
+     * Downloads an accounting snapshot archive for a wallet.
+     *
+     * Defaults to the authenticated account's wallet when `user` is omitted.
+     *
+     * @throws {@link DownloadAccountingSnapshotError}
+     * Thrown on failure.
+     */
+    downloadAccountingSnapshot(
+      request?: SecureDownloadAccountingSnapshotRequest,
+    ): Promise<Blob>;
+    /**
+     * Lists wallet activity.
+     *
+     * Defaults to the authenticated account's wallet when `user` is omitted.
+     *
+     * @throws {@link ListActivityError}
+     * Thrown on failure.
+     */
+    listActivity(request?: SecureListActivityRequest): Paginated<Activity[]>;
     /**
      * Lists trades for the authenticated account across all pages.
      *
@@ -316,7 +417,7 @@ export type AccountActions = Prettify<
   }
 >;
 
-function publicAccountActions(client: BaseClient): AccountPublicActions {
+function publicAccountActions(client: BaseClient): PublicAccountActions {
   return {
     listPositions: listPositions.bind(null, client),
     listClosedPositions: listClosedPositions.bind(null, client),
@@ -328,11 +429,21 @@ function publicAccountActions(client: BaseClient): AccountPublicActions {
   };
 }
 
-export function accountActions(client: BasePublicClient): AccountPublicActions;
-export function accountActions(client: BaseSecureClient): AccountActions;
+function withAccountWallet<TRequest extends { user?: string }>(
+  client: BaseSecureClient,
+  request: TRequest = {} as TRequest,
+): Omit<TRequest, 'user'> & { user: string } {
+  return {
+    ...request,
+    user: request.user ?? client.account.wallet,
+  };
+}
+
+export function accountActions(client: BasePublicClient): PublicAccountActions;
+export function accountActions(client: BaseSecureClient): SecureAccountActions;
 export function accountActions(
   client: BaseClient,
-): AccountPublicActions | AccountActions {
+): PublicAccountActions | SecureAccountActions {
   const actions = publicAccountActions(client);
 
   if (client.isPublicClient()) {
@@ -341,6 +452,19 @@ export function accountActions(
 
   return {
     ...actions,
+    listPositions: (request?: SecureListPositionsRequest) =>
+      listPositions(client, withAccountWallet(client, request)),
+    listClosedPositions: (request?: SecureListClosedPositionsRequest) =>
+      listClosedPositions(client, withAccountWallet(client, request)),
+    fetchPortfolioValue: (request?: SecureFetchPortfolioValueRequest) =>
+      fetchPortfolioValue(client, withAccountWallet(client, request)),
+    fetchTradedMarketCount: (request?: SecureFetchTradedMarketCountRequest) =>
+      fetchTradedMarketCount(client, withAccountWallet(client, request)),
+    downloadAccountingSnapshot: (
+      request?: SecureDownloadAccountingSnapshotRequest,
+    ) => downloadAccountingSnapshot(client, withAccountWallet(client, request)),
+    listActivity: (request?: SecureListActivityRequest) =>
+      listActivity(client, withAccountWallet(client, request)),
     listAccountTrades: listAccountTrades.bind(null, client),
     fetchNotifications: fetchNotifications.bind(null, client),
     dropNotifications: dropNotifications.bind(null, client),
@@ -350,7 +474,7 @@ export function accountActions(
 
 // Error unions and runtime `isError` guards for every action bound above.
 // Surfaced at the root entry point through `export * from './decorators'`.
-// Keep this list in sync with the methods on AccountPublicActions / AccountActions.
+// Keep this list in sync with the methods on PublicAccountActions / SecureAccountActions.
 export {
   DownloadAccountingSnapshotError,
   DropNotificationsError,

--- a/packages/client/src/decorators/index.ts
+++ b/packages/client/src/decorators/index.ts
@@ -5,32 +5,32 @@ import type {
   BaseSecureClient,
 } from '../clients';
 import {
-  type AccountActions,
-  type AccountPublicActions,
   accountActions,
+  type PublicAccountActions,
+  type SecureAccountActions,
 } from './account';
 import { type AnalyticsActions, analyticsActions } from './analytics';
 import { type DataActions, dataActions } from './data';
 import { type DiscoveryActions, discoveryActions } from './discovery';
 import {
-  type RewardsActions,
-  type RewardsPublicActions,
+  type PublicRewardsActions,
   rewardsActions,
+  type SecureRewardsActions,
 } from './rewards';
 import {
   type PublicSubscriptionsActions,
   type SecureSubscriptionsActions,
   subscriptionsActions,
 } from './subscriptions';
-import { type TradingActions, tradingActions } from './trading';
-import { type WalletActions, walletActions } from './wallet';
+import { type SecureTradingActions, tradingActions } from './trading';
+import { type SecureWalletActions, walletActions } from './wallet';
 
 export type PublicActions = Prettify<
   DiscoveryActions &
     DataActions &
     AnalyticsActions &
-    AccountPublicActions &
-    RewardsPublicActions &
+    PublicAccountActions &
+    PublicRewardsActions &
     PublicSubscriptionsActions
 >;
 
@@ -38,11 +38,11 @@ export type SecureActions = Prettify<
   DiscoveryActions &
     DataActions &
     AnalyticsActions &
-    AccountActions &
-    RewardsActions &
+    SecureAccountActions &
+    SecureRewardsActions &
     SecureSubscriptionsActions &
-    WalletActions &
-    TradingActions
+    SecureWalletActions &
+    SecureTradingActions
 >;
 
 export function allActions(client: BasePublicClient): PublicActions;

--- a/packages/client/src/decorators/rewards.ts
+++ b/packages/client/src/decorators/rewards.ts
@@ -32,7 +32,7 @@ import type {
 } from '../clients';
 import type { Paginated } from '../pagination';
 
-export type RewardsPublicActions = {
+export type PublicRewardsActions = {
   /**
    * Lists current active market rewards.
    *
@@ -105,8 +105,8 @@ export type RewardsPublicActions = {
   ): Paginated<MarketReward[]>;
 };
 
-export type RewardsActions = Prettify<
-  RewardsPublicActions & {
+export type SecureRewardsActions = Prettify<
+  PublicRewardsActions & {
     /**
      * Fetches whether a single order is currently scoring.
      *
@@ -240,18 +240,18 @@ export type RewardsActions = Prettify<
   }
 >;
 
-function publicRewardsActions(client: BaseClient): RewardsPublicActions {
+function publicRewardsActions(client: BaseClient): PublicRewardsActions {
   return {
     listCurrentRewards: listCurrentRewards.bind(null, client),
     listMarketRewards: listMarketRewards.bind(null, client),
   };
 }
 
-export function rewardsActions(client: BasePublicClient): RewardsPublicActions;
-export function rewardsActions(client: BaseSecureClient): RewardsActions;
+export function rewardsActions(client: BasePublicClient): PublicRewardsActions;
+export function rewardsActions(client: BaseSecureClient): SecureRewardsActions;
 export function rewardsActions(
   client: BaseClient,
-): RewardsPublicActions | RewardsActions {
+): PublicRewardsActions | SecureRewardsActions {
   const actions = publicRewardsActions(client);
 
   if (client.isPublicClient()) {
@@ -277,7 +277,7 @@ export function rewardsActions(
 
 // Error unions and runtime `isError` guards for every action bound above.
 // Surfaced at the root entry point through `export * from './decorators'`.
-// Keep this list in sync with the methods on RewardsPublicActions / RewardsActions.
+// Keep this list in sync with the methods on PublicRewardsActions / SecureRewardsActions.
 export {
   FetchOrderScoringError,
   FetchOrdersScoringError,

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -30,7 +30,7 @@ import type { SignedOrder } from '../actions/orders';
 import type { BaseSecureClient } from '../clients';
 import type { Paginated } from '../pagination';
 
-export type TradingActions = {
+export type SecureTradingActions = {
   /**
    * Creates a signed market order for the authenticated account.
    *
@@ -238,8 +238,8 @@ export type TradingActions = {
   fetchOrder(request: FetchOrderRequest): Promise<OpenOrder>;
 };
 
-export function tradingActions(client: BaseSecureClient): TradingActions;
-export function tradingActions(client: BaseSecureClient): TradingActions {
+export function tradingActions(client: BaseSecureClient): SecureTradingActions;
+export function tradingActions(client: BaseSecureClient): SecureTradingActions {
   return {
     createMarketOrder: createMarketOrder.bind(null, client),
     placeMarketOrder: placeMarketOrder.bind(null, client),
@@ -258,7 +258,7 @@ export function tradingActions(client: BaseSecureClient): TradingActions {
 
 // Error unions and runtime `isError` guards for every action bound above.
 // Surfaced at the root entry point through `export * from './decorators'`.
-// Keep this list in sync with the methods on TradingActions.
+// Keep this list in sync with the methods on SecureTradingActions.
 export {
   CancelAllError,
   CancelMarketOrdersError,

--- a/packages/client/src/decorators/wallet.ts
+++ b/packages/client/src/decorators/wallet.ts
@@ -17,7 +17,7 @@ import {
 import type { BaseSecureClient } from '../clients';
 import type { TransactionHandle } from '../types';
 
-export type WalletActions = {
+export type SecureWalletActions = {
   /**
    * Checks whether the authenticated account wallet is ready for gasless transactions.
    *
@@ -182,7 +182,7 @@ export type WalletActions = {
   ): Promise<TransactionHandle>;
 };
 
-export function walletActions(client: BaseSecureClient): WalletActions {
+export function walletActions(client: BaseSecureClient): SecureWalletActions {
   return {
     isGaslessReady: () =>
       isGaslessReady(client, {

--- a/packages/client/tests/integration/activity.test.ts
+++ b/packages/client/tests/integration/activity.test.ts
@@ -1,4 +1,4 @@
-import { expectPresent } from '@polymarket/types';
+import { expectPresent, isSameEvmAddress } from '@polymarket/types';
 import { describe, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
@@ -51,6 +51,20 @@ describe('Activity', () => {
           type: 'TRADE',
           wallet: TEST_USER,
         }),
+      );
+    });
+
+    it('defaults secure clients to the authenticated wallet', async ({
+      depositWalletAddress,
+      secureClientWithDepositWallet,
+    }) => {
+      const result = await secureClientWithDepositWallet
+        .listActivity({ pageSize: 1, type: ['TRADE'] })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      expect(expectPresent(result.items[0]).wallet).toSatisfy((wallet) =>
+        isSameEvmAddress(wallet, depositWalletAddress),
       );
     });
   });

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -1,3 +1,4 @@
+import { isSameEvmAddress } from '@polymarket/types';
 import { describe, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
@@ -21,6 +22,20 @@ describe('Portfolio', () => {
         }),
       );
     });
+
+    it('defaults secure clients to the authenticated wallet', async ({
+      depositWalletAddress,
+      secureClientWithDepositWallet,
+    }) => {
+      const result = await secureClientWithDepositWallet
+        .listPositions({ pageSize: 1 })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      expect(result.items[0]?.wallet).toSatisfy((wallet) =>
+        isSameEvmAddress(wallet, depositWalletAddress),
+      );
+    });
   });
 
   describe('listClosedPositions', () => {
@@ -40,6 +55,20 @@ describe('Portfolio', () => {
         }),
       );
     });
+
+    it('defaults secure clients to the authenticated wallet', async ({
+      depositWalletAddress,
+      secureClientWithDepositWallet,
+    }) => {
+      const result = await secureClientWithDepositWallet
+        .listClosedPositions({ pageSize: 1 })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      expect(result.items[0]?.wallet).toSatisfy((wallet) =>
+        isSameEvmAddress(wallet, depositWalletAddress),
+      );
+    });
   });
 
   describe('fetchPortfolioValue', () => {
@@ -54,6 +83,17 @@ describe('Portfolio', () => {
           value: expect.any(String),
         }),
       ]);
+    });
+
+    it('defaults secure clients to the authenticated wallet', async ({
+      depositWalletAddress,
+      secureClientWithDepositWallet,
+    }) => {
+      const result = await secureClientWithDepositWallet.fetchPortfolioValue();
+
+      expect(result[0]?.user).toSatisfy((user) =>
+        isSameEvmAddress(user, depositWalletAddress),
+      );
     });
   });
 
@@ -72,6 +112,18 @@ describe('Portfolio', () => {
         }),
       );
     });
+
+    it('defaults secure clients to the authenticated wallet', async ({
+      depositWalletAddress,
+      secureClientWithDepositWallet,
+    }) => {
+      const result =
+        await secureClientWithDepositWallet.fetchTradedMarketCount();
+
+      expect(result.user).toSatisfy((user) =>
+        isSameEvmAddress(user, depositWalletAddress),
+      );
+    });
   });
 
   describe('downloadAccountingSnapshot', () => {
@@ -81,6 +133,17 @@ describe('Portfolio', () => {
       const result = await publicClient.downloadAccountingSnapshot({
         user: TEST_USER,
       });
+
+      expect(result).toBeInstanceOf(Blob);
+      expect(result.size).toBeGreaterThan(0);
+      expect(result.type).toBe('application/zip');
+    });
+
+    it('defaults secure clients to the authenticated wallet', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const result =
+        await secureClientWithDepositWallet.downloadAccountingSnapshot();
 
       expect(result).toBeInstanceOf(Blob);
       expect(result.size).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Defaults secure account portfolio/activity methods to the authenticated wallet when `user` is omitted.
- Renames public/secure decorator action group types to follow the `Public...Actions` / `Secure...Actions` convention.
- Adds integration coverage using real `SecureClient` fixtures for default-wallet behavior.

## Tests
- `pnpm vitest --project client-integration packages/client/tests/integration/portfolio.test.ts packages/client/tests/integration/activity.test.ts`
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request signatures and runtime behavior for several `SecureClient` account methods by making `user` optional and defaulting it to `client.account.wallet`, which could affect callers that previously relied on explicit wallet selection or passed empty objects. Also introduces type renames (`Public...Actions`/`Secure...Actions`) that may be breaking for downstream TypeScript consumers.
> 
> **Overview**
> **Secure account portfolio/activity methods now default to the authenticated wallet.** In `decorators/account.ts`, `SecureClient` versions of `listPositions`, `listClosedPositions`, `fetchPortfolioValue`, `fetchTradedMarketCount`, `downloadAccountingSnapshot`, and `listActivity` accept an optional request and auto-fill `user` from `client.account.wallet` via a new `withAccountWallet` helper.
> 
> **Decorator action type naming was standardized.** Renames exported action-group types to `Public...Actions` / `Secure...Actions` across `account`, `rewards`, `trading`, and `wallet`, and updates `decorators/index.ts` aggregation types accordingly.
> 
> **Integration coverage added.** New tests assert the default-wallet behavior for secure clients in `activity.test.ts` and `portfolio.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18a248441ff7013e036c509d35a2b8fc181f03fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->