### PR TITLE
Recover allowance after order rejection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@
 - Introduce helpers only when they meaningfully improve reuse, safety, or readability. Helper names should reflect their real behavior; otherwise inline or rename them.
 - Shape implementation abstractions around real supported workflows and current platform behavior, not generic completeness. Add breadth only when a concrete use case requires it.
 - When translating one public error into another at an action boundary, prefer `ResultAsync.mapErr(...)` on the request pipeline over `try`/`catch` around `unwrap(...)` when the remap can stay inside the result chain.
+- When an action starts calling another action, awaiting a workflow step, waiting on a transaction handle, or otherwise adding a new operation that can throw, validate the containing action's public `...Error` union and runtime `makeErrorGuard(...)`. Add any newly propagated public errors unless they are caught, remapped, or intentionally handled before crossing the action boundary.
 - Prefer TypeScript enums with `z.enum(MyEnum)` over `z.union([z.literal(...), ...])` for string-valued sets. This gives consumers dot-notation access, keeps the schema and type in sync, and avoids `z.nativeEnum` which is deprecated in Zod v4.
 - In TSDoc `@example` blocks, do not include import statements. Keep examples focused on usage only.
 - Public TSDoc must not mention underlying service boundaries such as Gamma, CLOB, Data API, or relayer. Public docs should describe the unified SDK surface, while tests may mention the underlying services when useful.

