### PR TITLE
Export activity type enum

### DIFF
--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -12,6 +12,7 @@ import {
   TxHashSchema,
 } from '../shared';
 import {
+  ActivityType,
   ActivityTypeSchema,
   type Address,
   AddressSchema,
@@ -265,7 +266,7 @@ function normalizeActivity(activity: RawActivity): Activity {
   const base = normalizeActivityBase(activity);
 
   switch (activity.type) {
-    case 'TRADE':
+    case ActivityType.TRADE:
       return {
         ...base,
         type: activity.type,
@@ -282,10 +283,10 @@ function normalizeActivity(activity: RawActivity): Activity {
         icon: expectPresent(activity.icon, 'icon'),
         eventSlug: expectPresent(activity.eventSlug, 'eventSlug'),
       };
-    case 'SPLIT':
-    case 'MERGE':
-    case 'REDEEM':
-    case 'CONVERSION':
+    case ActivityType.SPLIT:
+    case ActivityType.MERGE:
+    case ActivityType.REDEEM:
+    case ActivityType.CONVERSION:
       return {
         ...base,
         type: activity.type,
@@ -296,10 +297,10 @@ function normalizeActivity(activity: RawActivity): Activity {
         icon: expectPresent(activity.icon, 'icon'),
         eventSlug: expectPresent(activity.eventSlug, 'eventSlug'),
       };
-    case 'REWARD':
-    case 'MAKER_REBATE':
-    case 'REFERRAL_REWARD':
-    case 'YIELD':
+    case ActivityType.REWARD:
+    case ActivityType.MAKER_REBATE:
+    case ActivityType.REFERRAL_REWARD:
+    case ActivityType.YIELD:
       return {
         ...base,
         type: activity.type,

--- a/packages/bindings/src/data/common.ts
+++ b/packages/bindings/src/data/common.ts
@@ -3,17 +3,19 @@ import { z } from 'zod';
 export const AddressSchema = z.string();
 export const Hash64Schema = z.string();
 
-export const ActivityTypeSchema = z.enum([
-  'TRADE',
-  'SPLIT',
-  'MERGE',
-  'REDEEM',
-  'REWARD',
-  'CONVERSION',
-  'MAKER_REBATE',
-  'REFERRAL_REWARD',
-  'YIELD',
-]);
+export const ActivityType = {
+  TRADE: 'TRADE',
+  SPLIT: 'SPLIT',
+  MERGE: 'MERGE',
+  REDEEM: 'REDEEM',
+  REWARD: 'REWARD',
+  CONVERSION: 'CONVERSION',
+  MAKER_REBATE: 'MAKER_REBATE',
+  REFERRAL_REWARD: 'REFERRAL_REWARD',
+  YIELD: 'YIELD',
+} as const;
+
+export const ActivityTypeSchema = z.enum(ActivityType);
 
 export const SideSchema = z.enum(['BUY', 'SELL']);
 

--- a/packages/bindings/src/data/common.ts
+++ b/packages/bindings/src/data/common.ts
@@ -3,17 +3,17 @@ import { z } from 'zod';
 export const AddressSchema = z.string();
 export const Hash64Schema = z.string();
 
-export const ActivityType = {
-  TRADE: 'TRADE',
-  SPLIT: 'SPLIT',
-  MERGE: 'MERGE',
-  REDEEM: 'REDEEM',
-  REWARD: 'REWARD',
-  CONVERSION: 'CONVERSION',
-  MAKER_REBATE: 'MAKER_REBATE',
-  REFERRAL_REWARD: 'REFERRAL_REWARD',
-  YIELD: 'YIELD',
-} as const;
+export enum ActivityType {
+  TRADE = 'TRADE',
+  SPLIT = 'SPLIT',
+  MERGE = 'MERGE',
+  REDEEM = 'REDEEM',
+  REWARD = 'REWARD',
+  CONVERSION = 'CONVERSION',
+  MAKER_REBATE = 'MAKER_REBATE',
+  REFERRAL_REWARD = 'REFERRAL_REWARD',
+  YIELD = 'YIELD',
+}
 
 export const ActivityTypeSchema = z.enum(ActivityType);
 
@@ -38,7 +38,6 @@ export const LeaderboardOrderBySchema = z.enum(['PNL', 'VOL']);
 
 export type Address = z.infer<typeof AddressSchema>;
 export type Hash64 = z.infer<typeof Hash64Schema>;
-export type ActivityType = z.infer<typeof ActivityTypeSchema>;
 export type Side = z.infer<typeof SideSchema>;
 export type TimePeriod = z.infer<typeof TimePeriodSchema>;
 export type LeaderboardCategory = z.infer<typeof LeaderboardCategorySchema>;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,6 +3,7 @@ export { OrderSide, OrderType } from '@polymarket/bindings';
 export type * from '@polymarket/bindings/clob';
 export { SignatureType } from '@polymarket/bindings/clob';
 export type * from '@polymarket/bindings/data';
+export { ActivityType } from '@polymarket/bindings/data';
 export type * from '@polymarket/bindings/gamma';
 export { WalletType } from '@polymarket/bindings/gamma';
 export type * from '@polymarket/bindings/relayer';

--- a/packages/client/tests/integration/activity.test.ts
+++ b/packages/client/tests/integration/activity.test.ts
@@ -1,3 +1,4 @@
+import { ActivityType } from '@polymarket/client';
 import { expectPresent, isSameEvmAddress } from '@polymarket/types';
 import { describe, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
@@ -39,7 +40,7 @@ describe('Activity', () => {
       const paginator = publicClient.listActivity({
         user: TEST_USER,
         pageSize: 100,
-        type: ['TRADE'],
+        type: [ActivityType.TRADE],
       });
       const result = await paginator.firstPage().then(expectNonEmptyPage);
 
@@ -48,7 +49,7 @@ describe('Activity', () => {
       expect(expectPresent(result.items[0])).toEqual(
         expect.objectContaining({
           conditionId: expect.any(String),
-          type: 'TRADE',
+          type: ActivityType.TRADE,
           wallet: TEST_USER,
         }),
       );
@@ -59,7 +60,7 @@ describe('Activity', () => {
       secureClientWithDepositWallet,
     }) => {
       const result = await secureClientWithDepositWallet
-        .listActivity({ pageSize: 1, type: ['TRADE'] })
+        .listActivity({ pageSize: 1, type: [ActivityType.TRADE] })
         .firstPage()
         .then(expectNonEmptyPage);
 


### PR DESCRIPTION
## Summary
- Add a runtime ActivityType enum for data activity types
- Re-export ActivityType from @polymarket/client
- Update activity integration tests to use ActivityType.TRADE

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test:bindings
- pnpm test:client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API typing for activity types changes from a schema-inferred string union to a runtime `ActivityType` enum, which could be a minor breaking change for downstream TypeScript consumers. Runtime behavior is largely unchanged aside from using the enum values in normalization and tests.
> 
> **Overview**
> Introduces a runtime `ActivityType` enum in bindings and updates `ActivityTypeSchema` to derive from it, replacing the prior string-literal `z.enum([...])` definition.
> 
> Updates activity normalization (`normalizeActivity`) and client integration tests to use `ActivityType.*` constants instead of raw strings, and re-exports `ActivityType` from `@polymarket/client` for consumer use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe501f6db9fbab0a074dfff573e6199efd90abb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->