### PR TITLE
fix(client): close subscription handles immediately

### DIFF
--- a/packages/client/src/websockets/handle.test.ts
+++ b/packages/client/src/websockets/handle.test.ts
@@ -1,0 +1,19 @@
+import { pushable } from 'it-pushable';
+import { describe, expect, it } from 'vitest';
+import { createSubscriptionHandle } from './handle';
+
+describe('createSubscriptionHandle', () => {
+  it('ends iterator reads after close without draining buffered events', async () => {
+    const queue = pushable<string>({ objectMode: true });
+    const handle = createSubscriptionHandle(queue, async () => {
+      queue.end();
+    });
+
+    queue.push('event');
+    await handle.close();
+
+    await expect(handle[Symbol.asyncIterator]().next()).resolves.toMatchObject({
+      done: true,
+    });
+  });
+});

--- a/packages/client/src/websockets/handle.ts
+++ b/packages/client/src/websockets/handle.ts
@@ -10,7 +10,9 @@ export function createSubscriptionHandle<TEvent>(
   return {
     close: () => {
       if (closing === undefined) {
-        closing = closeSubscription();
+        closing = Promise.resolve(queue.return()).then(() =>
+          closeSubscription(),
+        );
       }
       return closing;
     },


### PR DESCRIPTION
## Summary
- Clear buffered websocket subscription events when a handle is closed so subsequent iterator reads complete immediately.
- Add coverage for closing a handle with a buffered event.

## Verification
- pnpm exec vitest --project client packages/client/src/websockets/handle.test.ts
- pnpm exec vitest --project client-integration packages/client/tests/integration/subscriptions.test.ts
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral change to subscription shutdown that mainly affects iterator completion semantics when buffered events exist.
> 
> **Overview**
> Subscription `close()` now first terminates the underlying `it-pushable` queue via `queue.return()` before running the provided `closeSubscription`, ensuring async iterators complete immediately instead of draining buffered events.
> 
> Adds a focused `vitest` unit test covering closing a handle with a buffered event and asserting subsequent iterator reads return `{ done: true }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24b55430bd6723cbd352c607b3baf5c72b5a6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->