--- a/packages/bindings/src/clob/order-response.ts
+++ b/packages/bindings/src/clob/order-response.ts
@@ -34,7 +34,7 @@ export const OrderPostStatusSchema = z.nativeEnum(OrderPostStatus);
 export enum OrderResponseErrorCode {
   UNMATCHED = 'unmatched',
   MARKET_NOT_READY = 'market_not_ready',
-  NOT_ENOUGH_BALANCE = 'not_enough_balance',
+  INSUFFICIENT_BALANCE_OR_ALLOWANCE = 'insufficient_balance_or_allowance',
   INVALID_NONCE = 'invalid_nonce',
   INVALID_EXPIRATION = 'invalid_expiration',
   POST_ONLY_WOULD_CROSS = 'post_only_would_cross',
@@ -156,8 +156,10 @@ function inferOrderResponseErrorCode(
       return OrderResponseErrorCode.FAK_NOT_FILLED;
   }
 
+  // CLOB currently returns one legacy text bucket for both balance and
+  // allowance failures, so expose a combined structured code here.
   if (response.errorMsg.includes('not enough balance / allowance')) {
-    return OrderResponseErrorCode.NOT_ENOUGH_BALANCE;
+    return OrderResponseErrorCode.INSUFFICIENT_BALANCE_OR_ALLOWANCE;
   }
 
   return OrderResponseErrorCode.UNKNOWN;

--- a/packages/client/src/actions/orders/prepare.ts
+++ b/packages/client/src/actions/orders/prepare.ts
@@ -1,10 +1,4 @@
-import { OrderSide } from '@polymarket/bindings';
-import { AssetType } from '@polymarket/bindings/clob';
-import {
-  type EvmAddress,
-  type EvmSignature,
-  expectEvmSignature,
-} from '@polymarket/types';
+import { expectEvmSignature } from '@polymarket/types';
 import type { BaseSecureClient } from '../../clients';
 import {
   InsufficientLiquidityError,
@@ -17,15 +11,6 @@ import {
   UserInputError,
 } from '../../errors';
 import { parseUserInput } from '../../input';
-import type { TransactionHandle } from '../../types';
-import { updateBalanceAllowance } from '../account';
-import {
-  type Erc20ApprovalWorkflowRequest,
-  type Erc1155ApprovalForAllWorkflowRequest,
-  prepareErc20Approval,
-  prepareErc1155ApprovalForAll,
-} from '../approvals';
-import { resolveCurrentAllowance } from './allowance';
 import { PrepareLimitOrderParamsSchema, prepareLimitOrderDraft } from './limit';
 import {
   PrepareMarketOrderParamsSchema,
@@ -38,7 +23,6 @@ import {
   createOrderTypedDataPayload,
 } from './typed-data';
 import {
-  type OrderDraft,
   type OrderPostingWorkflow,
   type OrderWorkflow,
   type PrepareLimitOrderRequest,
@@ -90,8 +74,6 @@ export async function prepareMarketOrder(
 
   return async function* (): OrderWorkflow {
     const draft = await prepareMarketOrderDraft(client, params);
-
-    yield* ensureOrderApproval(client, draft);
 
     const unsignedOrder = createUnsignedOrder(draft, client.account);
 
@@ -150,8 +132,6 @@ export async function prepareLimitOrder(
 
   return async function* (): OrderWorkflow {
     const draft = await prepareLimitOrderDraft(client, params);
-
-    yield* ensureOrderApproval(client, draft);
 
     const unsignedOrder = createUnsignedOrder(draft, client.account);
 
@@ -240,45 +220,4 @@ async function createOrderPostingWorkflow(
 
     return postOrder(client)(order);
   }.call(null);
-}
-
-async function* ensureOrderApproval(
-  client: BaseSecureClient,
-  draft: OrderDraft,
-): AsyncGenerator<
-  Erc20ApprovalWorkflowRequest | Erc1155ApprovalForAllWorkflowRequest,
-  void,
-  EvmAddress | EvmSignature | TransactionHandle
-> {
-  const currentAllowance = await resolveCurrentAllowance(client, {
-    spenderAddress: draft.exchangeAddress,
-    side: draft.side,
-    tokenId: draft.tokenId,
-  });
-
-  if (currentAllowance >= draft.offeredAmount) {
-    return;
-  }
-
-  const handle =
-    draft.side === OrderSide.BUY
-      ? yield* await prepareErc20Approval(client, {
-          amount: 'max',
-          spenderAddress: draft.exchangeAddress,
-          tokenAddress: client.environment.collateralToken,
-        })
-      : yield* await prepareErc1155ApprovalForAll(client, {
-          operatorAddress: draft.exchangeAddress,
-          tokenAddress: client.environment.conditionalTokens,
-        });
-
-  await handle.wait();
-
-  await updateBalanceAllowance(client, {
-    assetType:
-      draft.side === OrderSide.BUY
-        ? AssetType.COLLATERAL
-        : AssetType.CONDITIONAL,
-    tokenId: draft.side === OrderSide.SELL ? draft.tokenId : undefined,
-  });
 }

--- a/packages/client/src/actions/orders/trade.ts
+++ b/packages/client/src/actions/orders/trade.ts
@@ -1,4 +1,6 @@
+import { OrderSide } from '@polymarket/bindings';
 import type { OrderResponse } from '@polymarket/bindings/clob';
+import { AssetType, OrderResponseErrorCode } from '@polymarket/bindings/clob';
 import type { BaseSecureClient } from '../../clients';
 import {
   CancelledSigningError,
@@ -7,11 +9,18 @@ import {
   RateLimitError,
   RequestRejectedError,
   SigningError,
+  TimeoutError,
+  TransactionFailedError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
 } from '../../errors';
 import { completeWith } from '../../workflow';
+import { updateBalanceAllowance } from '../account';
+import { approveErc20, approveErc1155ForAll } from '../approvals';
+import { fetchNegRisk } from '../clob';
+import { resolveCurrentAllowance } from './allowance';
+import { resolveExchangeAddress } from './context';
 import { type PostOrderError, postOrder } from './post';
 import {
   type PrepareLimitOrderError,
@@ -52,13 +61,19 @@ export function createMarketOrder(
   return prepareMarketOrder(client, request).then(completeWith(client.signer));
 }
 
-export type PlaceMarketOrderError = CreateMarketOrderError | PostOrderError;
+export type PlaceMarketOrderError =
+  | CreateMarketOrderError
+  | PostOrderError
+  | TimeoutError
+  | TransactionFailedError;
 export const PlaceMarketOrderError = makeErrorGuard(
   CancelledSigningError,
   InsufficientLiquidityError,
   RateLimitError,
   RequestRejectedError,
   SigningError,
+  TimeoutError,
+  TransactionFailedError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
@@ -74,7 +89,9 @@ export function placeMarketOrder(
   client: BaseSecureClient,
   request: PrepareMarketOrderRequest,
 ): Promise<OrderResponse> {
-  return createMarketOrder(client, request).then(postOrder(client));
+  return createMarketOrder(client, request).then((order) =>
+    postOrderWithAllowanceRecovery(client, order),
+  );
 }
 
 export type CreateLimitOrderError =
@@ -103,12 +120,18 @@ export function createLimitOrder(
   return prepareLimitOrder(client, request).then(completeWith(client.signer));
 }
 
-export type PlaceLimitOrderError = CreateLimitOrderError | PostOrderError;
+export type PlaceLimitOrderError =
+  | CreateLimitOrderError
+  | PostOrderError
+  | TimeoutError
+  | TransactionFailedError;
 export const PlaceLimitOrderError = makeErrorGuard(
   CancelledSigningError,
   RateLimitError,
   RequestRejectedError,
   SigningError,
+  TimeoutError,
+  TransactionFailedError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
@@ -124,5 +147,72 @@ export function placeLimitOrder(
   client: BaseSecureClient,
   request: PrepareLimitOrderRequest,
 ): Promise<OrderResponse> {
-  return createLimitOrder(client, request).then(postOrder(client));
+  return createLimitOrder(client, request).then((order) =>
+    postOrderWithAllowanceRecovery(client, order),
+  );
+}
+
+async function postOrderWithAllowanceRecovery(
+  client: BaseSecureClient,
+  order: SignedOrder,
+): Promise<OrderResponse> {
+  const postSignedOrder = postOrder(client);
+  const response = await postSignedOrder(order);
+
+  if (!isBalanceOrAllowanceRejection(response)) {
+    return response;
+  }
+
+  const approved = await ensureOrderApproval(client, order);
+
+  return approved ? postSignedOrder(order) : response;
+}
+
+function isBalanceOrAllowanceRejection(response: OrderResponse): boolean {
+  return (
+    response.ok === false &&
+    response.code === OrderResponseErrorCode.INSUFFICIENT_BALANCE_OR_ALLOWANCE
+  );
+}
+
+async function ensureOrderApproval(
+  client: BaseSecureClient,
+  order: SignedOrder,
+): Promise<boolean> {
+  const negRisk = await fetchNegRisk(client, { tokenId: order.tokenId });
+  const exchangeAddress = resolveExchangeAddress(client, negRisk);
+  const requiredAllowance = BigInt(order.makerAmount);
+  const currentAllowance = await resolveCurrentAllowance(client, {
+    spenderAddress: exchangeAddress,
+    side: order.side,
+    tokenId: order.tokenId,
+  });
+
+  if (currentAllowance >= requiredAllowance) {
+    return false;
+  }
+
+  const handle =
+    order.side === OrderSide.BUY
+      ? await approveErc20(client, {
+          amount: 'max',
+          spenderAddress: exchangeAddress,
+          tokenAddress: client.environment.collateralToken,
+        })
+      : await approveErc1155ForAll(client, {
+          operatorAddress: exchangeAddress,
+          tokenAddress: client.environment.conditionalTokens,
+        });
+
+  await handle.wait();
+
+  await updateBalanceAllowance(client, {
+    assetType:
+      order.side === OrderSide.BUY
+        ? AssetType.COLLATERAL
+        : AssetType.CONDITIONAL,
+    tokenId: order.side === OrderSide.SELL ? order.tokenId : undefined,
+  });
+
+  return true;
 }

--- a/packages/client/src/actions/orders/types.ts
+++ b/packages/client/src/actions/orders/types.ts
@@ -11,12 +11,8 @@ import type {
   EvmSignature,
   HexString,
 } from '@polymarket/types';
-import type { TransactionHandle, TypedDataPayload } from '../../types';
+import type { TypedDataPayload } from '../../types';
 import type { SignOrderRequest } from '../../workflow';
-import type {
-  Erc20ApprovalWorkflowRequest,
-  Erc1155ApprovalForAllWorkflowRequest,
-} from '../approvals';
 
 type BasePrepareMarketOrderRequest = {
   /** TokenID of the Conditional token asset being traded */
@@ -164,21 +160,18 @@ export type SignedOrder = {
   postOnly?: boolean;
 };
 
-export type OrderWorkflowRequest =
-  | Erc20ApprovalWorkflowRequest
-  | Erc1155ApprovalForAllWorkflowRequest
-  | SignOrderRequest;
+export type OrderWorkflowRequest = SignOrderRequest;
 
 export type OrderWorkflow = AsyncGenerator<
   OrderWorkflowRequest,
   SignedOrder,
-  EvmAddress | EvmSignature | TransactionHandle
+  EvmAddress | EvmSignature
 >;
 
 export type OrderPostingWorkflow = AsyncGenerator<
   OrderWorkflowRequest,
   OrderResponse,
-  EvmAddress | EvmSignature | TransactionHandle
+  EvmAddress | EvmSignature
 >;
 
 /** @internal */


### PR DESCRIPTION
## Summary
- Move order approval out of prepare/create workflows and into place-order recovery after CLOB rejects for insufficient balance/allowance
- Add one-time approval, balance/allowance refresh, and retry for place market/limit orders when allowance is actually insufficient
- Rename the combined CLOB order rejection code to `insufficient_balance_or_allowance`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:client`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automatic on-chain approval + balance/allowance refresh + retry path when order posting is rejected for insufficient balance/allowance, which can trigger new transactions and changes the public error surface.
> 
> **Overview**
> Updates the order posting flow so `prepare*Order` workflows only handle signing, while `placeMarketOrder`/`placeLimitOrder` now detect `INSUFFICIENT_BALANCE_OR_ALLOWANCE`, perform a one-time ERC20/ ERC1155 approval + `updateBalanceAllowance`, and retry posting.
> 
> Renames the CLOB rejection code from `NOT_ENOUGH_BALANCE` to `INSUFFICIENT_BALANCE_OR_ALLOWANCE` and adjusts error guards/unions (including `TimeoutError`/`TransactionFailedError`) and workflow request typing to reflect removal of approval steps from the signing workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acac161cc471a7080297fcd8b15b580186e29d1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->