### PR TITLE
fix: quote release workflow condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
       - test
       # Temporarily do not block canary publishing on integration tests while checks are blocked by a BE bug.
       # - integration-tests
-    if: ${{ !contains(github.event.head_commit.message, 'chore: bumps package versions') }}
+    if: "${{ !contains(github.event.head_commit.message, 'chore: bumps package versions') }}"
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary
- quote the canary job condition so the chore: bumps package versions string does not break workflow YAML parsing
- restores Release workflow scheduling on pushes to main

## Verification
- actionlint .github/workflows/release.yml
- pnpm lint
- pnpm typecheck