### PR TITLE
chore: add canary release workflow

### DIFF
--- a/.changeset/wide-houses-type.md
+++ b/.changeset/wide-houses-type.md
@@ -1,0 +1,7 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+"@polymarket/types": patch
+---
+
+chore: empty changeset to test new release workflow

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Fetch Base Branch
         run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,6 +11,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changeset:
+    name: Changeset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Fetch Base Branch
+        run: git fetch origin ${{ github.base_ref }}:${{ github.base_ref }}
+
+      - name: Set Up Repository
+        uses: ./.github/actions/setup
+
+      - name: Ensure Changeset Added
+        run: pnpm changeset status --since=${{ github.base_ref }}
+
   verify:
     name: Verify
     uses: ./.github/workflows/verify.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,7 @@ jobs:
     needs:
       - verify
       - test
-      # Temporarily do not block release PR updates on integration tests while checks are blocked by a BE bug.
-      # - integration-tests
+      - integration-tests
 
     steps:
       - name: Checkout Repository
@@ -56,3 +55,32 @@ jobs:
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  canary:
+    name: Publish Canary
+    runs-on: ubuntu-latest
+    needs:
+      - verify
+      - test
+      # Temporarily do not block canary publishing on integration tests while checks are blocked by a BE bug.
+      # - integration-tests
+    if: ${{ !contains(github.event.head_commit.message, 'chore: bumps package versions') }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Set Up Repository
+        uses: ./.github/actions/setup
+
+      - name: Disable Beta Prerelease Mode For Canary
+        run: mv .changeset/pre.json .changeset/pre.json.disabled
+
+      - name: Version Packages For Canary
+        run: pnpm version:canary
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish Canary Packages
+        run: pnpm release:canary

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clean": "rimraf packages/*/dist",
     "dev:react": "pnpm --filter @polymarket/examples-react dev",
     "release": "pnpm build && changeset publish --no-git-tag",
+    "release:canary": "changeset publish --tag canary --no-git-tag",
     "test:bindings": "vitest --project bindings --passWithNoTests",
     "test:client": "vitest --project client",
     "test:client:integration": "vitest --project client-integration",
@@ -25,6 +26,7 @@
     "test": "pnpm test:types && pnpm test:bindings && pnpm test:client",
     "typecheck": "pnpm -r --sort --if-present run typecheck",
     "version:bump": "changeset version",
+    "version:canary": "changeset version --snapshot canary",
     "lint": "biome check",
     "lint:fix": "biome check --write"
   },


### PR DESCRIPTION
## Summary
- publish canary snapshots from the existing Release workflow on normal main merges
- keep beta Changesets releases gated on integration tests
- require a changeset on every pull request

## Verification
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies CI/CD and package publishing behavior (new canary publish path and tighter gating), which can impact release automation and artifact versions if misconfigured.
> 
> **Overview**
> Adds a new PR workflow job that **fails pull requests without an added Changeset**, using `pnpm changeset status --since` against the base branch.
> 
> Updates the main `release.yml` pipeline to **gate the Changesets release PR on integration tests** and introduces a separate **canary publish job** that snapshots versions (`changeset version --snapshot canary`) and publishes to the `canary` tag (skipping runs triggered by the release-bump commit). Also adds the corresponding `package.json` scripts and an example Changeset file to exercise the workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9ad85b55a4d3878fc563c9e67038bc1af12081. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->