### PR TITLE
Use Viem Polygon RPC endpoint

### DIFF
--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -66,7 +66,7 @@ export type EnvironmentConfig = {
 export const production: EnvironmentConfig = {
   name: 'production',
   chainId: 137,
-  rpc: 'https://polygon-rpc.com',
+  rpc: 'https://polygon.drpc.org',
   walletDerivation: {
     depositWalletFactory: expectEvmAddress(
       '0x00000000000Fb5C9ADea0298D729A0CB3823Cc07',


### PR DESCRIPTION
## Summary
- replace the production Polygon RPC URL with Viem's configured Polygon default, https://polygon.drpc.org

## Verification
- pnpm lint
- pnpm typecheck
- pnpm vitest --project client packages/client/src/clients.test.ts packages/client/src/wallet.test.ts packages/client/src/rpc.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that only affects which Polygon RPC URL production clients connect to. Main risk is runtime connectivity/performance differences if the new endpoint behaves differently or rate-limits.
> 
> **Overview**
> Updates the production Polygon RPC endpoint in `packages/client/src/environments.ts`, switching from `https://polygon-rpc.com` to `https://polygon.drpc.org` for chain id `137`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ee31c31c00f4b110043ee5f21ef13f4bdac85a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->