### PR TITLE
chore: mark beta packages public

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [],

--- a/.changeset/public-beta-release.md
+++ b/.changeset/public-beta-release.md
@@ -4,4 +4,4 @@
 "@polymarket/types": patch
 ---
 
-Test public beta release.
+chore: configure packages for public beta release.

--- a/.changeset/public-beta-release.md
+++ b/.changeset/public-beta-release.md
@@ -1,0 +1,7 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+"@polymarket/types": patch
+---
+
+Test public beta release.

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -68,6 +68,6 @@
   },
   "license": "MIT",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -92,6 +92,6 @@
     "zod": "^4.3.6"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -26,6 +26,6 @@
   },
   "license": "MIT",
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
- set Changesets access to public
- set publishConfig.access to public for bindings, client, and types packages
- add a patch changeset to test public beta release

## Verification
- pnpm lint
- pnpm typecheck
- pnpm changeset status --verbose

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since this only changes release/publishing metadata, but it increases exposure by making the packages publicly publishable on npm.
> 
> **Overview**
> Switches Changesets and package `publishConfig.access` for `@polymarket/bindings`, `@polymarket/client`, and `@polymarket/types` from *restricted* to **public** to enable public publishing.
> 
> Adds a patch changeset (`public-beta-release`) to trigger a beta release of these packages under the new public access configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23eab9bc606c6929df354803f359793c565fb68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->