### PR TITLE
fix(client): route position lifecycle through collateral adapters

### DIFF
--- a/packages/client/src/abis.ts
+++ b/packages/client/src/abis.ts
@@ -24,9 +24,6 @@ const CTF_MERGE_POSITIONS_FUNCTION = AbiFunction.from(
 const CTF_REDEEM_POSITIONS_FUNCTION = AbiFunction.from(
   'function redeemPositions(address collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint256[] indexSets)',
 );
-const NEG_RISK_REDEEM_POSITIONS_FUNCTION = AbiFunction.from(
-  'function redeemPositions(bytes32 _conditionId, uint256[] _amounts)',
-);
 const SAFE_MULTISEND_FUNCTION = AbiFunction.from('function multiSend(bytes)');
 const PROXY_FACTORY_FUNCTION = AbiFunction.from(
   'function proxy((uint8 typeCode, address to, uint256 value, bytes data)[] calls) returns (bytes[])',
@@ -115,7 +112,7 @@ export const SplitPositionCallError = makeErrorGuard(UserInputError);
 
 /**
  * Creates a transaction call for `splitPosition(address,bytes32,bytes32,uint256[],uint256)`.
- * Works with both the Conditional Tokens contract and the neg-risk adapter.
+ * Works with both the standard and neg-risk collateral adapters.
  *
  * @remarks
  * This is a low-level transaction builder that most SDK consumers will not need.
@@ -128,15 +125,9 @@ export function splitPositionCall(
   collateralTokenAddress: EvmAddress,
   conditionId: ConditionId,
   amount: bigint,
-  negRisk = false,
 ): TransactionCall {
   return {
-    data: encodeSplitPositionCall(
-      collateralTokenAddress,
-      conditionId,
-      amount,
-      negRisk,
-    ),
+    data: encodeSplitPositionCall(collateralTokenAddress, conditionId, amount),
     to: targetAddress,
   };
 }
@@ -146,7 +137,7 @@ export const MergePositionsCallError = makeErrorGuard(UserInputError);
 
 /**
  * Creates a transaction call for `mergePositions(address,bytes32,bytes32,uint256[],uint256)`.
- * Works with both the Conditional Tokens contract and the neg-risk adapter.
+ * Works with both the standard and neg-risk collateral adapters.
  *
  * @remarks
  * This is a low-level transaction builder that most SDK consumers will not need.
@@ -159,22 +150,16 @@ export function mergePositionsCall(
   collateralTokenAddress: EvmAddress,
   conditionId: ConditionId,
   amount: bigint,
-  negRisk = false,
 ): TransactionCall {
   return {
-    data: encodeMergePositionsCall(
-      collateralTokenAddress,
-      conditionId,
-      amount,
-      negRisk,
-    ),
+    data: encodeMergePositionsCall(collateralTokenAddress, conditionId, amount),
     to: targetAddress,
   };
 }
 
 /**
  * Creates a transaction call for `redeemPositions(address,bytes32,bytes32,uint256[])`
- * on the Conditional Tokens contract.
+ * on Conditional Tokens-compatible contracts, including the collateral adapters.
  *
  * @remarks
  * This is a low-level transaction builder that most SDK consumers will not need.
@@ -190,30 +175,6 @@ export function ctfRedeemPositionsCall(
   return {
     data: encodeCtfRedeemPositionsCall(collateralTokenAddress, conditionId),
     to: conditionalTokensAddress,
-  };
-}
-
-export type NegRiskRedeemPositionsCallError = UserInputError;
-export const NegRiskRedeemPositionsCallError = makeErrorGuard(UserInputError);
-
-/**
- * Creates a transaction call for `redeemPositions(bytes32,uint256[])` on the
- * negative-risk adapter contract.
- *
- * @remarks
- * This is a low-level transaction builder that most SDK consumers will not need.
- *
- * @throws {@link NegRiskRedeemPositionsCallError}
- * Thrown when the condition or redeem amounts are invalid.
- */
-export function negRiskRedeemPositionsCall(
-  negRiskAdapterAddress: EvmAddress,
-  conditionId: ConditionId,
-  amounts: readonly [bigint, bigint],
-): TransactionCall {
-  return {
-    data: encodeNegRiskRedeemPositionsCall(conditionId, amounts),
-    to: negRiskAdapterAddress,
   };
 }
 
@@ -247,13 +208,12 @@ function encodeSplitPositionCall(
   collateralTokenAddress: EvmAddress,
   conditionId: ConditionId,
   amount: bigint,
-  negRisk: boolean,
 ): HexString {
   return AbiFunction.encodeData(CTF_SPLIT_POSITION_FUNCTION, [
     collateralTokenAddress,
     ZERO_BYTES32,
     conditionId,
-    negRisk ? [] : BINARY_OUTCOME_PARTITION,
+    BINARY_OUTCOME_PARTITION,
     expectUint256(amount, 'Split amount'),
   ]);
 }
@@ -262,13 +222,12 @@ function encodeMergePositionsCall(
   collateralTokenAddress: EvmAddress,
   conditionId: ConditionId,
   amount: bigint,
-  negRisk: boolean,
 ): HexString {
   return AbiFunction.encodeData(CTF_MERGE_POSITIONS_FUNCTION, [
     collateralTokenAddress,
     ZERO_BYTES32,
     conditionId,
-    negRisk ? [] : BINARY_OUTCOME_PARTITION,
+    BINARY_OUTCOME_PARTITION,
     expectUint256(amount, 'Merge amount'),
   ]);
 }
@@ -282,16 +241,6 @@ function encodeCtfRedeemPositionsCall(
     ZERO_BYTES32,
     conditionId,
     BINARY_OUTCOME_INDEX_SETS,
-  ]);
-}
-
-function encodeNegRiskRedeemPositionsCall(
-  conditionId: ConditionId,
-  amounts: readonly [bigint, bigint],
-): HexString {
-  return AbiFunction.encodeData(NEG_RISK_REDEEM_POSITIONS_FUNCTION, [
-    conditionId,
-    amounts.map((amount) => expectUint256(amount, 'Redeem amount')),
   ]);
 }
 

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -29,7 +29,7 @@ describe('prepareTradingApprovals', () => {
     const workflow = await prepareTradingApprovals(client);
     let result = await workflow.next();
 
-    for (let index = 0; index < 6; index += 1) {
+    for (let index = 0; index < 10; index += 1) {
       expect(result.done).toBe(false);
       result = await workflow.next(TRANSACTION_HANDLE);
     }

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -261,9 +261,9 @@ export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
  *
  * Prepares all approvals required for trading, including collateral and
  * position token approvals for both standard and neg-risk market flows.
- * The neg-risk adapter approvals cover split, merge, and redemption workflows
- * on neg-risk markets. Auto-redeem approval is included so accounts are ready
- * for supported position lifecycle workflows.
+ * The collateral adapter approvals cover split, merge, and redemption workflows.
+ * Auto-redeem approval is included so accounts are ready for supported position
+ * lifecycle workflows.
  *
  * @example
  * ```ts
@@ -276,7 +276,7 @@ export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
 export async function prepareTradingApprovals(
   client: BaseSecureClient,
 ): Promise<TradingApprovalsWorkflow> {
-  const calls = [
+  const erc20ApprovalCalls = [
     erc20ApprovalCall(
       client.environment.collateralToken,
       client.environment.standardExchange,
@@ -292,6 +292,18 @@ export async function prepareTradingApprovals(
       client.environment.negRiskAdapter,
       MAX_UINT256,
     ),
+    erc20ApprovalCall(
+      client.environment.collateralToken,
+      client.environment.collateralAdapter,
+      MAX_UINT256,
+    ),
+    erc20ApprovalCall(
+      client.environment.collateralToken,
+      client.environment.negRiskCollateralAdapter,
+      MAX_UINT256,
+    ),
+  ] as const;
+  const erc1155ApprovalCalls = [
     erc1155ApprovalForAllCall(
       client.environment.conditionalTokens,
       client.environment.standardExchange,
@@ -305,6 +317,16 @@ export async function prepareTradingApprovals(
     erc1155ApprovalForAllCall(
       client.environment.conditionalTokens,
       client.environment.negRiskAdapter,
+      true,
+    ),
+    erc1155ApprovalForAllCall(
+      client.environment.conditionalTokens,
+      client.environment.collateralAdapter,
+      true,
+    ),
+    erc1155ApprovalForAllCall(
+      client.environment.conditionalTokens,
+      client.environment.negRiskCollateralAdapter,
       true,
     ),
     erc1155ApprovalForAllCall(
@@ -313,60 +335,35 @@ export async function prepareTradingApprovals(
       true,
     ),
   ] as const;
-
   return async function* (): TradingApprovalsWorkflow {
     if (client.account.walletType === WalletType.EOA) {
-      const collateralStandardApproval = expectTransactionHandle(
-        yield sendErc20ApprovalTransaction(
-          signerTransactionRequest(client.environment.chainId, calls[0]),
-        ),
-      );
-      await collateralStandardApproval.wait();
+      for (const call of erc20ApprovalCalls) {
+        const handle = expectTransactionHandle(
+          yield sendErc20ApprovalTransaction(
+            signerTransactionRequest(client.environment.chainId, call),
+          ),
+        );
 
-      const collateralNegRiskApproval = expectTransactionHandle(
-        yield sendErc20ApprovalTransaction(
-          signerTransactionRequest(client.environment.chainId, calls[1]),
-        ),
-      );
-      await collateralNegRiskApproval.wait();
+        await handle.wait();
+      }
 
-      const collateralNegRiskAdapterApproval = expectTransactionHandle(
-        yield sendErc20ApprovalTransaction(
-          signerTransactionRequest(client.environment.chainId, calls[2]),
-        ),
-      );
-      await collateralNegRiskAdapterApproval.wait();
+      for (const [index, call] of erc1155ApprovalCalls.entries()) {
+        const handle = expectTransactionHandle(
+          yield sendErc1155ApprovalForAllTransaction(
+            signerTransactionRequest(client.environment.chainId, call),
+          ),
+        );
 
-      const conditionalStandardApproval = expectTransactionHandle(
-        yield sendErc1155ApprovalForAllTransaction(
-          signerTransactionRequest(client.environment.chainId, calls[3]),
-        ),
-      );
-      await conditionalStandardApproval.wait();
+        if (index === erc1155ApprovalCalls.length - 1) {
+          return handle;
+        }
 
-      const conditionalNegRiskApproval = expectTransactionHandle(
-        yield sendErc1155ApprovalForAllTransaction(
-          signerTransactionRequest(client.environment.chainId, calls[4]),
-        ),
-      );
-      await conditionalNegRiskApproval.wait();
-
-      const conditionalNegRiskAdapterApproval = expectTransactionHandle(
-        yield sendErc1155ApprovalForAllTransaction(
-          signerTransactionRequest(client.environment.chainId, calls[5]),
-        ),
-      );
-      await conditionalNegRiskAdapterApproval.wait();
-
-      return expectTransactionHandle(
-        yield sendErc1155ApprovalForAllTransaction(
-          signerTransactionRequest(client.environment.chainId, calls[6]),
-        ),
-      );
+        await handle.wait();
+      }
     }
 
     return yield* await prepareGaslessTransaction(client, {
-      calls: [...calls],
+      calls: [...erc20ApprovalCalls, ...erc1155ApprovalCalls],
       metadata: 'Trading setup approvals',
     });
   }.call(null);

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -13,7 +13,6 @@ import { z } from 'zod';
 import {
   ctfRedeemPositionsCall,
   mergePositionsCall,
-  negRiskRedeemPositionsCall,
   splitPositionCall,
 } from '../abis';
 import type { BaseSecureClient } from '../clients';
@@ -178,11 +177,10 @@ export async function prepareSplitPosition(
     params.conditionId,
   );
   const call = splitPositionCall(
-    resolveSplitTargetAddress(client, negativeRisk),
+    resolveLifecycleTargetAddress(client, negativeRisk),
     client.environment.collateralToken,
     params.conditionId,
     params.amount,
-    negativeRisk,
   );
 
   return async function* (): SplitPositionWorkflow {
@@ -262,11 +260,10 @@ export async function prepareMergePositions(
   const negativeRisk = expectNegativeRiskFlag(binaryPositions);
   const amount = resolveMergeAmount(binaryPositions, params.amount);
   const call = mergePositionsCall(
-    resolveMergeTargetAddress(client, negativeRisk),
+    resolveLifecycleTargetAddress(client, negativeRisk),
     client.environment.collateralToken,
     params.conditionId,
     amount,
-    negativeRisk,
   );
 
   return async function* (): MergePositionsWorkflow {
@@ -355,17 +352,11 @@ export async function prepareRedeemPositions(
   const binaryPositions = expectBinaryPositions(positions);
   const conditionId = resolveBinaryPositionsConditionId(binaryPositions);
   const negativeRisk = expectNegativeRiskFlag(binaryPositions);
-  const call = negativeRisk
-    ? negRiskRedeemPositionsCall(
-        client.environment.negRiskAdapter,
-        conditionId,
-        deriveNegRiskRedeemAmounts(binaryPositions),
-      )
-    : ctfRedeemPositionsCall(
-        client.environment.conditionalTokens,
-        client.environment.collateralToken,
-        conditionId,
-      );
+  const call = ctfRedeemPositionsCall(
+    resolveLifecycleTargetAddress(client, negativeRisk),
+    client.environment.collateralToken,
+    conditionId,
+  );
 
   return async function* (): RedeemPositionsWorkflow {
     if (client.account.walletType === WalletType.EOA) {
@@ -440,10 +431,13 @@ function sendRedeemPositionsTransaction(
   };
 }
 
-function resolveSplitTargetAddress(client: BaseSecureClient, negRisk: boolean) {
+function resolveLifecycleTargetAddress(
+  client: BaseSecureClient,
+  negRisk: boolean,
+) {
   return negRisk
-    ? client.environment.negRiskAdapter
-    : client.environment.conditionalTokens;
+    ? client.environment.negRiskCollateralAdapter
+    : client.environment.collateralAdapter;
 }
 
 async function resolveMarketNegativeRiskFlag(
@@ -473,19 +467,6 @@ async function resolveMarketNegativeRiskFlag(
   );
 
   return market.state.negRisk;
-}
-
-function resolveMergeTargetAddress(client: BaseSecureClient, negRisk: boolean) {
-  return negRisk
-    ? client.environment.negRiskAdapter
-    : client.environment.conditionalTokens;
-}
-
-function deriveNegRiskRedeemAmounts([
-  yesPosition,
-  noPosition,
-]: BinaryPositions): readonly [bigint, bigint] {
-  return [toPositionAmount(yesPosition, 0), toPositionAmount(noPosition, 1)];
 }
 
 function expectNegativeRiskFlag([

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -22,6 +22,10 @@ export type EnvironmentConfig = {
   /** @internal */
   negRiskAdapter: EvmAddress;
   /** @internal */
+  collateralAdapter: EvmAddress;
+  /** @internal */
+  negRiskCollateralAdapter: EvmAddress;
+  /** @internal */
   standardExchange: EvmAddress;
   /** @internal */
   negRiskExchange: EvmAddress;
@@ -84,6 +88,12 @@ export const production: EnvironmentConfig = {
   ),
   negRiskAdapter: expectEvmAddress(
     '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296',
+  ),
+  collateralAdapter: expectEvmAddress(
+    '0xAdA100Db00Ca00073811820692005400218FcE1f',
+  ),
+  negRiskCollateralAdapter: expectEvmAddress(
+    '0xadA2005600Dec949baf300f4C6120000bDB6eAab',
   ),
   standardExchange: expectEvmAddress(
     '0xE111180000d2663C0091e4f400237545B87B996B',


### PR DESCRIPTION
## Summary
- add production collateral adapter addresses to the client environment
- route split, merge, and redeem position lifecycle calls through the standard or neg-risk collateral adapter
- update trading setup approvals to include collateral adapter allowances while retaining existing exchange and neg-risk adapter approvals

## Verification
- pnpm lint
- pnpm typecheck

Linear: DEV-100

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-chain targets and required approvals for split/merge/redeem flows, which can break position lifecycle transactions if adapter addresses or call semantics are wrong. Also increases the number of approval transactions (EOA and gasless), impacting user setup and allowance scope.
> 
> **Overview**
> **Position lifecycle transactions now go through collateral adapters.** `prepareSplitPosition`, `prepareMergePositions`, and `prepareRedeemPositions` select `collateralAdapter` vs `negRiskCollateralAdapter` as the call target, and neg-risk redemption is unified to use `ctfRedeemPositionsCall` (removing the custom `negRiskRedeemPositionsCall` path).
> 
> **Trading setup approvals are expanded for the new adapters.** `prepareTradingApprovals` adds ERC-20 and ERC-1155 approvals for both collateral adapters, refactors the EOA flow to iterate through approval call lists, and updates the test to expect additional approval steps.
> 
> **Environment config is extended.** Adds production addresses for `collateralAdapter` and `negRiskCollateralAdapter` to `EnvironmentConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 661478def74b4731a6056e2a10f44aed4aef7d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->