### PR TITLE
DEV-108 Add RFQ quoter WebSocket support

### DIFF
--- a/.changeset/protocol-v2-approvals.md
+++ b/.changeset/protocol-v2-approvals.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/client": patch
+"@polymarket/bindings": patch
+---
+
+Add maker-side RFQ WebSocket support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@
 - Prefer function declarations over arrow functions unless there is a clear reason to use an arrow function.
 - When a type is specific to a single function, such as a one-off params object, argument union, or return shape, colocate that `type` directly above the function declaration. Promote it to a shared or domain abstraction only when it is reused, part of the public model, or needed to express a real abstraction boundary.
 - Treat property-access-derived types like `SecureClient['signatureType']` as a code smell in most cases. Prefer a named domain type when the value is part of the public or shared model.
+- Do not use indexed-access-derived types like `SomeType['field']` in implementation code, public APIs, examples, TSDoc, or docs. This is non-negotiable; define and use a named type instead.
 - Prefer simple, local code. Accept small duplication when it keeps logic easier to read.
 - Introduce helpers only when they meaningfully improve reuse, safety, or readability. Helper names should reflect their real behavior; otherwise inline or rename them.
 - Shape implementation abstractions around real supported workflows and current platform behavior, not generic completeness. Add breadth only when a concrete use case requires it.

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -31,6 +31,10 @@
       "types": "./dist/relayer/index.d.ts",
       "default": "./dist/relayer/index.js"
     },
+    "./rfq": {
+      "types": "./dist/rfq.d.ts",
+      "default": "./dist/rfq.js"
+    },
     "./subscriptions": {
       "types": "./dist/subscriptions/index.d.ts",
       "default": "./dist/subscriptions/index.js"
@@ -49,6 +53,9 @@
       ],
       "relayer": [
         "./dist/relayer/index.d.ts"
+      ],
+      "rfq": [
+        "./dist/rfq.d.ts"
       ],
       "subscriptions": [
         "./dist/subscriptions/index.d.ts"

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -16,6 +16,8 @@ import {
   MarketIdSchema,
   MixedDateTimeStringSchema,
   PaginationCursorSchema,
+  type PositionId,
+  PositionIdSchema,
   type QuestionId,
   QuestionIdSchema,
   type ResolutionRequestId,
@@ -53,6 +55,10 @@ const OutcomePriceArraySchema = z
 
 const TokenIdArraySchema = z
   .preprocess(parseJsonString, z.array(TokenIdSchema).nullish())
+  .transform((value) => value ?? []);
+
+const PositionIdArraySchema = z
+  .preprocess(parseJsonString, z.array(PositionIdSchema).nullish())
   .transform((value) => value ?? []);
 
 export enum UmaResolutionStatus {
@@ -176,6 +182,7 @@ export type Market = {
   sports: MarketSportsMetadata;
   events: MarketEvent[];
   tags: MarketTag[];
+  positionIds: PositionId[];
 };
 
 export const GammaMarketSchema = z.object({
@@ -263,6 +270,7 @@ export const GammaMarketSchema = z.object({
   gameStartTime: IsoDateTimeStringSchema.nullish(),
   secondsDelay: z.number().int().nullish(),
   clobTokenIds: TokenIdArraySchema,
+  positionIds: PositionIdArraySchema,
   disqusThread: z.string().nullish(),
   shortOutcomes: z.string().nullish(),
   teamAID: z.string().nullish(),
@@ -458,6 +466,7 @@ export function normalizeMarket(market: GammaMarket): Market {
       slug: event.slug ?? null,
       title: event.title ?? null,
     })),
+    positionIds: market.positionIds,
     tags: (market.tags ?? []).map((tag) => ({
       id: tag.id,
       slug: tag.slug,

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -35,6 +35,7 @@ export enum RfqDirection {
 
 export enum RfqSide {
   Yes = 'YES',
+  No = 'NO',
 }
 
 export enum RfqConfirmationDecision {
@@ -51,7 +52,7 @@ export enum RfqExecutionStatus {
 }
 
 export const RfqDirectionSchema = z.enum(RfqDirection);
-export const RfqSideSchema = z.enum(RfqSide);
+export const RfqSideSchema = z.literal(RfqSide.Yes);
 export const RfqConfirmationDecisionSchema = z.enum(RfqConfirmationDecision);
 export const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
 

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -51,10 +51,39 @@ export enum RfqExecutionStatus {
   Failed = 'FAILED',
 }
 
+export enum RfqErrorCode {
+  AddressMismatch = 'ADDRESS_MISMATCH',
+  CompetitionWindowClosed = 'COMPETITION_WINDOW_CLOSED',
+  ContradictoryLegs = 'CONTRADICTORY_LEGS',
+  ExpiredRfq = 'EXPIRED_RFQ',
+  InvalidAcceptance = 'INVALID_ACCEPTANCE',
+  InvalidConfirmation = 'INVALID_CONFIRMATION',
+  InvalidExecutionResult = 'INVALID_EXECUTION_RESULT',
+  InvalidIdentity = 'INVALID_IDENTITY',
+  InvalidMessage = 'INVALID_MESSAGE',
+  InvalidQuote = 'INVALID_QUOTE',
+  InvalidRfq = 'INVALID_RFQ',
+  InvalidRfqState = 'INVALID_RFQ_STATE',
+  InvalidRole = 'INVALID_ROLE',
+  LegMetadataUnavailable = 'LEG_METADATA_UNAVAILABLE',
+  MakerAlreadyResponded = 'MAKER_ALREADY_RESPONDED',
+  MakerNotRequired = 'MAKER_NOT_REQUIRED',
+  QuoteMismatch = 'QUOTE_MISMATCH',
+  QuoteUnavailable = 'QUOTE_UNAVAILABLE',
+  RateLimited = 'RATE_LIMITED',
+  RequestFailed = 'REQUEST_FAILED',
+  ServiceUnavailable = 'SERVICE_UNAVAILABLE',
+  TradeSubmissionFailed = 'TRADE_SUBMISSION_FAILED',
+  Unauthenticated = 'UNAUTHENTICATED',
+  UnauthorizedRole = 'UNAUTHORIZED_ROLE',
+  UnknownRfq = 'UNKNOWN_RFQ',
+}
+
 export const RfqDirectionSchema = z.enum(RfqDirection);
 export const RfqSideSchema = z.literal(RfqSide.Yes);
 export const RfqConfirmationDecisionSchema = z.enum(RfqConfirmationDecision);
 export const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
+export const RfqErrorCodeSchema = z.enum(RfqErrorCode);
 
 const E6DecimalStringSchema = z.number().int().transform(toDecimalStringFromE6);
 
@@ -233,10 +262,43 @@ export const RfqExecutionUpdateSchema = z
 
 export type RfqExecutionUpdate = z.infer<typeof RfqExecutionUpdateSchema>;
 
-export const RfqErrorMessageSchema = z.object({
-  type: z.literal('error'),
-  error: z.string(),
-});
+export const RfqErrorRequestSchema = z
+  .object({
+    leg_position_ids: z.array(z.string()),
+    direction: z.string(),
+    side: z.string(),
+    size_notional_e6: z.number().int().optional(),
+    size_shares_e6: z.number().int().optional(),
+  })
+  .transform((request) => ({
+    direction: request.direction,
+    legPositionIds: request.leg_position_ids,
+    side: request.side,
+    sizeNotionalE6: request.size_notional_e6,
+    sizeSharesE6: request.size_shares_e6,
+  }));
+
+export type RfqErrorRequest = z.infer<typeof RfqErrorRequestSchema>;
+
+export const RfqErrorMessageSchema = z
+  .object({
+    type: z.literal('RFQ_ERROR'),
+    request_type: z.string().optional(),
+    rfq_id: RfqIdSchema.optional(),
+    quote_id: RfqQuoteIdSchema.optional(),
+    code: RfqErrorCodeSchema,
+    error: z.string(),
+    request: RfqErrorRequestSchema.optional(),
+  })
+  .transform((message) => ({
+    code: message.code,
+    message: message.error,
+    quoteId: message.quote_id,
+    request: message.request,
+    requestType: message.request_type,
+    rfqId: message.rfq_id,
+    type: 'rfq_error' as const,
+  }));
 
 export type RfqErrorMessage = z.infer<typeof RfqErrorMessageSchema>;
 

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -5,7 +5,7 @@ import type {
 } from '@polymarket/types';
 import { z } from 'zod';
 import { type SignatureType, SignatureTypeSchema } from './clob/signature-type';
-import type { BaseUnits, EvmAddress, TokenId } from './shared';
+import type { BaseUnits, DecimalString, EvmAddress, TokenId } from './shared';
 import {
   ConditionIdSchema,
   EpochMicrosecondsSchema,
@@ -51,6 +51,11 @@ export enum RfqExecutionStatus {
   Failed = 'FAILED',
 }
 
+export enum RfqRequestedSizeUnit {
+  Notional = 'notional',
+  Shares = 'shares',
+}
+
 export enum RfqErrorCode {
   AddressMismatch = 'ADDRESS_MISMATCH',
   CompetitionWindowClosed = 'COMPETITION_WINDOW_CLOSED',
@@ -83,9 +88,20 @@ export const RfqDirectionSchema = z.enum(RfqDirection);
 export const RfqSideSchema = z.literal(RfqSide.Yes);
 export const RfqConfirmationDecisionSchema = z.enum(RfqConfirmationDecision);
 export const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
+export const RfqRequestedSizeUnitSchema = z.enum(RfqRequestedSizeUnit);
 export const RfqErrorCodeSchema = z.enum(RfqErrorCode);
 
 const E6DecimalStringSchema = z.number().int().transform(toDecimalStringFromE6);
+
+export type RfqRequestedSize =
+  | {
+      unit: RfqRequestedSizeUnit.Notional;
+      value: DecimalString;
+    }
+  | {
+      unit: RfqRequestedSizeUnit.Shares;
+      value: DecimalString;
+    };
 
 export type RfqSignedOrder = {
   salt: string;
@@ -142,18 +158,20 @@ export const RfqQuoteRequestSchema = z
     no_position_id: PositionIdSchema,
     direction: RfqDirectionSchema,
     side: RfqSideSchema,
-    size_e6: E6DecimalStringSchema,
+    size_notional_e6: E6DecimalStringSchema.optional(),
+    size_shares_e6: E6DecimalStringSchema.optional(),
     submission_deadline: EpochMicrosecondsSchema,
   })
+  .superRefine(validateRequestedSizeFields)
   .transform((message) => ({
     conditionId: message.condition_id,
     direction: message.direction,
     legPositionIds: message.leg_position_ids,
     noPositionId: message.no_position_id,
     requestorPublicId: message.requestor_public_id,
+    requestedSize: toRequestedSize(message),
     rfqId: message.rfq_id,
     side: message.side,
-    size: message.size_e6,
     submissionDeadline: message.submission_deadline,
     type: 'quote_request' as const,
     yesPositionId: message.yes_position_id,
@@ -262,24 +280,6 @@ export const RfqExecutionUpdateSchema = z
 
 export type RfqExecutionUpdate = z.infer<typeof RfqExecutionUpdateSchema>;
 
-export const RfqErrorRequestSchema = z
-  .object({
-    leg_position_ids: z.array(z.string()),
-    direction: z.string(),
-    side: z.string(),
-    size_notional_e6: z.number().int().optional(),
-    size_shares_e6: z.number().int().optional(),
-  })
-  .transform((request) => ({
-    direction: request.direction,
-    legPositionIds: request.leg_position_ids,
-    side: request.side,
-    sizeNotionalE6: request.size_notional_e6,
-    sizeSharesE6: request.size_shares_e6,
-  }));
-
-export type RfqErrorRequest = z.infer<typeof RfqErrorRequestSchema>;
-
 export const RfqErrorMessageSchema = z
   .object({
     type: z.literal('RFQ_ERROR'),
@@ -288,13 +288,12 @@ export const RfqErrorMessageSchema = z
     quote_id: RfqQuoteIdSchema.optional(),
     code: RfqErrorCodeSchema,
     error: z.string(),
-    request: RfqErrorRequestSchema.optional(),
+    request: z.unknown().optional(),
   })
   .transform((message) => ({
     code: message.code,
     message: message.error,
     quoteId: message.quote_id,
-    request: message.request,
     requestType: message.request_type,
     rfqId: message.rfq_id,
     type: 'rfq_error' as const,
@@ -335,4 +334,42 @@ function toDecimalStringFromE6(value: number) {
   return toDecimalString(
     `${whole}${trimmedFraction === '' ? '' : `.${trimmedFraction}`}`,
   );
+}
+
+type RequestedSizeFields = {
+  size_notional_e6?: DecimalString;
+  size_shares_e6?: DecimalString;
+};
+
+function validateRequestedSizeFields(
+  fields: RequestedSizeFields,
+  ctx: z.RefinementCtx,
+): void {
+  if (
+    (fields.size_notional_e6 === undefined) ===
+    (fields.size_shares_e6 === undefined)
+  ) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Expected exactly one RFQ requested size field.',
+    });
+  }
+}
+
+function toRequestedSize(fields: RequestedSizeFields): RfqRequestedSize {
+  if (fields.size_notional_e6 !== undefined) {
+    return {
+      unit: RfqRequestedSizeUnit.Notional,
+      value: fields.size_notional_e6,
+    };
+  }
+
+  if (fields.size_shares_e6 === undefined) {
+    throw new TypeError('Expected RFQ requested size.');
+  }
+
+  return {
+    unit: RfqRequestedSizeUnit.Shares,
+    value: fields.size_shares_e6,
+  };
 }

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -215,6 +215,14 @@ export type RfqQuoteMessage = {
   signed_order: RfqSignedOrder;
 };
 
+export type RfqQuoteCancelMessage = {
+  type: 'RFQ_QUOTE_CANCEL';
+  rfq_id: RfqId;
+  quote_id: RfqQuoteId;
+  signer_address: EvmAddress;
+  maker_address: EvmAddress;
+};
+
 export const RfqQuoteAckSchema = z
   .object({
     type: z.literal('ACK_RFQ_QUOTE'),
@@ -228,6 +236,20 @@ export const RfqQuoteAckSchema = z
   }));
 
 export type RfqQuoteAck = z.infer<typeof RfqQuoteAckSchema>;
+
+export const RfqQuoteCancelAckSchema = z
+  .object({
+    type: z.literal('ACK_RFQ_QUOTE_CANCEL'),
+    rfq_id: RfqIdSchema,
+    quote_id: RfqQuoteIdSchema,
+  })
+  .transform((message) => ({
+    quoteId: message.quote_id,
+    rfqId: message.rfq_id,
+    type: 'quote_cancel_ack' as const,
+  }));
+
+export type RfqQuoteCancelAck = z.infer<typeof RfqQuoteCancelAckSchema>;
 
 export const RfqConfirmationRequestSchema = z
   .object({
@@ -333,6 +355,7 @@ export const RfqQuoterInboundMessageSchema = z.union([
   RfqAuthResponseMessageSchema,
   RfqQuoteRequestSchema,
   RfqQuoteAckSchema,
+  RfqQuoteCancelAckSchema,
   RfqConfirmationRequestSchema,
   RfqConfirmationAckSchema,
   RfqExecutionUpdateSchema,
@@ -345,4 +368,5 @@ export type RfqQuoterInboundMessage = z.infer<
 
 export type RfqQuoterOutboundMessage =
   | RfqQuoteMessage
+  | RfqQuoteCancelMessage
   | RfqConfirmationResponseMessage;

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -8,7 +8,7 @@ import { type SignatureType, SignatureTypeSchema } from './clob/signature-type';
 import type { BaseUnits, DecimalString, EvmAddress, TokenId } from './shared';
 import {
   ConditionIdSchema,
-  EpochMicrosecondsSchema,
+  EpochMillisecondsSchema,
   EvmAddressSchema,
   type OrderSide,
   type PositionId,
@@ -91,7 +91,19 @@ export const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
 export const RfqRequestedSizeUnitSchema = z.enum(RfqRequestedSizeUnit);
 export const RfqErrorCodeSchema = z.enum(RfqErrorCode);
 
-const E6DecimalStringSchema = z.number().int().transform(toDecimalStringFromE6);
+const BigIntStringToDecimalStringSchema = z
+  .string()
+  .regex(/^\d+$/)
+  .transform((value) => {
+    const scaledValue = BigInt(value);
+    const whole = scaledValue / 1_000_000n;
+    const fraction = (scaledValue % 1_000_000n)
+      .toString()
+      .padStart(6, '0')
+      .replace(/0+$/, '');
+
+    return toDecimalString(`${whole}${fraction === '' ? '' : `.${fraction}`}`);
+  });
 
 export type RfqRequestedSize =
   | {
@@ -102,6 +114,24 @@ export type RfqRequestedSize =
       unit: RfqRequestedSizeUnit.Shares;
       value: DecimalString;
     };
+
+const RfqRequestedSizeSchema = z
+  .discriminatedUnion('unit', [
+    z.object({
+      unit: z.literal(RfqRequestedSizeUnit.Notional),
+      value_e6: BigIntStringToDecimalStringSchema,
+    }),
+    z.object({
+      unit: z.literal(RfqRequestedSizeUnit.Shares),
+      value_e6: BigIntStringToDecimalStringSchema,
+    }),
+  ])
+  .transform(
+    (size): RfqRequestedSize => ({
+      unit: size.unit,
+      value: size.value_e6,
+    }),
+  ) satisfies z.ZodType<RfqRequestedSize>;
 
 export type RfqSignedOrder = {
   salt: string;
@@ -158,18 +188,16 @@ export const RfqQuoteRequestSchema = z
     no_position_id: PositionIdSchema,
     direction: RfqDirectionSchema,
     side: RfqSideSchema,
-    size_notional_e6: E6DecimalStringSchema.optional(),
-    size_shares_e6: E6DecimalStringSchema.optional(),
-    submission_deadline: EpochMicrosecondsSchema,
+    requested_size: RfqRequestedSizeSchema,
+    submission_deadline: EpochMillisecondsSchema,
   })
-  .superRefine(validateRequestedSizeFields)
   .transform((message) => ({
     conditionId: message.condition_id,
     direction: message.direction,
     legPositionIds: message.leg_position_ids,
     noPositionId: message.no_position_id,
     requestorPublicId: message.requestor_public_id,
-    requestedSize: toRequestedSize(message),
+    requestedSize: message.requested_size,
     rfqId: message.rfq_id,
     side: message.side,
     submissionDeadline: message.submission_deadline,
@@ -182,8 +210,8 @@ export type RfqQuoteRequest = z.infer<typeof RfqQuoteRequestSchema>;
 export type RfqQuoteMessage = {
   type: 'RFQ_QUOTE';
   rfq_id: RfqId;
-  price_e6: number;
-  size_e6: number;
+  price_e6: string;
+  size_e6: string;
   signed_order: RfqSignedOrder;
 };
 
@@ -215,9 +243,9 @@ export const RfqConfirmationRequestSchema = z
     no_position_id: PositionIdSchema,
     direction: RfqDirectionSchema,
     side: RfqSideSchema,
-    fill_size_e6: E6DecimalStringSchema,
-    price_e6: E6DecimalStringSchema,
-    confirm_by: EpochMicrosecondsSchema,
+    fill_size_e6: BigIntStringToDecimalStringSchema,
+    price_e6: BigIntStringToDecimalStringSchema,
+    confirm_by: EpochMillisecondsSchema,
   })
   .transform((message) => ({
     conditionId: message.condition_id,
@@ -318,58 +346,3 @@ export type RfqQuoterInboundMessage = z.infer<
 export type RfqQuoterOutboundMessage =
   | RfqQuoteMessage
   | RfqConfirmationResponseMessage;
-
-function toDecimalStringFromE6(value: number) {
-  if (!Number.isSafeInteger(value)) {
-    throw new TypeError(`Expected a safe integer, received: ${value}`);
-  }
-  if (value < 0) {
-    throw new TypeError(`Expected a non-negative integer, received: ${value}`);
-  }
-
-  const whole = Math.floor(value / 1_000_000);
-  const fraction = (value % 1_000_000).toString().padStart(6, '0');
-  const trimmedFraction = fraction.replace(/0+$/, '');
-
-  return toDecimalString(
-    `${whole}${trimmedFraction === '' ? '' : `.${trimmedFraction}`}`,
-  );
-}
-
-type RequestedSizeFields = {
-  size_notional_e6?: DecimalString;
-  size_shares_e6?: DecimalString;
-};
-
-function validateRequestedSizeFields(
-  fields: RequestedSizeFields,
-  ctx: z.RefinementCtx,
-): void {
-  if (
-    (fields.size_notional_e6 === undefined) ===
-    (fields.size_shares_e6 === undefined)
-  ) {
-    ctx.addIssue({
-      code: 'custom',
-      message: 'Expected exactly one RFQ requested size field.',
-    });
-  }
-}
-
-function toRequestedSize(fields: RequestedSizeFields): RfqRequestedSize {
-  if (fields.size_notional_e6 !== undefined) {
-    return {
-      unit: RfqRequestedSizeUnit.Notional,
-      value: fields.size_notional_e6,
-    };
-  }
-
-  if (fields.size_shares_e6 === undefined) {
-    throw new TypeError('Expected RFQ requested size.');
-  }
-
-  return {
-    unit: RfqRequestedSizeUnit.Shares,
-    value: fields.size_shares_e6,
-  };
-}

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -22,6 +22,12 @@ import {
   toDecimalString,
 } from './shared';
 
+export type {
+  RfqId,
+  RfqQuoteId,
+  RfqRequestorPublicId,
+} from './shared';
+
 export enum RfqDirection {
   Buy = 'BUY',
   Sell = 'SELL',

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -1,0 +1,269 @@
+import type {
+  Erc1271Signature,
+  EvmSignature,
+  HexString,
+} from '@polymarket/types';
+import { z } from 'zod';
+import { type SignatureType, SignatureTypeSchema } from './clob/signature-type';
+import type { BaseUnits, EvmAddress, TokenId } from './shared';
+import {
+  ConditionIdSchema,
+  EpochMicrosecondsSchema,
+  EvmAddressSchema,
+  type OrderSide,
+  type PositionId,
+  PositionIdSchema,
+  type RfqId,
+  RfqIdSchema,
+  type RfqQuoteId,
+  RfqQuoteIdSchema,
+  RfqRequestorPublicIdSchema,
+  TxHashSchema,
+  toDecimalString,
+} from './shared';
+
+export enum RfqDirection {
+  Buy = 'BUY',
+  Sell = 'SELL',
+}
+
+export enum RfqSide {
+  Yes = 'YES',
+}
+
+export enum RfqConfirmationDecision {
+  Confirm = 'CONFIRM',
+  Decline = 'DECLINE',
+}
+
+export enum RfqExecutionStatus {
+  Matched = 'MATCHED',
+  Mined = 'MINED',
+  Confirmed = 'CONFIRMED',
+  Retrying = 'RETRYING',
+  Failed = 'FAILED',
+}
+
+export const RfqDirectionSchema = z.enum(RfqDirection);
+export const RfqSideSchema = z.enum(RfqSide);
+export const RfqConfirmationDecisionSchema = z.enum(RfqConfirmationDecision);
+export const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
+
+const E6DecimalStringSchema = z.number().int().transform(toDecimalStringFromE6);
+
+export type RfqSignedOrder = {
+  salt: string;
+  maker: EvmAddress;
+  signer: EvmAddress;
+  tokenId: PositionId | TokenId;
+  makerAmount: BaseUnits;
+  takerAmount: BaseUnits;
+  side: RfqOrderSide;
+  signatureType: SignatureType;
+  timestamp: string;
+  builder?: HexString;
+  expiration?: string;
+  metadata?: HexString;
+  signature: EvmSignature | Erc1271Signature;
+};
+
+export type RfqOrderSide = OrderSide | 0 | 1;
+
+export type RfqAuthMessage = {
+  type: 'auth';
+  auth: {
+    apiKey: string;
+    passphrase: string;
+    secret: string;
+  };
+  identity: {
+    signer_address: EvmAddress;
+    maker_address: EvmAddress;
+    signature_type: SignatureType;
+  };
+};
+
+export const RfqAuthResponseMessageSchema = z.object({
+  type: z.literal('auth'),
+  success: z.boolean(),
+  address: EvmAddressSchema.optional(),
+  role: z.string().optional(),
+  error: z.string().optional(),
+});
+
+export type RfqAuthResponseMessage = z.infer<
+  typeof RfqAuthResponseMessageSchema
+>;
+
+export const RfqQuoteRequestSchema = z
+  .object({
+    type: z.literal('RFQ_REQUEST'),
+    rfq_id: RfqIdSchema,
+    requestor_public_id: RfqRequestorPublicIdSchema,
+    leg_position_ids: z.array(PositionIdSchema),
+    condition_id: ConditionIdSchema,
+    yes_position_id: PositionIdSchema,
+    no_position_id: PositionIdSchema,
+    direction: RfqDirectionSchema,
+    side: RfqSideSchema,
+    size_e6: E6DecimalStringSchema,
+    submission_deadline: EpochMicrosecondsSchema,
+  })
+  .transform((message) => ({
+    conditionId: message.condition_id,
+    direction: message.direction,
+    legPositionIds: message.leg_position_ids,
+    noPositionId: message.no_position_id,
+    requestorPublicId: message.requestor_public_id,
+    rfqId: message.rfq_id,
+    side: message.side,
+    size: message.size_e6,
+    submissionDeadline: message.submission_deadline,
+    type: 'quote_request' as const,
+    yesPositionId: message.yes_position_id,
+  }));
+
+export type RfqQuoteRequest = z.infer<typeof RfqQuoteRequestSchema>;
+
+export type RfqQuoteMessage = {
+  type: 'RFQ_QUOTE';
+  rfq_id: RfqId;
+  price_e6: number;
+  size_e6: number;
+  signed_order: RfqSignedOrder;
+};
+
+export const RfqQuoteAckSchema = z
+  .object({
+    type: z.literal('ACK_RFQ_QUOTE'),
+    rfq_id: RfqIdSchema,
+    quote_id: RfqQuoteIdSchema,
+  })
+  .transform((message) => ({
+    quoteId: message.quote_id,
+    rfqId: message.rfq_id,
+    type: 'quote_ack' as const,
+  }));
+
+export type RfqQuoteAck = z.infer<typeof RfqQuoteAckSchema>;
+
+export const RfqConfirmationRequestSchema = z
+  .object({
+    type: z.literal('RFQ_CONFIRMATION_REQUEST'),
+    rfq_id: RfqIdSchema,
+    quote_id: RfqQuoteIdSchema,
+    signer_address: EvmAddressSchema,
+    maker_address: EvmAddressSchema,
+    signature_type: SignatureTypeSchema,
+    leg_position_ids: z.array(PositionIdSchema),
+    condition_id: ConditionIdSchema,
+    yes_position_id: PositionIdSchema,
+    no_position_id: PositionIdSchema,
+    direction: RfqDirectionSchema,
+    side: RfqSideSchema,
+    fill_size_e6: E6DecimalStringSchema,
+    price_e6: E6DecimalStringSchema,
+    confirm_by: EpochMicrosecondsSchema,
+  })
+  .transform((message) => ({
+    conditionId: message.condition_id,
+    confirmBy: message.confirm_by,
+    direction: message.direction,
+    fillSize: message.fill_size_e6,
+    legPositionIds: message.leg_position_ids,
+    makerAddress: message.maker_address,
+    noPositionId: message.no_position_id,
+    price: message.price_e6,
+    quoteId: message.quote_id,
+    rfqId: message.rfq_id,
+    side: message.side,
+    signatureType: message.signature_type,
+    signerAddress: message.signer_address,
+    type: 'confirmation_request' as const,
+    yesPositionId: message.yes_position_id,
+  }));
+
+export type RfqConfirmationRequest = z.infer<
+  typeof RfqConfirmationRequestSchema
+>;
+
+export type RfqConfirmationResponseMessage = {
+  type: 'RFQ_CONFIRMATION_RESPONSE';
+  rfq_id: RfqId;
+  quote_id: RfqQuoteId;
+  decision: RfqConfirmationDecision;
+};
+
+export const RfqConfirmationAckSchema = z
+  .object({
+    type: z.literal('ACK_RFQ_CONFIRMATION_RESPONSE'),
+    rfq_id: RfqIdSchema,
+    quote_id: RfqQuoteIdSchema,
+    decision: RfqConfirmationDecisionSchema,
+  })
+  .transform((message) => ({
+    decision: message.decision,
+    quoteId: message.quote_id,
+    rfqId: message.rfq_id,
+    type: 'confirmation_ack' as const,
+  }));
+
+export type RfqConfirmationAck = z.infer<typeof RfqConfirmationAckSchema>;
+
+export const RfqExecutionUpdateSchema = z
+  .object({
+    type: z.literal('RFQ_EXECUTION_UPDATE'),
+    rfq_id: RfqIdSchema,
+    status: RfqExecutionStatusSchema,
+    tx_hash: TxHashSchema.optional(),
+  })
+  .transform((message) => ({
+    rfqId: message.rfq_id,
+    status: message.status,
+    ...(message.tx_hash === undefined ? {} : { txHash: message.tx_hash }),
+    type: 'execution_update' as const,
+  }));
+
+export type RfqExecutionUpdate = z.infer<typeof RfqExecutionUpdateSchema>;
+
+export const RfqErrorMessageSchema = z.object({
+  type: z.literal('error'),
+  error: z.string(),
+});
+
+export type RfqErrorMessage = z.infer<typeof RfqErrorMessageSchema>;
+
+export const RfqQuoterInboundMessageSchema = z.union([
+  RfqAuthResponseMessageSchema,
+  RfqQuoteRequestSchema,
+  RfqQuoteAckSchema,
+  RfqConfirmationRequestSchema,
+  RfqConfirmationAckSchema,
+  RfqExecutionUpdateSchema,
+  RfqErrorMessageSchema,
+]);
+
+export type RfqQuoterInboundMessage = z.infer<
+  typeof RfqQuoterInboundMessageSchema
+>;
+
+export type RfqQuoterOutboundMessage =
+  | RfqQuoteMessage
+  | RfqConfirmationResponseMessage;
+
+function toDecimalStringFromE6(value: number) {
+  if (!Number.isSafeInteger(value)) {
+    throw new TypeError(`Expected a safe integer, received: ${value}`);
+  }
+  if (value < 0) {
+    throw new TypeError(`Expected a non-negative integer, received: ${value}`);
+  }
+
+  const whole = Math.floor(value / 1_000_000);
+  const fraction = (value % 1_000_000).toString().padStart(6, '0');
+  const trimmedFraction = fraction.replace(/0+$/, '');
+
+  return toDecimalString(
+    `${whole}${trimmedFraction === '' ? '' : `.${trimmedFraction}`}`,
+  );
+}

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -65,8 +65,12 @@ export type MixedDateTimeString = Tagged<string, 'MixedDateTimeString'>;
 export type NotificationId = Tagged<number, 'NotificationId'>;
 export type PartnerId = Tagged<number, 'PartnerId'>;
 export type PaginationCursor = Tagged<string, 'PaginationCursor'>;
+export type PositionId = Tagged<string, 'PositionId'>;
 export type QuestionId = Tagged<HexString, 'QuestionId'>;
 export type ResolutionRequestId = Tagged<HexString, 'ResolutionRequestId'>;
+export type RfqId = Tagged<string, 'RfqId'>;
+export type RfqQuoteId = Tagged<string, 'RfqQuoteId'>;
+export type RfqRequestorPublicId = Tagged<string, 'RfqRequestorPublicId'>;
 export type SeriesId = Tagged<string, 'SeriesId'>;
 export type SportId = Tagged<number, 'SportId'>;
 export type TagId = Tagged<string, 'TagId'>;
@@ -76,6 +80,7 @@ export type TransactionId = Tagged<string, 'TransactionId'>;
 export type TokenId = Tagged<string, 'TokenId'>;
 export type DecimalString = Tagged<string, 'DecimalString'>;
 export type BaseUnits = Tagged<string, 'BaseUnits'>;
+export type EpochMicroseconds = Tagged<number, 'EpochMicroseconds'>;
 
 export function toBestLineId(value: string): BestLineId {
   return toTaggedString<BestLineId>(value);
@@ -175,12 +180,28 @@ export function toPaginationCursor(value: string): PaginationCursor {
   return toTaggedString<PaginationCursor>(value);
 }
 
+export function toPositionId(value: string): PositionId {
+  return toTaggedString<PositionId>(value);
+}
+
 export function toQuestionId(value: string): QuestionId {
   return to32ByteHexString(value) as QuestionId;
 }
 
 export function toResolutionRequestId(value: string): ResolutionRequestId {
   return to32ByteHexString(value) as ResolutionRequestId;
+}
+
+export function toRfqId(value: string): RfqId {
+  return toTaggedString<RfqId>(value);
+}
+
+export function toRfqQuoteId(value: string): RfqQuoteId {
+  return toTaggedString<RfqQuoteId>(value);
+}
+
+export function toRfqRequestorPublicId(value: string): RfqRequestorPublicId {
+  return toTaggedString<RfqRequestorPublicId>(value);
 }
 
 export function toSeriesId(value: string): SeriesId {
@@ -219,6 +240,10 @@ export function toBaseUnits(value: string): BaseUnits {
   return toTaggedString<BaseUnits>(value);
 }
 
+export function toEpochMicroseconds(value: number): EpochMicroseconds {
+  return toTaggedInteger<EpochMicroseconds>(value);
+}
+
 export const CategoryIdSchema = z.string().transform(toCategoryId);
 export const ApiKeySchema = z.string().transform(toApiKey);
 export const BuilderCodeSchema = z.string().transform(toBuilderCode);
@@ -234,6 +259,10 @@ export const EpochMillisecondsSchema = z
   .number()
   .int()
   .transform(toEpochMilliseconds);
+export const EpochMicrosecondsSchema = z
+  .number()
+  .int()
+  .transform(toEpochMicroseconds);
 export const EpochSecondsToMillisecondsSchema = z
   .number()
   .int()
@@ -319,10 +348,16 @@ export const PaginationCursorSchema = z
   .string()
   .min(1)
   .transform(toPaginationCursor);
+export const PositionIdSchema = z.string().transform(toPositionId);
 export const QuestionIdSchema = z.string().transform(toQuestionId);
 export const ResolutionRequestIdSchema = z
   .string()
   .transform(toResolutionRequestId);
+export const RfqIdSchema = z.string().transform(toRfqId);
+export const RfqQuoteIdSchema = z.string().transform(toRfqQuoteId);
+export const RfqRequestorPublicIdSchema = z
+  .string()
+  .transform(toRfqRequestorPublicId);
 export const TagIdSchema = z.string().transform(toTagId);
 export const TokenIdSchema = z.string().transform(toTokenId);
 export const TransactionIdSchema = z.string().min(1).transform(toTransactionId);

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -80,7 +80,6 @@ export type TransactionId = Tagged<string, 'TransactionId'>;
 export type TokenId = Tagged<string, 'TokenId'>;
 export type DecimalString = Tagged<string, 'DecimalString'>;
 export type BaseUnits = Tagged<string, 'BaseUnits'>;
-export type EpochMicroseconds = Tagged<number, 'EpochMicroseconds'>;
 
 export function toBestLineId(value: string): BestLineId {
   return toTaggedString<BestLineId>(value);
@@ -240,10 +239,6 @@ export function toBaseUnits(value: string): BaseUnits {
   return toTaggedString<BaseUnits>(value);
 }
 
-export function toEpochMicroseconds(value: number): EpochMicroseconds {
-  return toTaggedInteger<EpochMicroseconds>(value);
-}
-
 export const CategoryIdSchema = z.string().transform(toCategoryId);
 export const ApiKeySchema = z.string().transform(toApiKey);
 export const BuilderCodeSchema = z.string().transform(toBuilderCode);
@@ -259,10 +254,6 @@ export const EpochMillisecondsSchema = z
   .number()
   .int()
   .transform(toEpochMilliseconds);
-export const EpochMicrosecondsSchema = z
-  .number()
-  .int()
-  .transform(toEpochMicroseconds);
 export const EpochSecondsToMillisecondsSchema = z
   .number()
   .int()

--- a/packages/bindings/tsup.config.ts
+++ b/packages/bindings/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(() => ({
     'src/data/index.ts',
     'src/gamma/index.ts',
     'src/relayer/index.ts',
+    'src/rfq.ts',
     'src/subscriptions/index.ts',
   ],
   outDir: 'dist',

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -22,39 +22,33 @@ const MAX_UINT256_RESULT = `0x${'f'.repeat(64)}` as HexString;
 const wallet = expectEvmAddress('0x0000000000000000000000000000000000000001');
 
 describe('prepareTradingApprovals', () => {
-  it('includes auto-redeem approval in account setup', async () => {
+  it('submits every missing approval and waits after each EOA transaction', async () => {
     const { client } = createClient([
-      ...Array<HexString>(5).fill(FALSE_RESULT),
-      ...Array<HexString>(6).fill(FALSE_RESULT),
+      ...Array<HexString>(7).fill(FALSE_RESULT),
+      ...Array<HexString>(9).fill(FALSE_RESULT),
     ]);
     const workflow = await prepareTradingApprovals(client);
+    const handles = Array.from({ length: 16 }, createTransactionHandle);
     let result = await workflow.next();
 
-    for (let index = 0; index < 10; index += 1) {
+    for (const handle of handles) {
       expect(result.done).toBe(false);
-      result = await workflow.next(createTransactionHandle());
+      result = await workflow.next(handle);
     }
 
     expect(result).toEqual({
-      done: false,
-      value: {
-        kind: 'sendErc1155ApprovalForAllTransaction',
-        request: {
-          chainId: production.chainId,
-          ...erc1155ApprovalForAllCall(
-            production.conditionalTokens,
-            production.autoRedeemOperator,
-            true,
-          ),
-        },
-      },
+      done: true,
+      value: undefined,
     });
+    for (const handle of handles) {
+      expect(handle.wait).toHaveBeenCalledTimes(1);
+    }
   });
 
   it('completes without transactions when approvals are already set', async () => {
     const { client, ethCallBatch } = createClient([
-      ...Array<HexString>(5).fill(MAX_UINT256_RESULT),
-      ...Array<HexString>(6).fill(TRUE_RESULT),
+      ...Array<HexString>(7).fill(MAX_UINT256_RESULT),
+      ...Array<HexString>(9).fill(TRUE_RESULT),
     ]);
 
     const workflow = await prepareTradingApprovals(client);
@@ -66,15 +60,15 @@ describe('prepareTradingApprovals', () => {
       value: undefined,
     });
     expect(ethCallBatch).toHaveBeenCalledTimes(1);
-    expect(ethCallBatch.mock.calls[0]?.[0]).toHaveLength(11);
+    expect(ethCallBatch.mock.calls[0]?.[0]).toHaveLength(16);
   });
 
   it('submits only missing approvals', async () => {
     const { client } = createClient([
       FALSE_RESULT,
-      ...Array<HexString>(4).fill(MAX_UINT256_RESULT),
+      ...Array<HexString>(6).fill(MAX_UINT256_RESULT),
       FALSE_RESULT,
-      ...Array<HexString>(5).fill(TRUE_RESULT),
+      ...Array<HexString>(8).fill(TRUE_RESULT),
     ]);
     const firstHandle = createTransactionHandle();
     const secondHandle = createTransactionHandle();

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -301,13 +301,6 @@ type TradingApprovalRequirements = {
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
- * Prepares missing approvals required for trading, including collateral and
- * position token approvals for both standard and neg-risk market flows.
- * The collateral adapter approvals cover split, merge, and redemption workflows.
- * Auto-redeem approval is included so accounts are ready for supported position
- * lifecycle workflows. If all approvals are already in place, the workflow
- * completes without yielding any transaction requests.
- *
  * @example
  * ```ts
  * const workflow = await prepareTradingApprovals(client);
@@ -495,6 +488,16 @@ function getRequiredTradingApprovals(
         spenderAddress: client.environment.negRiskCollateralAdapter,
         tokenAddress: client.environment.collateralToken,
       },
+      {
+        amount: MAX_UINT256,
+        spenderAddress: client.environment.protocolV2Router,
+        tokenAddress: client.environment.collateralToken,
+      },
+      {
+        amount: MAX_UINT256,
+        spenderAddress: client.environment.exchangeV3,
+        tokenAddress: client.environment.collateralToken,
+      },
     ],
     erc1155: [
       {
@@ -520,6 +523,18 @@ function getRequiredTradingApprovals(
       {
         operatorAddress: client.environment.autoRedeemOperator,
         tokenAddress: client.environment.conditionalTokens,
+      },
+      {
+        operatorAddress: client.environment.protocolV2Router,
+        tokenAddress: client.environment.positionManager,
+      },
+      {
+        operatorAddress: client.environment.exchangeV3,
+        tokenAddress: client.environment.positionManager,
+      },
+      {
+        operatorAddress: client.environment.autoRedeemOperator,
+        tokenAddress: client.environment.positionManager,
       },
     ],
   };

--- a/packages/client/src/actions/index.ts
+++ b/packages/client/src/actions/index.ts
@@ -13,6 +13,7 @@ export * from './orders';
 export * from './portfolio';
 export * from './positions';
 export * from './profiles';
+export * from './rfq';
 export * from './search';
 export * from './series';
 export * from './sports';

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -2,6 +2,7 @@ import {
   ConditionIdSchema,
   IsoDateTimeStringSchema,
   PaginationCursorSchema,
+  PositionIdSchema,
 } from '@polymarket/bindings';
 import {
   ListMarketHoldersResponseSchema,
@@ -61,6 +62,7 @@ const ListMarketsRequestSchema = z.object({
   locale: z.string().optional(),
   marketMakerAddresses: z.array(z.string()).optional(),
   order: z.string().optional(),
+  positionIds: z.array(PositionIdSchema).optional(),
   questionIds: z.array(z.string()).optional(),
   relatedTags: z.boolean().optional(),
   rfqEnabled: z.boolean().optional(),

--- a/packages/client/src/actions/orders/orders.ts
+++ b/packages/client/src/actions/orders/orders.ts
@@ -1,7 +1,6 @@
-import { SignatureType } from '@polymarket/bindings/clob';
 import type { HexString } from '@polymarket/types';
 import type { AccountIdentity } from '../../wallet';
-import { toSignatureType } from '../../wallet';
+import { resolveOrderIdentity } from '../../wallet';
 import type { OrderDraft, SignedOrder, UnsignedOrder } from './types';
 
 const BYTES32_ZERO =
@@ -11,22 +10,21 @@ export function createUnsignedOrder(
   order: OrderDraft,
   account: AccountIdentity,
 ): UnsignedOrder {
-  const signatureType = toSignatureType(account.walletType);
+  const identity = resolveOrderIdentity(account);
 
   return {
     builder: order.builderCode ?? BYTES32_ZERO,
     chainId: order.chainId,
     exchangeAddress: order.exchangeAddress,
     expiration: order.expiration,
-    maker: order.funderAddress,
+    maker: identity.maker,
     makerAmount: order.offeredAmount.toString(),
     metadata: BYTES32_ZERO,
     orderType: order.orderType,
     salt: generateOrderSalt().toString(),
     side: order.side,
-    signatureType,
-    signer:
-      signatureType === SignatureType.POLY_1271 ? account.wallet : order.signer,
+    signatureType: identity.signatureType,
+    signer: identity.signer,
     takerAmount: order.requestedAmount.toString(),
     timestamp: Date.now().toString(),
     tokenId: order.tokenId,

--- a/packages/client/src/actions/orders/typed-data.ts
+++ b/packages/client/src/actions/orders/typed-data.ts
@@ -1,237 +1,36 @@
-import { OrderSide } from '@polymarket/bindings';
-import { SignatureType } from '@polymarket/bindings/clob';
+import type { Erc1271Signature, EvmSignature } from '@polymarket/types';
 import {
-  type Erc1271Signature,
-  type EvmAddress,
-  type EvmSignature,
-  expectErc1271Signature,
-  expectHexString,
-  type HexString,
-} from '@polymarket/types';
-import { AbiParameters, Bytes, Hash } from 'ox';
-import type { TypedDataField, TypedDataPayload } from '../../types';
+  createExchangeOrderSignature,
+  createExchangeOrderTypedDataPayload,
+  ExchangeOrderProtocolVersion,
+} from '../../exchange';
+import type { TypedDataPayload } from '../../types';
 import type { UnsignedOrder } from './types';
-
-const EIP712_DOMAIN: readonly TypedDataField[] = [
-  { name: 'name', type: 'string' },
-  { name: 'version', type: 'string' },
-  { name: 'chainId', type: 'uint256' },
-  { name: 'verifyingContract', type: 'address' },
-];
-
-const ORDER_STRUCTURE: readonly TypedDataField[] = [
-  { name: 'salt', type: 'uint256' },
-  { name: 'maker', type: 'address' },
-  { name: 'signer', type: 'address' },
-  { name: 'tokenId', type: 'uint256' },
-  { name: 'makerAmount', type: 'uint256' },
-  { name: 'takerAmount', type: 'uint256' },
-  { name: 'side', type: 'uint8' },
-  { name: 'signatureType', type: 'uint8' },
-  { name: 'timestamp', type: 'uint256' },
-  { name: 'metadata', type: 'bytes32' },
-  { name: 'builder', type: 'bytes32' },
-];
-
-const TYPED_DATA_SIGN_STRUCTURE: readonly TypedDataField[] = [
-  { name: 'contents', type: 'Order' },
-  { name: 'name', type: 'string' },
-  { name: 'version', type: 'string' },
-  { name: 'chainId', type: 'uint256' },
-  { name: 'verifyingContract', type: 'address' },
-  { name: 'salt', type: 'bytes32' },
-];
-
-const PROTOCOL_NAME = 'Polymarket CTF Exchange';
-const PROTOCOL_VERSION = '2';
-const DEPOSIT_WALLET_DOMAIN_NAME = 'DepositWallet';
-const DEPOSIT_WALLET_DOMAIN_VERSION = '1';
-const BYTES32_ZERO =
-  '0x0000000000000000000000000000000000000000000000000000000000000000';
-const ORDER_TYPE_STRING =
-  'Order(uint256 salt,address maker,address signer,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,uint256 timestamp,bytes32 metadata,bytes32 builder)';
-const ORDER_TYPE_HASH = Hash.keccak256(Bytes.fromString(ORDER_TYPE_STRING), {
-  as: 'Hex',
-});
-const DOMAIN_TYPE_HASH = Hash.keccak256(
-  Bytes.fromString(
-    'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)',
-  ),
-  { as: 'Hex' },
-);
-const PROTOCOL_NAME_HASH = Hash.keccak256(Bytes.fromString(PROTOCOL_NAME), {
-  as: 'Hex',
-});
-const PROTOCOL_VERSION_HASH = Hash.keccak256(
-  Bytes.fromString(PROTOCOL_VERSION),
-  { as: 'Hex' },
-);
-
-type OrderTypedDataMessage = {
-  builder: HexString;
-  maker: EvmAddress;
-  makerAmount: bigint;
-  metadata: HexString;
-  salt: bigint;
-  side: number;
-  signatureType: UnsignedOrder['signatureType'];
-  signer: EvmAddress;
-  takerAmount: bigint;
-  timestamp: bigint;
-  tokenId: bigint;
-};
-
-function createLegacyOrderTypedDataPayload(
-  order: UnsignedOrder,
-): TypedDataPayload {
-  return {
-    domain: {
-      chainId: order.chainId,
-      name: PROTOCOL_NAME,
-      verifyingContract: order.exchangeAddress,
-      version: PROTOCOL_VERSION,
-    },
-    message: createOrderTypedDataMessage(order),
-    primaryType: 'Order',
-    types: {
-      EIP712Domain: EIP712_DOMAIN,
-      Order: ORDER_STRUCTURE,
-    },
-  };
-}
 
 export function createOrderTypedDataPayload(
   order: UnsignedOrder,
 ): TypedDataPayload {
-  const orderPayload = createLegacyOrderTypedDataPayload(order);
-
-  if (order.signatureType !== SignatureType.POLY_1271) {
-    return orderPayload;
-  }
-
-  return {
-    domain: {
-      chainId: order.chainId,
-      name: PROTOCOL_NAME,
-      verifyingContract: order.exchangeAddress,
-      version: PROTOCOL_VERSION,
-    },
-    message: {
-      chainId: order.chainId,
-      contents: orderPayload.message,
-      name: DEPOSIT_WALLET_DOMAIN_NAME,
-      salt: BYTES32_ZERO,
-      verifyingContract: order.signer,
-      version: DEPOSIT_WALLET_DOMAIN_VERSION,
-    },
-    primaryType: 'TypedDataSign',
-    types: {
-      Order: ORDER_STRUCTURE,
-      TypedDataSign: TYPED_DATA_SIGN_STRUCTURE,
-    },
-  };
+  return createExchangeOrderTypedDataPayload({
+    domain: createOrderExchangeDomain(order),
+    order,
+  });
 }
 
 export function createOrderSignature(
   order: UnsignedOrder,
   signature: EvmSignature,
 ): EvmSignature | Erc1271Signature {
-  if (order.signatureType !== SignatureType.POLY_1271) {
-    return signature;
-  }
-
-  const contentsType = Bytes.toHex(Bytes.fromString(ORDER_TYPE_STRING));
-  const contentsTypeLength = ORDER_TYPE_STRING.length
-    .toString(16)
-    .padStart(4, '0');
-
-  return expectErc1271Signature(
-    `0x${signature.slice(2)}${createAppDomainSeparator(order).slice(2)}${createOrderContentsHash(order).slice(2)}${contentsType.slice(2)}${contentsTypeLength}`,
-  );
+  return createExchangeOrderSignature({
+    domain: createOrderExchangeDomain(order),
+    order,
+    signature,
+  });
 }
 
-function createAppDomainSeparator(order: UnsignedOrder): HexString {
-  return expectHexString(
-    Hash.keccak256(
-      AbiParameters.encode(
-        [
-          { type: 'bytes32' },
-          { type: 'bytes32' },
-          { type: 'bytes32' },
-          { type: 'uint256' },
-          { type: 'address' },
-        ],
-        [
-          DOMAIN_TYPE_HASH,
-          PROTOCOL_NAME_HASH,
-          PROTOCOL_VERSION_HASH,
-          BigInt(order.chainId),
-          order.exchangeAddress,
-        ],
-      ),
-      { as: 'Hex' },
-    ),
-  );
-}
-
-function createOrderContentsHash(order: UnsignedOrder): HexString {
-  const message = createOrderTypedDataMessage(order);
-
-  return expectHexString(
-    Hash.keccak256(
-      AbiParameters.encode(
-        [
-          { type: 'bytes32' },
-          { type: 'uint256' },
-          { type: 'address' },
-          { type: 'address' },
-          { type: 'uint256' },
-          { type: 'uint256' },
-          { type: 'uint256' },
-          { type: 'uint8' },
-          { type: 'uint8' },
-          { type: 'uint256' },
-          { type: 'bytes32' },
-          { type: 'bytes32' },
-        ],
-        [
-          ORDER_TYPE_HASH,
-          message.salt,
-          message.maker,
-          message.signer,
-          message.tokenId,
-          message.makerAmount,
-          message.takerAmount,
-          message.side,
-          message.signatureType,
-          message.timestamp,
-          message.metadata,
-          message.builder,
-        ],
-      ),
-      { as: 'Hex' },
-    ),
-  );
-}
-
-function createOrderTypedDataMessage(
-  order: UnsignedOrder,
-): OrderTypedDataMessage {
+function createOrderExchangeDomain(order: UnsignedOrder) {
   return {
-    builder: order.builder,
-    maker: order.maker,
-    makerAmount: BigInt(order.makerAmount),
-    metadata: order.metadata,
-    salt: BigInt(order.salt),
-    side: encodeOrderSide(order.side),
-    signatureType: order.signatureType,
-    signer: order.signer,
-    takerAmount: BigInt(order.takerAmount),
-    timestamp: BigInt(order.timestamp),
-    tokenId: BigInt(order.tokenId),
+    chainId: order.chainId,
+    exchange: order.exchangeAddress,
+    protocolVersion: ExchangeOrderProtocolVersion.V2,
   };
-}
-
-function encodeOrderSide(side: OrderSide): number {
-  return side === OrderSide.BUY ? 0 : 1;
 }

--- a/packages/client/src/actions/orders/types.ts
+++ b/packages/client/src/actions/orders/types.ts
@@ -64,7 +64,10 @@ export type PrepareMarketSellOrderRequest = BasePrepareMarketOrderRequest & {
   side: OrderSide.SELL;
 
   /**
-   * Number of conditional-token shares to sell.
+   * Number of outcome tokens to sell.
+   *
+   * This is the human-readable token amount: `1` means one full share, not one
+   * 6-decimal base unit.
    */
   shares: number | string;
 };
@@ -80,7 +83,12 @@ export type PrepareLimitOrderRequest = {
   /** Price used to create the order */
   price: number | string;
 
-  /** Size in terms of the conditional token */
+  /**
+   * Order size in outcome tokens.
+   *
+   * This is the human-readable token amount: `1` means one full share, not one
+   * 6-decimal base unit.
+   */
   size: number | string;
 
   /** Side of the order */

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -244,11 +244,8 @@ export interface RfqSession extends AsyncIterable<RfqEvent> {
   close(): Promise<void>;
 }
 
-export type OpenRfqSessionError = TransportError | UserInputError;
-export const OpenRfqSessionError = makeErrorGuard(
-  TransportError,
-  UserInputError,
-);
+export type OpenRfqSessionError = TransportError;
+export const OpenRfqSessionError = makeErrorGuard(TransportError);
 
 /**
  * Opens an RFQ event session.

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -35,9 +35,29 @@ export type RfqConfirmationAck = Omit<
   'decision' | 'type'
 >;
 
+export type RfqQuoteSource = 'collateral' | 'inventory';
+
 export type RfqQuoteResponse = {
   /** Quote price, for example `0.45` or `"0.45"`. */
   price: number | string;
+
+  /**
+   * How the maker wants to fund the quote.
+   *
+   * @remarks
+   * For a BUY request (BUY YES):
+   * - `inventory` sells YES tokens from the maker's inventory at `price`.
+   * - `collateral` buys NO tokens with collateral at `1 - price`.
+   *
+   * For a SELL request (SELL YES):
+   * - `inventory` sells NO tokens from the maker's inventory at `1 - price`.
+   * - `collateral` buys YES tokens with collateral at `price`.
+   *
+   * When omitted, the SDK uses `collateral`.
+   *
+   * @defaultValue `'collateral'`
+   */
+  source?: RfqQuoteSource;
 
   /**
    * Optional quote size. When omitted, the quote uses the full RFQ request size.
@@ -122,6 +142,16 @@ export const RfqConfirmationError = makeErrorGuard(
  */
 export interface RfqQuoteRequestEvent extends RfqQuoteRequest {
   /**
+   * Requested RFQ position side.
+   *
+   * @remarks
+   * The current RFQ backend only supports YES-side requests, so this is always
+   * {@link RfqSide.Yes}. Use {@link RfqQuoteRequestEvent.direction} to determine
+   * whether the requester wants to buy or sell that YES-side position.
+   */
+  side: RfqSide.Yes;
+
+  /**
    * Sends a quote response for this RFQ request.
    *
    * @remarks
@@ -138,6 +168,16 @@ export interface RfqQuoteRequestEvent extends RfqQuoteRequest {
  * Server request asking the market maker to confirm or decline a selected quote.
  */
 export interface RfqConfirmationRequestEvent extends RfqConfirmationRequest {
+  /**
+   * Requested RFQ position side.
+   *
+   * @remarks
+   * The current RFQ backend only supports YES-side requests, so this is always
+   * {@link RfqSide.Yes}. Use {@link RfqConfirmationRequestEvent.direction} to
+   * determine whether the requester wants to buy or sell that YES-side position.
+   */
+  side: RfqSide.Yes;
+
   /**
    * Confirms that the maker wants to proceed with the selected quote.
    *

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -48,7 +48,7 @@ export type RfqConfirmationAck = Omit<
 export type RfqQuoteSource = 'collateral' | 'inventory';
 
 export type RfqQuoteResponse = {
-  /** Quote price, for example `0.45` or `"0.45"`. */
+  /** Quote price in pUSD per outcome token, for example `0.45` or `"0.45"`. */
   price: number | string;
 
   /**
@@ -70,7 +70,10 @@ export type RfqQuoteResponse = {
   source?: RfqQuoteSource;
 
   /**
-   * Optional quote size. When omitted, the quote uses the full RFQ request size.
+   * Optional quote size in outcome tokens.
+   *
+   * This is the human-readable token amount: `1` means one full share, not one
+   * 6-decimal base unit. When omitted, the quote uses the full RFQ request size.
    */
   size?: number | string;
 };
@@ -159,7 +162,7 @@ export const RfqConfirmationError = makeErrorGuard(
  * Server request asking the market maker to provide a quote for an RFQ.
  */
 export interface RfqQuoteRequestEvent extends RfqQuoteRequest {
-  /** Requested RFQ size and unit. */
+  /** Requested RFQ size and unit. Share values are human-readable outcome-token amounts. */
   requestedSize: RfqRequestedSize;
 
   /**

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -1,24 +1,39 @@
 import type {
-  RfqConfirmationAck,
+  RfqConfirmationAck as BindingRfqConfirmationAck,
+  RfqQuoteAck as BindingRfqQuoteAck,
   RfqConfirmationRequest,
   RfqDirection,
   RfqExecutionUpdate,
-  RfqQuoteAck,
+  RfqId,
+  RfqQuoteId,
   RfqQuoteRequest,
   RfqSide,
 } from '@polymarket/bindings/rfq';
+import { PolymarketError } from '@polymarket/types';
 import type { BaseSecureClient } from '../clients';
-import { makeErrorGuard, TransportError, UserInputError } from '../errors';
+import {
+  makeErrorGuard,
+  SigningError,
+  TimeoutError,
+  TransportError,
+  UserInputError,
+} from '../errors';
 
 export type {
-  RfqConfirmationAck,
   RfqConfirmationRequest,
   RfqDirection,
   RfqExecutionUpdate,
-  RfqQuoteAck,
+  RfqId,
+  RfqQuoteId,
   RfqQuoteRequest,
   RfqSide,
 };
+
+export type RfqQuoteAck = Omit<BindingRfqQuoteAck, 'type'>;
+export type RfqConfirmationAck = Omit<
+  BindingRfqConfirmationAck,
+  'decision' | 'type'
+>;
 
 export type RfqQuoteResponse = {
   /** Quote price, for example `0.45` or `"0.45"`. */
@@ -30,12 +45,91 @@ export type RfqQuoteResponse = {
   size?: number | string;
 };
 
+export type RfqQuoteRejectedErrorOptions = {
+  /** RFQ identifier for the rejected quote. */
+  rfqId: RfqId;
+};
+
+/**
+ * Error thrown when the RFQ server rejects a quote response.
+ */
+export class RfqQuoteRejectedError extends PolymarketError {
+  override name = 'RfqQuoteRejectedError' as const;
+
+  readonly rfqId: RfqId;
+
+  constructor(
+    message: string,
+    options: ErrorOptions & RfqQuoteRejectedErrorOptions,
+  ) {
+    super(message, options);
+    this.rfqId = options.rfqId;
+  }
+}
+
+export type RfqQuoteError =
+  | RfqQuoteRejectedError
+  | SigningError
+  | TimeoutError
+  | TransportError
+  | UserInputError;
+export const RfqQuoteError = makeErrorGuard(
+  RfqQuoteRejectedError,
+  SigningError,
+  TimeoutError,
+  TransportError,
+  UserInputError,
+);
+
+export type RfqConfirmationRejectedErrorOptions = {
+  /** RFQ identifier for the rejected confirmation decision. */
+  rfqId: RfqId;
+  /** Quote identifier for the rejected confirmation decision. */
+  quoteId: RfqQuoteId;
+};
+
+/**
+ * Error thrown when the RFQ server rejects a confirmation decision.
+ */
+export class RfqConfirmationRejectedError extends PolymarketError {
+  override name = 'RfqConfirmationRejectedError' as const;
+
+  readonly rfqId: RfqId;
+  readonly quoteId: RfqQuoteId;
+
+  constructor(
+    message: string,
+    options: ErrorOptions & RfqConfirmationRejectedErrorOptions,
+  ) {
+    super(message, options);
+    this.rfqId = options.rfqId;
+    this.quoteId = options.quoteId;
+  }
+}
+
+export type RfqConfirmationError =
+  | RfqConfirmationRejectedError
+  | TimeoutError
+  | TransportError;
+export const RfqConfirmationError = makeErrorGuard(
+  RfqConfirmationRejectedError,
+  TimeoutError,
+  TransportError,
+);
+
 /**
  * Server request asking the market maker to provide a quote for an RFQ.
  */
 export interface RfqQuoteRequestEvent extends RfqQuoteRequest {
   /**
    * Sends a quote response for this RFQ request.
+   *
+   * @remarks
+   * If this resolves, the server accepted the quote and assigned `quoteId`.
+   *
+   * @throws {@link RfqQuoteError}
+   * Thrown when validation fails, signing fails, the websocket fails, the quote
+   * acknowledgement times out, or the server rejects the quote.
    */
   quote(response: RfqQuoteResponse): Promise<RfqQuoteAck>;
 }
@@ -46,11 +140,25 @@ export interface RfqQuoteRequestEvent extends RfqQuoteRequest {
 export interface RfqConfirmationRequestEvent extends RfqConfirmationRequest {
   /**
    * Confirms that the maker wants to proceed with the selected quote.
+   *
+   * @remarks
+   * If this resolves, the server accepted the confirmation decision.
+   *
+   * @throws {@link RfqConfirmationError}
+   * Thrown when the websocket fails, the acknowledgement times out, or the
+   * server rejects the confirmation decision.
    */
   confirm(): Promise<RfqConfirmationAck>;
 
   /**
    * Declines the selected quote during the confirmation window.
+   *
+   * @remarks
+   * If this resolves, the server accepted the decline decision.
+   *
+   * @throws {@link RfqConfirmationError}
+   * Thrown when the websocket fails, the acknowledgement times out, or the
+   * server rejects the decline decision.
    */
   decline(): Promise<RfqConfirmationAck>;
 }

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -3,6 +3,7 @@ import type {
   RfqQuoteAck as BindingRfqQuoteAck,
   RfqConfirmationRequest,
   RfqDirection,
+  RfqErrorCode,
   RfqExecutionUpdate,
   RfqId,
   RfqQuoteId,
@@ -22,6 +23,7 @@ import {
 export type {
   RfqConfirmationRequest,
   RfqDirection,
+  RfqErrorCode,
   RfqExecutionUpdate,
   RfqId,
   RfqQuoteId,
@@ -66,6 +68,8 @@ export type RfqQuoteResponse = {
 };
 
 export type RfqQuoteRejectedErrorOptions = {
+  /** Backend RFQ error code for the rejected quote. */
+  code?: RfqErrorCode;
   /** RFQ identifier for the rejected quote. */
   rfqId: RfqId;
 };
@@ -76,6 +80,7 @@ export type RfqQuoteRejectedErrorOptions = {
 export class RfqQuoteRejectedError extends PolymarketError {
   override name = 'RfqQuoteRejectedError' as const;
 
+  readonly code: RfqErrorCode | undefined;
   readonly rfqId: RfqId;
 
   constructor(
@@ -83,6 +88,7 @@ export class RfqQuoteRejectedError extends PolymarketError {
     options: ErrorOptions & RfqQuoteRejectedErrorOptions,
   ) {
     super(message, options);
+    this.code = options.code;
     this.rfqId = options.rfqId;
   }
 }
@@ -102,6 +108,8 @@ export const RfqQuoteError = makeErrorGuard(
 );
 
 export type RfqConfirmationRejectedErrorOptions = {
+  /** Backend RFQ error code for the rejected confirmation decision. */
+  code?: RfqErrorCode;
   /** RFQ identifier for the rejected confirmation decision. */
   rfqId: RfqId;
   /** Quote identifier for the rejected confirmation decision. */
@@ -114,6 +122,7 @@ export type RfqConfirmationRejectedErrorOptions = {
 export class RfqConfirmationRejectedError extends PolymarketError {
   override name = 'RfqConfirmationRejectedError' as const;
 
+  readonly code: RfqErrorCode | undefined;
   readonly rfqId: RfqId;
   readonly quoteId: RfqQuoteId;
 
@@ -122,6 +131,7 @@ export class RfqConfirmationRejectedError extends PolymarketError {
     options: ErrorOptions & RfqConfirmationRejectedErrorOptions,
   ) {
     super(message, options);
+    this.code = options.code;
     this.rfqId = options.rfqId;
     this.quoteId = options.quoteId;
   }

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -2,12 +2,13 @@ import type {
   RfqConfirmationAck as BindingRfqConfirmationAck,
   RfqQuoteAck as BindingRfqQuoteAck,
   RfqConfirmationRequest,
-  RfqDirection,
   RfqErrorCode,
   RfqExecutionUpdate,
   RfqId,
   RfqQuoteId,
   RfqQuoteRequest,
+  RfqRequestedSize,
+  RfqRequestorPublicId,
   RfqSide,
 } from '@polymarket/bindings/rfq';
 import { PolymarketError } from '@polymarket/types';
@@ -20,15 +21,22 @@ import {
   UserInputError,
 } from '../errors';
 
-export type {
-  RfqConfirmationRequest,
+export {
+  RfqConfirmationDecision,
   RfqDirection,
   RfqErrorCode,
+  RfqExecutionStatus,
+  RfqRequestedSizeUnit,
+  RfqSide,
+} from '@polymarket/bindings/rfq';
+export type {
+  RfqConfirmationRequest,
   RfqExecutionUpdate,
   RfqId,
   RfqQuoteId,
   RfqQuoteRequest,
-  RfqSide,
+  RfqRequestedSize,
+  RfqRequestorPublicId,
 };
 
 export type RfqQuoteAck = Omit<BindingRfqQuoteAck, 'type'>;
@@ -68,7 +76,7 @@ export type RfqQuoteResponse = {
 };
 
 export type RfqQuoteRejectedErrorOptions = {
-  /** Backend RFQ error code for the rejected quote. */
+  /** RFQ error code for the rejected quote. */
   code?: RfqErrorCode;
   /** RFQ identifier for the rejected quote. */
   rfqId: RfqId;
@@ -108,7 +116,7 @@ export const RfqQuoteError = makeErrorGuard(
 );
 
 export type RfqConfirmationRejectedErrorOptions = {
-  /** Backend RFQ error code for the rejected confirmation decision. */
+  /** RFQ error code for the rejected confirmation decision. */
   code?: RfqErrorCode;
   /** RFQ identifier for the rejected confirmation decision. */
   rfqId: RfqId;
@@ -151,11 +159,14 @@ export const RfqConfirmationError = makeErrorGuard(
  * Server request asking the market maker to provide a quote for an RFQ.
  */
 export interface RfqQuoteRequestEvent extends RfqQuoteRequest {
+  /** Requested RFQ size and unit. */
+  requestedSize: RfqRequestedSize;
+
   /**
    * Requested RFQ position side.
    *
    * @remarks
-   * The current RFQ backend only supports YES-side requests, so this is always
+   * The current RFQ system only supports YES-side requests, so this is always
    * {@link RfqSide.Yes}. Use {@link RfqQuoteRequestEvent.direction} to determine
    * whether the requester wants to buy or sell that YES-side position.
    */
@@ -182,7 +193,7 @@ export interface RfqConfirmationRequestEvent extends RfqConfirmationRequest {
    * Requested RFQ position side.
    *
    * @remarks
-   * The current RFQ backend only supports YES-side requests, so this is always
+   * The current RFQ system only supports YES-side requests, so this is always
    * {@link RfqSide.Yes}. Use {@link RfqConfirmationRequestEvent.direction} to
    * determine whether the requester wants to buy or sell that YES-side position.
    */

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -1,6 +1,7 @@
 import type {
   RfqConfirmationAck as BindingRfqConfirmationAck,
   RfqQuoteAck as BindingRfqQuoteAck,
+  RfqQuoteCancelAck as BindingRfqQuoteCancelAck,
   RfqConfirmationRequest,
   RfqErrorCode,
   RfqExecutionUpdate,
@@ -39,7 +40,17 @@ export type {
   RfqRequestorPublicId,
 };
 
-export type RfqQuoteAck = Omit<BindingRfqQuoteAck, 'type'>;
+/**
+ * Plain-data reference identifying a submitted RFQ quote.
+ *
+ * @remarks
+ * This identifies the quote; it does not imply execution or guarantee that a
+ * later cancellation request can withdraw it.
+ */
+export type RfqQuoteReference = Omit<BindingRfqQuoteAck, 'type'>;
+
+/** Acknowledgement that a quote cancellation request was processed. */
+export type RfqCancelQuoteAck = Omit<BindingRfqQuoteCancelAck, 'type'>;
 export type RfqConfirmationAck = Omit<
   BindingRfqConfirmationAck,
   'decision' | 'type'
@@ -118,6 +129,46 @@ export const RfqQuoteError = makeErrorGuard(
   UserInputError,
 );
 
+export type RfqCancelQuoteRejectedErrorOptions = {
+  /** RFQ error code for the rejected cancellation request. */
+  code?: RfqErrorCode;
+  /** RFQ identifier for the cancellation request. */
+  rfqId: RfqId;
+  /** Quote identifier for the cancellation request. */
+  quoteId: RfqQuoteId;
+};
+
+/**
+ * Error thrown when the RFQ server rejects a quote cancellation request.
+ */
+export class RfqCancelQuoteRejectedError extends PolymarketError {
+  override name = 'RfqCancelQuoteRejectedError' as const;
+
+  readonly code: RfqErrorCode | undefined;
+  readonly rfqId: RfqId;
+  readonly quoteId: RfqQuoteId;
+
+  constructor(
+    message: string,
+    options: ErrorOptions & RfqCancelQuoteRejectedErrorOptions,
+  ) {
+    super(message, options);
+    this.code = options.code;
+    this.rfqId = options.rfqId;
+    this.quoteId = options.quoteId;
+  }
+}
+
+export type RfqCancelQuoteError =
+  | RfqCancelQuoteRejectedError
+  | TimeoutError
+  | TransportError;
+export const RfqCancelQuoteError = makeErrorGuard(
+  RfqCancelQuoteRejectedError,
+  TimeoutError,
+  TransportError,
+);
+
 export type RfqConfirmationRejectedErrorOptions = {
   /** RFQ error code for the rejected confirmation decision. */
   code?: RfqErrorCode;
@@ -185,7 +236,7 @@ export interface RfqQuoteRequestEvent extends RfqQuoteRequest {
    * Thrown when validation fails, signing fails, the websocket fails, the quote
    * acknowledgement times out, or the server rejects the quote.
    */
-  quote(response: RfqQuoteResponse): Promise<RfqQuoteAck>;
+  quote(response: RfqQuoteResponse): Promise<RfqQuoteReference>;
 }
 
 /**
@@ -241,6 +292,19 @@ export type RfqEvent =
   | RfqExecutionUpdateEvent;
 
 export interface RfqSession extends AsyncIterable<RfqEvent> {
+  /**
+   * Requests cancellation of a submitted RFQ quote.
+   *
+   * @remarks
+   * The returned ack means the backend processed the cancellation request; it
+   * does not guarantee the quote was withdrawn from an already-selected RFQ.
+   *
+   * @throws {@link RfqCancelQuoteError}
+   * Thrown when the websocket fails, the acknowledgement times out, or the
+   * server rejects the cancellation request.
+   */
+  cancelQuote(reference: RfqQuoteReference): Promise<RfqCancelQuoteAck>;
+
   /**
    * Closes the RFQ quoter stream.
    */

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -1,0 +1,99 @@
+import type {
+  RfqConfirmationAck,
+  RfqConfirmationRequest,
+  RfqDirection,
+  RfqExecutionUpdate,
+  RfqQuoteAck,
+  RfqQuoteRequest,
+  RfqSide,
+} from '@polymarket/bindings/rfq';
+import type { BaseSecureClient } from '../clients';
+import { makeErrorGuard, TransportError, UserInputError } from '../errors';
+
+export type {
+  RfqConfirmationAck,
+  RfqConfirmationRequest,
+  RfqDirection,
+  RfqExecutionUpdate,
+  RfqQuoteAck,
+  RfqQuoteRequest,
+  RfqSide,
+};
+
+export type RfqQuoteResponse = {
+  /** Quote price, for example `0.45` or `"0.45"`. */
+  price: number | string;
+
+  /**
+   * Optional quote size. When omitted, the quote uses the full RFQ request size.
+   */
+  size?: number | string;
+};
+
+/**
+ * Server request asking the market maker to provide a quote for an RFQ.
+ */
+export interface RfqQuoteRequestEvent extends RfqQuoteRequest {
+  /**
+   * Sends a quote response for this RFQ request.
+   */
+  quote(response: RfqQuoteResponse): Promise<RfqQuoteAck>;
+}
+
+/**
+ * Server request asking the market maker to confirm or decline a selected quote.
+ */
+export interface RfqConfirmationRequestEvent extends RfqConfirmationRequest {
+  /**
+   * Confirms that the maker wants to proceed with the selected quote.
+   */
+  confirm(): Promise<RfqConfirmationAck>;
+
+  /**
+   * Declines the selected quote during the confirmation window.
+   */
+  decline(): Promise<RfqConfirmationAck>;
+}
+
+/**
+ * Execution status update for an RFQ after acceptance and handoff.
+ */
+export interface RfqExecutionUpdateEvent extends RfqExecutionUpdate {}
+
+/**
+ * Event emitted by an RFQ session.
+ */
+export type RfqEvent =
+  | RfqQuoteRequestEvent
+  | RfqConfirmationRequestEvent
+  | RfqExecutionUpdateEvent;
+
+export interface RfqSession extends AsyncIterable<RfqEvent> {
+  /**
+   * Closes the RFQ quoter stream.
+   */
+  close(): Promise<void>;
+}
+
+export type OpenRfqSessionError = TransportError | UserInputError;
+export const OpenRfqSessionError = makeErrorGuard(
+  TransportError,
+  UserInputError,
+);
+
+/**
+ * Opens an RFQ event session.
+ *
+ * @remarks
+ * The returned async iterator is a stream, not a worker queue. Await inside the
+ * loop to process RFQ events sequentially, or dispatch handlers without awaiting
+ * them to fan out handling when quote windows are tight.
+ *
+ * @throws {@link OpenRfqSessionError}
+ * Thrown on failure.
+ */
+export async function openRfqSession(
+  client: BaseSecureClient,
+): Promise<RfqSession> {
+  return client.webSockets.rfqQuoter.connect();
+}

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -374,7 +374,7 @@ class BasePublicClient<
    */
   beginAuthentication(
     request: BeginAuthenticationRequest,
-    signer?: Signer,
+    signer: Signer,
   ): Promise<
     AuthenticationWorkflow<SecureClient<TPublicActions, TSecureActions>>
   > {
@@ -440,7 +440,7 @@ class BasePublicClient<
   #createSecureClient(
     credentials: ApiKeyCreds,
     account: AccountIdentity,
-    signer?: Signer,
+    signer: Signer,
   ): SecureClient<TPublicActions, TSecureActions> {
     const client = new BaseSecureClient({
       account: account,
@@ -551,11 +551,6 @@ class BaseSecureClient<
 
   /** @internal */
   get signer(): Signer {
-    invariant(
-      this.context.signer !== undefined,
-      'Secure client does not have a signer. Create secure clients with createSecureClient to use wallet-interactive methods.',
-    );
-
     return this.context.signer;
   }
 
@@ -719,7 +714,7 @@ type SecureContext = PublicContext & {
   /** @internal */
   credentials: ApiKeyCreds;
   /** @internal */
-  signer?: Signer;
+  signer: Signer;
   /** @internal */
   secureClob: ServiceClient;
   /** @internal */
@@ -729,7 +724,7 @@ type SecureContext = PublicContext & {
 type SecureClientConfig = PublicClientConfig & {
   account: AccountIdentity;
   credentials: ApiKeyCreds;
-  signer?: Signer;
+  signer: Signer;
 };
 
 export type PublicClient<

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -511,15 +511,15 @@ class BaseSecureClient<
           url: config.environment.clobMarketWs,
         }),
         clobUser: new ClobUserWebSocketManager({
-          resolveCredentials: () => this.credentials,
+          credentials: config.credentials,
           url: config.environment.clobUserWs,
         }),
         rfqQuoter: new RfqQuoterWebSocketManager({
+          account: config.account,
           chainId: config.environment.chainId,
-          exchangeV3: config.environment.exchangeV3,
-          resolveAccount: () => this.account,
-          resolveCredentials: () => this.credentials,
-          resolveSigner: () => this.signer,
+          credentials: config.credentials,
+          exchange: config.environment.exchangeV3,
+          signer: config.signer,
           url: config.environment.rfqQuoterWs,
         }),
         sports: new SportsWebSocketManager({

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -55,6 +55,7 @@ import {
   ClobMarketWebSocketManager,
   ClobUserWebSocketManager,
   type PublicWebSocketManagers,
+  RfqQuoterWebSocketManager,
   RtdsWebSocketManager,
   type SecureWebSocketManagers,
   SportsWebSocketManager,
@@ -513,6 +514,14 @@ class BaseSecureClient<
           resolveCredentials: () => this.credentials,
           url: config.environment.clobUserWs,
         }),
+        rfqQuoter: new RfqQuoterWebSocketManager({
+          chainId: config.environment.chainId,
+          exchangeV3: config.environment.exchangeV3,
+          resolveAccount: () => this.account,
+          resolveCredentials: () => this.credentials,
+          resolveSigner: () => this.signer,
+          url: config.environment.rfqQuoterWs,
+        }),
         sports: new SportsWebSocketManager({
           url: config.environment.sportsWs,
         }),
@@ -590,6 +599,7 @@ class BaseSecureClient<
       this.webSockets.rtds.close(),
       this.webSockets.sports.close(),
       this.webSockets.clobUser.close(),
+      this.webSockets.rfqQuoter.close(),
     ]).then(() => undefined);
   }
 

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -519,6 +519,7 @@ class BaseSecureClient<
           chainId: config.environment.chainId,
           credentials: config.credentials,
           exchange: config.environment.exchangeV3,
+          headers: config.environment.rfqQuoterWsHeaders,
           signer: config.signer,
           url: config.environment.rfqQuoterWs,
         }),

--- a/packages/client/src/decorators/index.ts
+++ b/packages/client/src/decorators/index.ts
@@ -17,6 +17,7 @@ import {
   rewardsActions,
   type SecureRewardsActions,
 } from './rewards';
+import { rfqActions, type SecureRfqActions } from './rfq';
 import {
   type PublicSubscriptionsActions,
   type SecureSubscriptionsActions,
@@ -40,6 +41,7 @@ export type SecureActions = Prettify<
     AnalyticsActions &
     SecureAccountActions &
     SecureRewardsActions &
+    SecureRfqActions &
     SecureSubscriptionsActions &
     SecureWalletActions &
     SecureTradingActions
@@ -55,6 +57,7 @@ export function allActions(client: BaseClient): PublicActions | SecureActions {
       ...dataActions(client),
       ...discoveryActions(client),
       ...rewardsActions(client),
+      ...rfqActions(client),
       ...subscriptionsActions(client),
       ...tradingActions(client),
       ...walletActions(client),
@@ -76,6 +79,7 @@ export * from './analytics';
 export * from './data';
 export * from './discovery';
 export * from './rewards';
+export * from './rfq';
 export * from './subscriptions';
 export * from './trading';
 export * from './wallet';

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -10,6 +10,103 @@ export type SecureRfqActions = {
    * loop to process RFQ events sequentially, or dispatch handlers without awaiting
    * them to fan out handling when quote windows are tight.
    *
+   * @example
+   * Quote the full requested size:
+   * ```ts
+   * const session = await client.openRfqSession();
+   *
+   * for await (const event of session) {
+   *   switch (event.type) {
+   *     case 'quote_request':
+   *       await event.quote({ price: 0.45 });
+   *       break;
+   *
+   *     case 'execution_update':
+   *       // event.rfqId: RfqId
+   *       // event.status: RfqExecutionStatus
+   *       // event.txHash: TxHash | undefined
+   *       break;
+   *   }
+   * }
+   * ```
+   *
+   * @example
+   * Quote a specific size:
+   * ```ts
+   * const session = await client.openRfqSession();
+   *
+   * for await (const event of session) {
+   *   switch (event.type) {
+   *     case 'quote_request':
+   *       await event.quote({ price: 0.45, size: 0.5 });
+   *       break;
+   *
+   *     // …
+   *   }
+   * }
+   * ```
+   *
+   * @example
+   * Handle Last Look confirmation requests:
+   * ```ts
+   * const session = await client.openRfqSession();
+   *
+   * for await (const event of session) {
+   *   switch (event.type) {
+   *     case 'quote_request':
+   *       await event.quote({ price: 0.45 });
+   *       break;
+   *
+   *     case 'confirmation_request':
+   *       await event.confirm();
+   *       break;
+   *
+   *     // …
+   *   }
+   * }
+   * ```
+   * Any maker can quote permissionlessly. Last Look confirmation requests are
+   * only sent to makers with Last Look enabled.
+   *
+   * @example
+   * Choose collateral or inventory per request:
+   * ```ts
+   * const session = await client.openRfqSession();
+   *
+   * for await (const event of session) {
+   *   switch (event.type) {
+   *     case 'quote_request': {
+   *       switch (event.direction) {
+   *         case RfqDirection.Buy:
+   *           await event.quote({
+   *             price: 0.45,
+   *             source: chooseSource(event.yesPositionId, event.size),
+   *           });
+   *           break;
+   *
+   *         case RfqDirection.Sell:
+   *           await event.quote({
+   *             price: 0.45,
+   *             source: chooseSource(event.noPositionId, event.size),
+   *           });
+   *           break;
+   *       }
+   *       break;
+   *     }
+   *
+   *     case 'confirmation_request':
+   *       await event.confirm();
+   *       break;
+   *
+   *     // …
+   *   }
+   * }
+   *
+   * function chooseSource(positionId: PositionId, size: DecimalString): RfqQuoteSource {
+   *   return hasInventory(positionId, size) ? 'inventory' : 'collateral';
+   * }
+   * ```
+   *
    * @throws {@link OpenRfqSessionError}
    * Thrown on failure.
    */

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -1,0 +1,25 @@
+import { openRfqSession, type RfqSession } from '../actions';
+import type { BaseSecureClient } from '../clients';
+
+export type SecureRfqActions = {
+  /**
+   * Opens an RFQ event session.
+   *
+   * @remarks
+   * The returned async iterator is a stream, not a worker queue. Await inside the
+   * loop to process RFQ events sequentially, or dispatch handlers without awaiting
+   * them to fan out handling when quote windows are tight.
+   *
+   * @throws {@link OpenRfqSessionError}
+   * Thrown on failure.
+   */
+  openRfqSession(): Promise<RfqSession>;
+};
+
+export function rfqActions(client: BaseSecureClient): SecureRfqActions {
+  return {
+    openRfqSession() {
+      return openRfqSession(client);
+    },
+  };
+}

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -2,14 +2,16 @@ import { openRfqSession, type RfqSession } from '../actions';
 import type { BaseSecureClient } from '../clients';
 
 export type {
+  RfqCancelQuoteAck,
+  RfqCancelQuoteRejectedErrorOptions,
   RfqConfirmationAck,
   RfqConfirmationRequest,
   RfqConfirmationRequestEvent,
   RfqEvent,
   RfqExecutionUpdate,
   RfqId,
-  RfqQuoteAck,
   RfqQuoteId,
+  RfqQuoteReference,
   RfqQuoteRejectedErrorOptions,
   RfqQuoteRequest,
   RfqQuoteRequestEvent,
@@ -21,6 +23,8 @@ export type {
 } from '../actions/rfq';
 export {
   OpenRfqSessionError,
+  RfqCancelQuoteError,
+  RfqCancelQuoteRejectedError,
   RfqConfirmationDecision,
   RfqConfirmationError,
   RfqConfirmationRejectedError,
@@ -78,6 +82,29 @@ export type SecureRfqActions = {
    *   }
    * }
    * ```
+   *
+   * @example
+   * Cancel a submitted quote using the live session:
+   * ```ts
+   * const session = await client.openRfqSession();
+   *
+   * for await (const event of session) {
+   *   switch (event.type) {
+   *     case 'quote_request': {
+   *       const ref = await event.quote({ price: 0.45 });
+   *
+   *       if (shouldCancel(ref)) {
+   *         await session.cancelQuote(ref);
+   *       }
+   *       break;
+   *     }
+   *
+   *     // …
+   *   }
+   * }
+   * ```
+   * The cancellation ack means the backend processed the request; it does not
+   * guarantee the quote was withdrawn from an already-selected RFQ.
    *
    * @example
    * Handle Last Look confirmation requests:

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -1,6 +1,37 @@
 import { openRfqSession, type RfqSession } from '../actions';
 import type { BaseSecureClient } from '../clients';
 
+export type {
+  RfqConfirmationAck,
+  RfqConfirmationRequest,
+  RfqConfirmationRequestEvent,
+  RfqEvent,
+  RfqExecutionUpdate,
+  RfqId,
+  RfqQuoteAck,
+  RfqQuoteId,
+  RfqQuoteRejectedErrorOptions,
+  RfqQuoteRequest,
+  RfqQuoteRequestEvent,
+  RfqQuoteResponse,
+  RfqQuoteSource,
+  RfqRequestedSize,
+  RfqRequestorPublicId,
+  RfqSession,
+} from '../actions/rfq';
+export {
+  RfqConfirmationDecision,
+  RfqConfirmationError,
+  RfqConfirmationRejectedError,
+  RfqDirection,
+  RfqErrorCode,
+  RfqExecutionStatus,
+  RfqQuoteError,
+  RfqQuoteRejectedError,
+  RfqRequestedSizeUnit,
+  RfqSide,
+} from '../actions/rfq';
+
 export type SecureRfqActions = {
   /**
    * Opens an RFQ event session.
@@ -80,14 +111,14 @@ export type SecureRfqActions = {
    *         case RfqDirection.Buy:
    *           await event.quote({
    *             price: 0.45,
-   *             source: chooseSource(event.yesPositionId, event.size),
+   *             source: chooseSource(event.yesPositionId, event.requestedSize),
    *           });
    *           break;
    *
    *         case RfqDirection.Sell:
    *           await event.quote({
    *             price: 0.45,
-   *             source: chooseSource(event.noPositionId, event.size),
+   *             source: chooseSource(event.noPositionId, event.requestedSize),
    *           });
    *           break;
    *       }

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -20,6 +20,7 @@ export type {
   RfqSession,
 } from '../actions/rfq';
 export {
+  OpenRfqSessionError,
   RfqConfirmationDecision,
   RfqConfirmationError,
   RfqConfirmationRejectedError,
@@ -62,7 +63,8 @@ export type SecureRfqActions = {
    * ```
    *
    * @example
-   * Quote a specific size:
+   * Quote a specific outcome-token size. `0.5` means half of one share, not
+   * half of one 6-decimal base unit:
    * ```ts
    * const session = await client.openRfqSession();
    *
@@ -133,8 +135,8 @@ export type SecureRfqActions = {
    *   }
    * }
    *
-   * function chooseSource(positionId: PositionId, size: DecimalString): RfqQuoteSource {
-   *   return hasInventory(positionId, size) ? 'inventory' : 'collateral';
+   * function chooseSource(positionId: PositionId, requestedSize: RfqRequestedSize): RfqQuoteSource {
+   *   return hasInventory(positionId, requestedSize) ? 'inventory' : 'collateral';
    * }
    * ```
    *

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -35,6 +35,10 @@ export type EnvironmentConfig = {
   /** @internal */
   exchangeV3: EvmAddress;
   /** @internal */
+  protocolV2Router: EvmAddress;
+  /** @internal */
+  positionManager: EvmAddress;
+  /** @internal */
   autoRedeemOperator: EvmAddress;
   /** @internal */
   safeMultisend: EvmAddress;
@@ -112,9 +116,15 @@ export const production: EnvironmentConfig = {
   negRiskExchange: expectEvmAddress(
     '0xe2222d279d744050d28e00520010520000310F59',
   ),
-  exchangeV3: expectEvmAddress('0x9fE6e61422AdB6F610d8597F9684b16912D50C3D'),
+  exchangeV3: expectEvmAddress('0xe3333700cA9d93003F00f0F71f8515005F6c00Aa'),
+  protocolV2Router: expectEvmAddress(
+    '0x12121212006e4CD160D18e3f00711DA5c3372600',
+  ),
+  positionManager: expectEvmAddress(
+    '0x006F54F7f9A22e0000CC2AB60031000000ae9fEF',
+  ),
   autoRedeemOperator: expectEvmAddress(
-    '0xF3cFb6a6eBFeB51876289Eb235719EB1C65252B0',
+    '0xa1200000d0002264C9a1698e001292D00E1b00af',
   ),
   safeMultisend: expectEvmAddress('0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761'),
   relayHub: expectEvmAddress('0xD216153c06E857cD7f72665E0aF1d7D82172F494'),

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -63,6 +63,8 @@ export type EnvironmentConfig = {
   /** @internal */
   rfqQuoterWs: string;
   /** @internal */
+  rfqQuoterWsHeaders?: Record<string, string>;
+  /** @internal */
   relayerMaxPolls: number;
   /** @internal */
   relayerPollFrequencyMs: number;

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -137,7 +137,8 @@ export const production: EnvironmentConfig = {
   gamma: 'https://gamma-api.polymarket.com',
   data: 'https://data-api.polymarket.com',
   rtdsWs: 'wss://ws-live-data.polymarket.com',
-  rfqQuoterWs: 'wss://combos-rfq-gateway-quoter.preprod.pmd.euw2.polymarket.sh/ws',
+  rfqQuoterWs:
+    'wss://combos-rfq-gateway-quoter.preprod.pmd.euw2.polymarket.sh/ws',
   sportsWs: 'wss://sports-api.polymarket.com/ws',
   relayerMaxPolls: 100,
   relayerPollFrequencyMs: 2000,

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -33,6 +33,8 @@ export type EnvironmentConfig = {
   /** @internal */
   negRiskExchange: EvmAddress;
   /** @internal */
+  exchangeV3: EvmAddress;
+  /** @internal */
   autoRedeemOperator: EvmAddress;
   /** @internal */
   safeMultisend: EvmAddress;
@@ -54,6 +56,8 @@ export type EnvironmentConfig = {
   rtdsWs: string;
   /** @internal */
   sportsWs: string;
+  /** @internal */
+  rfqQuoterWs: string;
   /** @internal */
   relayerMaxPolls: number;
   /** @internal */
@@ -108,6 +112,7 @@ export const production: EnvironmentConfig = {
   negRiskExchange: expectEvmAddress(
     '0xe2222d279d744050d28e00520010520000310F59',
   ),
+  exchangeV3: expectEvmAddress('0x9fE6e61422AdB6F610d8597F9684b16912D50C3D'),
   autoRedeemOperator: expectEvmAddress(
     '0xF3cFb6a6eBFeB51876289Eb235719EB1C65252B0',
   ),
@@ -120,6 +125,7 @@ export const production: EnvironmentConfig = {
   gamma: 'https://gamma-api.polymarket.com',
   data: 'https://data-api.polymarket.com',
   rtdsWs: 'wss://ws-live-data.polymarket.com',
+  rfqQuoterWs: 'wss://rfq-quoter.example.invalid/ws',
   sportsWs: 'wss://sports-api.polymarket.com/ws',
   relayerMaxPolls: 100,
   relayerPollFrequencyMs: 2000,

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -137,7 +137,7 @@ export const production: EnvironmentConfig = {
   gamma: 'https://gamma-api.polymarket.com',
   data: 'https://data-api.polymarket.com',
   rtdsWs: 'wss://ws-live-data.polymarket.com',
-  rfqQuoterWs: 'wss://rfq-quoter.example.invalid/ws',
+  rfqQuoterWs: 'wss://combos-rfq-gateway-quoter.preprod.pmd.euw2.polymarket.sh/ws',
   sportsWs: 'wss://sports-api.polymarket.com/ws',
   relayerMaxPolls: 100,
   relayerPollFrequencyMs: 2000,

--- a/packages/client/src/exchange.ts
+++ b/packages/client/src/exchange.ts
@@ -1,0 +1,287 @@
+import { OrderSide, type PositionId, type TokenId } from '@polymarket/bindings';
+import { SignatureType } from '@polymarket/bindings/clob';
+import {
+  type Erc1271Signature,
+  type EvmAddress,
+  type EvmSignature,
+  expectErc1271Signature,
+  expectHexString,
+  type HexString,
+} from '@polymarket/types';
+import { AbiParameters, Bytes, Hash } from 'ox';
+import type { TypedDataField, TypedDataPayload } from './types';
+
+const PROTOCOL_NAME = 'Polymarket CTF Exchange';
+const DEPOSIT_WALLET_DOMAIN_NAME = 'DepositWallet';
+const DEPOSIT_WALLET_DOMAIN_VERSION = '1';
+const BYTES32_ZERO =
+  '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies HexString;
+const ORDER_TYPE_STRING =
+  'Order(uint256 salt,address maker,address signer,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,uint256 timestamp,bytes32 metadata,bytes32 builder)';
+const ORDER_TYPE_HASH = Hash.keccak256(Bytes.fromString(ORDER_TYPE_STRING), {
+  as: 'Hex',
+});
+const DOMAIN_TYPE_HASH = Hash.keccak256(
+  Bytes.fromString(
+    'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)',
+  ),
+  { as: 'Hex' },
+);
+const PROTOCOL_NAME_HASH = Hash.keccak256(Bytes.fromString(PROTOCOL_NAME), {
+  as: 'Hex',
+});
+const EIP712_DOMAIN: readonly TypedDataField[] = [
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+];
+const ORDER_STRUCTURE: readonly TypedDataField[] = [
+  { name: 'salt', type: 'uint256' },
+  { name: 'maker', type: 'address' },
+  { name: 'signer', type: 'address' },
+  { name: 'tokenId', type: 'uint256' },
+  { name: 'makerAmount', type: 'uint256' },
+  { name: 'takerAmount', type: 'uint256' },
+  { name: 'side', type: 'uint8' },
+  { name: 'signatureType', type: 'uint8' },
+  { name: 'timestamp', type: 'uint256' },
+  { name: 'metadata', type: 'bytes32' },
+  { name: 'builder', type: 'bytes32' },
+];
+const TYPED_DATA_SIGN_STRUCTURE: readonly TypedDataField[] = [
+  { name: 'contents', type: 'Order' },
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+  { name: 'salt', type: 'bytes32' },
+];
+
+/** @internal */
+export enum ExchangeOrderProtocolVersion {
+  V2 = '2',
+  V3 = '3',
+}
+
+/** @internal */
+export type ExchangeOrderDomain = {
+  chainId: number;
+  exchange: EvmAddress;
+  protocolVersion: ExchangeOrderProtocolVersion;
+};
+
+/** @internal */
+export type ExchangeOrderInput = {
+  builder?: HexString;
+  maker: EvmAddress;
+  makerAmount: string;
+  metadata?: HexString;
+  salt: string;
+  side: OrderSide | 0 | 1;
+  signatureType: SignatureType;
+  signer: EvmAddress;
+  takerAmount: string;
+  timestamp: string;
+  tokenId: PositionId | TokenId;
+};
+
+/** @internal */
+export type ExchangeOrderMessage = {
+  builder: HexString;
+  maker: EvmAddress;
+  makerAmount: bigint;
+  metadata: HexString;
+  salt: bigint;
+  side: 0 | 1;
+  signatureType: SignatureType;
+  signer: EvmAddress;
+  takerAmount: bigint;
+  timestamp: bigint;
+  tokenId: bigint;
+};
+
+/** @internal */
+export type CreateExchangeOrderTypedDataPayloadParams = {
+  domain: ExchangeOrderDomain;
+  order: ExchangeOrderInput;
+};
+
+/** @internal */
+export type CreateExchangeOrderSignatureParams = {
+  domain: ExchangeOrderDomain;
+  order: ExchangeOrderInput;
+  signature: EvmSignature;
+};
+
+/** @internal */
+export function createExchangeOrderTypedDataPayload(
+  params: CreateExchangeOrderTypedDataPayloadParams,
+): TypedDataPayload {
+  const orderPayload = createLegacyExchangeOrderTypedDataPayload(
+    params.domain,
+    params.order,
+  );
+
+  if (params.order.signatureType !== SignatureType.POLY_1271) {
+    return orderPayload;
+  }
+
+  return {
+    domain: createExchangeOrderTypedDataDomain(params.domain),
+    message: {
+      chainId: params.domain.chainId,
+      contents: orderPayload.message,
+      name: DEPOSIT_WALLET_DOMAIN_NAME,
+      salt: BYTES32_ZERO,
+      verifyingContract: params.order.signer,
+      version: DEPOSIT_WALLET_DOMAIN_VERSION,
+    },
+    primaryType: 'TypedDataSign',
+    types: {
+      Order: ORDER_STRUCTURE,
+      TypedDataSign: TYPED_DATA_SIGN_STRUCTURE,
+    },
+  };
+}
+
+/** @internal */
+export function createExchangeOrderSignature(
+  params: CreateExchangeOrderSignatureParams,
+): EvmSignature | Erc1271Signature {
+  if (params.order.signatureType !== SignatureType.POLY_1271) {
+    return params.signature;
+  }
+
+  const contentsType = Bytes.toHex(Bytes.fromString(ORDER_TYPE_STRING));
+  const contentsTypeLength = ORDER_TYPE_STRING.length
+    .toString(16)
+    .padStart(4, '0');
+
+  return expectErc1271Signature(
+    `0x${params.signature.slice(2)}${createExchangeOrderDomainSeparator(params.domain).slice(2)}${createExchangeOrderContentsHash(params.order).slice(2)}${contentsType.slice(2)}${contentsTypeLength}`,
+  );
+}
+
+/** @internal */
+export function createExchangeOrderMessage(
+  order: ExchangeOrderInput,
+): ExchangeOrderMessage {
+  return {
+    builder: order.builder ?? BYTES32_ZERO,
+    maker: order.maker,
+    makerAmount: BigInt(order.makerAmount),
+    metadata: order.metadata ?? BYTES32_ZERO,
+    salt: BigInt(order.salt),
+    side: encodeExchangeOrderSide(order.side),
+    signatureType: order.signatureType,
+    signer: order.signer,
+    takerAmount: BigInt(order.takerAmount),
+    timestamp: BigInt(order.timestamp),
+    tokenId: BigInt(order.tokenId),
+  };
+}
+
+function createLegacyExchangeOrderTypedDataPayload(
+  domain: ExchangeOrderDomain,
+  order: ExchangeOrderInput,
+): TypedDataPayload {
+  return {
+    domain: createExchangeOrderTypedDataDomain(domain),
+    message: createExchangeOrderMessage(order),
+    primaryType: 'Order',
+    types: {
+      EIP712Domain: EIP712_DOMAIN,
+      Order: ORDER_STRUCTURE,
+    },
+  };
+}
+
+function createExchangeOrderTypedDataDomain(domain: ExchangeOrderDomain) {
+  return {
+    chainId: domain.chainId,
+    name: PROTOCOL_NAME,
+    verifyingContract: domain.exchange,
+    version: domain.protocolVersion,
+  };
+}
+
+function createExchangeOrderDomainSeparator(
+  domain: ExchangeOrderDomain,
+): HexString {
+  return expectHexString(
+    Hash.keccak256(
+      AbiParameters.encode(
+        [
+          { type: 'bytes32' },
+          { type: 'bytes32' },
+          { type: 'bytes32' },
+          { type: 'uint256' },
+          { type: 'address' },
+        ],
+        [
+          DOMAIN_TYPE_HASH,
+          PROTOCOL_NAME_HASH,
+          protocolVersionHash(domain.protocolVersion),
+          BigInt(domain.chainId),
+          domain.exchange,
+        ],
+      ),
+      { as: 'Hex' },
+    ),
+  );
+}
+
+function createExchangeOrderContentsHash(order: ExchangeOrderInput): HexString {
+  const message = createExchangeOrderMessage(order);
+
+  return expectHexString(
+    Hash.keccak256(
+      AbiParameters.encode(
+        [
+          { type: 'bytes32' },
+          { type: 'uint256' },
+          { type: 'address' },
+          { type: 'address' },
+          { type: 'uint256' },
+          { type: 'uint256' },
+          { type: 'uint256' },
+          { type: 'uint8' },
+          { type: 'uint8' },
+          { type: 'uint256' },
+          { type: 'bytes32' },
+          { type: 'bytes32' },
+        ],
+        [
+          ORDER_TYPE_HASH,
+          message.salt,
+          message.maker,
+          message.signer,
+          message.tokenId,
+          message.makerAmount,
+          message.takerAmount,
+          message.side,
+          message.signatureType,
+          message.timestamp,
+          message.metadata,
+          message.builder,
+        ],
+      ),
+      { as: 'Hex' },
+    ),
+  );
+}
+
+function protocolVersionHash(
+  protocolVersion: ExchangeOrderProtocolVersion,
+): HexString {
+  return expectHexString(
+    Hash.keccak256(Bytes.fromString(protocolVersion), { as: 'Hex' }),
+  );
+}
+
+function encodeExchangeOrderSide(side: OrderSide | 0 | 1): 0 | 1 {
+  if (side === 0 || side === 1) return side;
+
+  return side === OrderSide.BUY ? 0 : 1;
+}

--- a/packages/client/src/wallet.ts
+++ b/packages/client/src/wallet.ts
@@ -50,6 +50,27 @@ export function toSignatureType(walletType: WalletType): SignatureType {
   }
 }
 
+/** @internal */
+export type OrderIdentity = {
+  maker: EvmAddress;
+  signatureType: SignatureType;
+  signer: EvmAddress;
+};
+
+/** @internal */
+export function resolveOrderIdentity(account: AccountIdentity): OrderIdentity {
+  const signatureType = toSignatureType(account.walletType);
+
+  return {
+    maker: account.wallet,
+    signatureType,
+    signer:
+      signatureType === SignatureType.POLY_1271
+        ? account.wallet
+        : account.signer,
+  };
+}
+
 const PROXY_BYTECODE_TEMPLATE =
   '3d3d606380380380913d393d73%s5af4602a57600080fd5b602d8060366000396000f3363d3d373d3d3d363d73%s5af43d82803e903d91602b57fd5bf352e831dd00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000';
 

--- a/packages/client/src/websockets/clob/market.ts
+++ b/packages/client/src/websockets/clob/market.ts
@@ -17,7 +17,7 @@ import {
   SubscriptionRegistry,
   type SubscriptionRegistryChange,
 } from '../registry';
-import type { WebSocketManager } from '../types';
+import type { WebSocketSubscriptionManager } from '../types';
 import {
   buildMarketSubscribeMessage,
   deriveMarketServerSubscription,
@@ -38,7 +38,7 @@ export type ClobMarketWebSocketManagerOptions = {
  * Incremental subscribe/unsubscribe frames mutate that server-side asset set.
  */
 export class ClobMarketWebSocketManager
-  implements WebSocketManager<MarketSubscription, MarketEvent>
+  implements WebSocketSubscriptionManager<MarketSubscription, MarketEvent>
 {
   readonly #url: string;
   #closing: Promise<void> | undefined;

--- a/packages/client/src/websockets/clob/user.test.ts
+++ b/packages/client/src/websockets/clob/user.test.ts
@@ -22,7 +22,7 @@ const credentials = ApiKeyCredsSchema.parse({
   secret: 'test-secret',
 });
 const manager = new ClobUserWebSocketManager({
-  resolveCredentials: () => credentials,
+  credentials,
   url: production.clobUserWs,
 });
 

--- a/packages/client/src/websockets/clob/user.ts
+++ b/packages/client/src/websockets/clob/user.ts
@@ -18,7 +18,7 @@ import {
   SubscriptionRegistry,
   type SubscriptionRegistryChange,
 } from '../registry';
-import type { WebSocketManager } from '../types';
+import type { WebSocketSubscriptionManager } from '../types';
 import {
   buildUserSubscribeMessage,
   deriveUserServerSubscription,
@@ -36,7 +36,7 @@ export type ClobUserWebSocketManagerOptions = {
 };
 
 export class ClobUserWebSocketManager
-  implements WebSocketManager<UserSubscription, UserEvent>
+  implements WebSocketSubscriptionManager<UserSubscription, UserEvent>
 {
   readonly #url: string;
   readonly #resolveCredentials: ApiKeyCredsProvider;

--- a/packages/client/src/websockets/clob/user.ts
+++ b/packages/client/src/websockets/clob/user.ts
@@ -28,10 +28,8 @@ import {
   userMatcherFor,
 } from './protocol';
 
-type ApiKeyCredsProvider = () => ApiKeyCreds;
-
 export type ClobUserWebSocketManagerOptions = {
-  resolveCredentials: ApiKeyCredsProvider;
+  credentials: ApiKeyCreds;
   url: string;
 };
 
@@ -39,7 +37,7 @@ export class ClobUserWebSocketManager
   implements WebSocketSubscriptionManager<UserSubscription, UserEvent>
 {
   readonly #url: string;
-  readonly #resolveCredentials: ApiKeyCredsProvider;
+  readonly #credentials: ApiKeyCreds;
   #closing: Promise<void> | undefined;
   readonly #connection = new WebSocketConnection({
     heartbeat: new ClobWebSocketHeartbeat(),
@@ -53,7 +51,7 @@ export class ClobUserWebSocketManager
 
   constructor(options: ClobUserWebSocketManagerOptions) {
     this.#url = options.url;
-    this.#resolveCredentials = options.resolveCredentials;
+    this.#credentials = options.credentials;
   }
 
   async subscribe(
@@ -127,7 +125,7 @@ export class ClobUserWebSocketManager
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: (credentials) => this.#onConnectionOpen(credentials),
-      prepare: () => this.#resolveCredentials(),
+      prepare: () => this.#credentials,
       url: this.#url,
     });
   }

--- a/packages/client/src/websockets/index.ts
+++ b/packages/client/src/websockets/index.ts
@@ -1,8 +1,11 @@
 export { ClobMarketWebSocketManager, ClobUserWebSocketManager } from './clob';
+export { RfqQuoterWebSocketManager } from './rfq';
 export { RtdsWebSocketManager } from './rtds';
 export { SportsWebSocketManager } from './sports';
 export type {
   PublicWebSocketManagers,
   SecureWebSocketManagers,
+  WebSocketSession,
+  WebSocketSessionManager,
   WebSocketSubscriptionManager,
 } from './types';

--- a/packages/client/src/websockets/index.ts
+++ b/packages/client/src/websockets/index.ts
@@ -4,5 +4,5 @@ export { SportsWebSocketManager } from './sports';
 export type {
   PublicWebSocketManagers,
   SecureWebSocketManagers,
-  WebSocketManager,
+  WebSocketSubscriptionManager,
 } from './types';

--- a/packages/client/src/websockets/lifecycle.test.ts
+++ b/packages/client/src/websockets/lifecycle.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WebSocketConnection } from './lifecycle';
+
+describe('WebSocketConnection', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('passes configured headers to the WebSocket constructor', async () => {
+    const constructions: Array<{ options: unknown; url: string }> = [];
+
+    class HeaderWebSocket extends EventTarget {
+      static OPEN = 1;
+      static CLOSED = 3;
+      static CLOSING = 2;
+
+      readyState = 0;
+
+      constructor(url: string, options?: unknown) {
+        super();
+        constructions.push({ options, url });
+
+        queueMicrotask(() => {
+          this.readyState = HeaderWebSocket.OPEN;
+          this.dispatchEvent(new Event('open'));
+        });
+      }
+
+      send(): void {}
+
+      close(): void {
+        this.readyState = HeaderWebSocket.CLOSED;
+        this.dispatchEvent(new Event('close'));
+      }
+    }
+
+    vi.stubGlobal('WebSocket', HeaderWebSocket);
+    const connection = new WebSocketConnection();
+
+    await connection.connect({
+      headers: { 'x-preprod-access': 'token' },
+      onClose: () => undefined,
+      onError: () => undefined,
+      onMessage: () => undefined,
+      onOpen: () => undefined,
+      url: 'wss://example.test/rfq',
+    });
+
+    expect(constructions).toEqual([
+      {
+        options: { headers: { 'x-preprod-access': 'token' } },
+        url: 'wss://example.test/rfq',
+      },
+    ]);
+
+    await connection.close();
+  });
+});

--- a/packages/client/src/websockets/lifecycle.ts
+++ b/packages/client/src/websockets/lifecycle.ts
@@ -34,7 +34,7 @@ export type WebSocketConnectionResult = {
 };
 
 export type WebSocketConnectionConstructorOptions = {
-  heartbeat: WebSocketHeartbeat;
+  heartbeat?: WebSocketHeartbeat;
 };
 
 export class ReconnectScheduler {
@@ -80,12 +80,12 @@ export class ReconnectScheduler {
 }
 
 export class WebSocketConnection {
-  readonly #heartbeat: WebSocketHeartbeat;
+  readonly #heartbeat: WebSocketHeartbeat | undefined;
   #socket: WebSocket | undefined;
   #connecting: Promise<WebSocketConnectionResult> | undefined;
   #watchdog: ReturnType<typeof setInterval> | undefined;
 
-  constructor(options: WebSocketConnectionConstructorOptions) {
+  constructor(options: WebSocketConnectionConstructorOptions = {}) {
     this.#heartbeat = options.heartbeat;
   }
 
@@ -165,7 +165,7 @@ export class WebSocketConnection {
       socket.addEventListener('message', (event) => {
         if (this.#socket !== socket) return;
         const message = String(event.data);
-        if (this.#heartbeat.handleMessage(message)) return;
+        if (this.#heartbeat?.handleMessage(message)) return;
 
         let raw: unknown;
         try {
@@ -196,9 +196,12 @@ export class WebSocketConnection {
 
   #startHeartbeat(): void {
     this.#stopHeartbeat();
-    this.#heartbeat.start((message) => this.#sendRaw(message));
+    const heartbeat = this.#heartbeat;
+    if (heartbeat === undefined) return;
+
+    heartbeat.start((message) => this.#sendRaw(message));
     this.#watchdog = setNonBlockingInterval(() => {
-      if (!this.#heartbeat.isStale(Date.now())) return;
+      if (!heartbeat.isStale(Date.now())) return;
       const socket = this.#socket;
       if (socket?.readyState === WebSocket.OPEN) {
         // Let the normal close path reconnect and resubscribe active handles.
@@ -212,7 +215,7 @@ export class WebSocketConnection {
       clearInterval(this.#watchdog);
       this.#watchdog = undefined;
     }
-    this.#heartbeat.stop();
+    this.#heartbeat?.stop();
   }
 
   async #takeCurrent(): Promise<WebSocket | undefined> {

--- a/packages/client/src/websockets/lifecycle.ts
+++ b/packages/client/src/websockets/lifecycle.ts
@@ -21,6 +21,7 @@ export type ScheduleReconnectOptions = {
 };
 
 export type WebSocketConnectionOptions<TContext = undefined> = {
+  headers?: Record<string, string>;
   onClose: () => void;
   onError: () => void;
   onMessage: (message: unknown) => void;
@@ -142,7 +143,7 @@ export class WebSocketConnection {
     const context = await options.prepare?.();
 
     return new Promise<WebSocket>((resolve, reject) => {
-      const socket = new WebSocket(options.url);
+      const socket = createWebSocket(options.url, options.headers);
 
       const onOpen = () => {
         socket.removeEventListener('error', onOpenError);
@@ -231,6 +232,27 @@ export class WebSocketConnection {
       () => undefined,
     );
   }
+}
+
+function createWebSocket(
+  url: string,
+  headers: Record<string, string> | undefined,
+): WebSocket {
+  if (headers === undefined) return new WebSocket(url);
+
+  try {
+    const socket: unknown = Reflect.construct(WebSocket, [url, { headers }]);
+    if (socket instanceof WebSocket) return socket;
+  } catch (cause) {
+    throw new TransportError(
+      'WebSocket headers require a header-capable WebSocket implementation.',
+      { cause },
+    );
+  }
+
+  throw new TransportError(
+    'WebSocket headers require a header-capable WebSocket implementation.',
+  );
 }
 
 type ReconnectDelayOptions = {

--- a/packages/client/src/websockets/rfq/events.ts
+++ b/packages/client/src/websockets/rfq/events.ts
@@ -1,0 +1,85 @@
+import {
+  type RfqConfirmationAck as BindingRfqConfirmationAck,
+  type RfqQuoteAck as BindingRfqQuoteAck,
+  RfqConfirmationDecision,
+  type RfqConfirmationRequest,
+  type RfqExecutionUpdate,
+  type RfqId,
+  type RfqQuoteId,
+  type RfqQuoteRequest,
+} from '@polymarket/bindings/rfq';
+import type {
+  RfqConfirmationAck,
+  RfqConfirmationRequestEvent,
+  RfqExecutionUpdateEvent,
+  RfqQuoteAck,
+  RfqQuoteRequestEvent,
+  RfqQuoteResponse,
+} from '../../actions/rfq';
+
+export interface RfqEventController {
+  quote(
+    request: RfqQuoteRequest,
+    response: RfqQuoteResponse,
+  ): Promise<RfqQuoteAck>;
+  respondToConfirmation(
+    rfqId: RfqId,
+    quoteId: RfqQuoteId,
+    decision: RfqConfirmationDecision,
+  ): Promise<RfqConfirmationAck>;
+}
+
+export function toQuoteRequestEvent(
+  controller: RfqEventController,
+  message: RfqQuoteRequest,
+): RfqQuoteRequestEvent {
+  return {
+    ...message,
+    quote: (request) => controller.quote(message, request),
+  };
+}
+
+export function toConfirmationRequestEvent(
+  controller: RfqEventController,
+  message: RfqConfirmationRequest,
+): RfqConfirmationRequestEvent {
+  const rfqId = message.rfqId;
+  const quoteId = message.quoteId;
+  return {
+    ...message,
+    confirm: () =>
+      controller.respondToConfirmation(
+        rfqId,
+        quoteId,
+        RfqConfirmationDecision.Confirm,
+      ),
+    decline: () =>
+      controller.respondToConfirmation(
+        rfqId,
+        quoteId,
+        RfqConfirmationDecision.Decline,
+      ),
+  };
+}
+
+export function toExecutionUpdateEvent(
+  message: RfqExecutionUpdate,
+): RfqExecutionUpdateEvent {
+  return message;
+}
+
+export function toQuoteAck(message: BindingRfqQuoteAck): RfqQuoteAck {
+  return {
+    quoteId: message.quoteId,
+    rfqId: message.rfqId,
+  };
+}
+
+export function toConfirmationAck(
+  message: BindingRfqConfirmationAck,
+): RfqConfirmationAck {
+  return {
+    quoteId: message.quoteId,
+    rfqId: message.rfqId,
+  };
+}

--- a/packages/client/src/websockets/rfq/events.ts
+++ b/packages/client/src/websockets/rfq/events.ts
@@ -1,6 +1,7 @@
 import {
   type RfqConfirmationAck as BindingRfqConfirmationAck,
   type RfqQuoteAck as BindingRfqQuoteAck,
+  type RfqQuoteCancelAck as BindingRfqQuoteCancelAck,
   RfqConfirmationDecision,
   type RfqConfirmationRequest,
   type RfqExecutionUpdate,
@@ -9,10 +10,11 @@ import {
   type RfqQuoteRequest,
 } from '@polymarket/bindings/rfq';
 import type {
+  RfqCancelQuoteAck,
   RfqConfirmationAck,
   RfqConfirmationRequestEvent,
   RfqExecutionUpdateEvent,
-  RfqQuoteAck,
+  RfqQuoteReference,
   RfqQuoteRequestEvent,
   RfqQuoteResponse,
 } from '../../actions/rfq';
@@ -21,7 +23,7 @@ export interface RfqEventController {
   quote(
     request: RfqQuoteRequest,
     response: RfqQuoteResponse,
-  ): Promise<RfqQuoteAck>;
+  ): Promise<RfqQuoteReference>;
   respondToConfirmation(
     rfqId: RfqId,
     quoteId: RfqQuoteId,
@@ -68,7 +70,16 @@ export function toExecutionUpdateEvent(
   return message;
 }
 
-export function toQuoteAck(message: BindingRfqQuoteAck): RfqQuoteAck {
+export function toQuoteAck(message: BindingRfqQuoteAck): RfqQuoteReference {
+  return {
+    quoteId: message.quoteId,
+    rfqId: message.rfqId,
+  };
+}
+
+export function toQuoteCancelAck(
+  message: BindingRfqQuoteCancelAck,
+): RfqCancelQuoteAck {
   return {
     quoteId: message.quoteId,
     rfqId: message.rfqId,

--- a/packages/client/src/websockets/rfq/index.ts
+++ b/packages/client/src/websockets/rfq/index.ts
@@ -1,0 +1,4 @@
+export {
+  RfqQuoterWebSocketManager,
+  type RfqQuoterWebSocketManagerOptions,
+} from './quoter';

--- a/packages/client/src/websockets/rfq/messages.ts
+++ b/packages/client/src/websockets/rfq/messages.ts
@@ -38,10 +38,10 @@ export function createQuoteMessage(
   quote: RfqQuote,
 ): RfqQuoteMessage {
   return {
-    price_e6: Number(quote.price),
+    price_e6: quote.price.toString(),
     rfq_id: request.rfqId,
     signed_order: quote.signedOrder,
-    size_e6: Number(quote.size),
+    size_e6: quote.size.toString(),
     type: 'RFQ_QUOTE',
   };
 }

--- a/packages/client/src/websockets/rfq/messages.ts
+++ b/packages/client/src/websockets/rfq/messages.ts
@@ -38,10 +38,10 @@ export function createQuoteMessage(
   quote: RfqQuote,
 ): RfqQuoteMessage {
   return {
-    price_e6: quote.priceE6,
+    price_e6: Number(quote.price),
     rfq_id: request.rfqId,
     signed_order: quote.signedOrder,
-    size_e6: quote.sizeE6,
+    size_e6: Number(quote.size),
     type: 'RFQ_QUOTE',
   };
 }

--- a/packages/client/src/websockets/rfq/messages.ts
+++ b/packages/client/src/websockets/rfq/messages.ts
@@ -4,6 +4,7 @@ import type {
   RfqConfirmationDecision,
   RfqConfirmationResponseMessage,
   RfqId,
+  RfqQuoteCancelMessage,
   RfqQuoteId,
   RfqQuoteMessage,
   RfqQuoteRequest,
@@ -43,6 +44,22 @@ export function createQuoteMessage(
     signed_order: quote.signedOrder,
     size_e6: quote.size.toString(),
     type: 'RFQ_QUOTE',
+  };
+}
+
+export function createQuoteCancelMessage(
+  account: AccountIdentity,
+  rfqId: RfqId,
+  quoteId: RfqQuoteId,
+): RfqQuoteCancelMessage {
+  const identity = resolveOrderIdentity(account);
+
+  return {
+    maker_address: identity.maker,
+    quote_id: quoteId,
+    rfq_id: rfqId,
+    signer_address: identity.signer,
+    type: 'RFQ_QUOTE_CANCEL',
   };
 }
 

--- a/packages/client/src/websockets/rfq/messages.ts
+++ b/packages/client/src/websockets/rfq/messages.ts
@@ -1,0 +1,60 @@
+import type { ApiKeyCreds } from '@polymarket/bindings/clob';
+import type {
+  RfqAuthMessage,
+  RfqConfirmationDecision,
+  RfqConfirmationResponseMessage,
+  RfqId,
+  RfqQuoteId,
+  RfqQuoteMessage,
+  RfqQuoteRequest,
+} from '@polymarket/bindings/rfq';
+import type { AccountIdentity } from '../../wallet';
+import { resolveOrderIdentity } from '../../wallet';
+import type { RfqQuote } from './quote';
+
+export function createAuthMessage(
+  account: AccountIdentity,
+  credentials: ApiKeyCreds,
+): RfqAuthMessage {
+  const identity = resolveOrderIdentity(account);
+
+  return {
+    auth: {
+      apiKey: credentials.key,
+      passphrase: credentials.passphrase,
+      secret: credentials.secret,
+    },
+    identity: {
+      maker_address: identity.maker,
+      signature_type: identity.signatureType,
+      signer_address: identity.signer,
+    },
+    type: 'auth',
+  };
+}
+
+export function createQuoteMessage(
+  request: RfqQuoteRequest,
+  quote: RfqQuote,
+): RfqQuoteMessage {
+  return {
+    price_e6: quote.priceE6,
+    rfq_id: request.rfqId,
+    signed_order: quote.signedOrder,
+    size_e6: quote.sizeE6,
+    type: 'RFQ_QUOTE',
+  };
+}
+
+export function createConfirmationResponseMessage(
+  rfqId: RfqId,
+  quoteId: RfqQuoteId,
+  decision: RfqConfirmationDecision,
+): RfqConfirmationResponseMessage {
+  return {
+    decision,
+    quote_id: quoteId,
+    rfq_id: rfqId,
+    type: 'RFQ_CONFIRMATION_RESPONSE',
+  };
+}

--- a/packages/client/src/websockets/rfq/pending.ts
+++ b/packages/client/src/websockets/rfq/pending.ts
@@ -1,0 +1,71 @@
+import { setNonBlockingTimeout } from '@polymarket/types';
+import { TimeoutError } from '../../errors';
+
+type PendingResponse<T> = {
+  promise: Promise<T>;
+  reject(error: Error): void;
+  resolve(value: T): void;
+};
+
+export class PendingResponses {
+  readonly #pending = new Map<string, PendingResponse<unknown>[]>();
+  readonly #timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    this.#timeoutMs = timeoutMs;
+  }
+
+  waitFor<T>(key: string, timeoutMessage: string): Promise<T> {
+    const pending = createPending<T>();
+    let promise!: Promise<T>;
+    const timeout = setNonBlockingTimeout(() => {
+      this.remove(key, promise);
+      pending.reject(new TimeoutError(timeoutMessage));
+    }, this.#timeoutMs);
+    promise = pending.promise.finally(() => clearTimeout(timeout));
+    const entries = this.#pending.get(key) ?? [];
+    entries.push({ ...pending, promise } as PendingResponse<unknown>);
+    this.#pending.set(key, entries);
+    return promise;
+  }
+
+  resolve<T>(key: string, value: T): void {
+    const entries = this.#pending.get(key);
+    const pending = entries?.shift();
+    if (pending === undefined) return;
+    if (entries !== undefined && entries.length === 0) {
+      this.#pending.delete(key);
+    }
+    pending.resolve(value);
+  }
+
+  remove<T>(key: string, promise: Promise<T>): void {
+    const entries = this.#pending.get(key);
+    if (entries === undefined) return;
+    const remaining = entries.filter((entry) => entry.promise !== promise);
+    if (remaining.length === 0) {
+      this.#pending.delete(key);
+    } else {
+      this.#pending.set(key, remaining);
+    }
+  }
+
+  rejectAll(error: Error): void {
+    for (const entries of this.#pending.values()) {
+      for (const pending of entries) {
+        pending.reject(error);
+      }
+    }
+    this.#pending.clear();
+  }
+}
+
+function createPending<T>(): PendingResponse<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/packages/client/src/websockets/rfq/pending.ts
+++ b/packages/client/src/websockets/rfq/pending.ts
@@ -39,6 +39,16 @@ export class PendingResponses {
     pending.resolve(value);
   }
 
+  reject(key: string, error: Error): void {
+    const entries = this.#pending.get(key);
+    const pending = entries?.shift();
+    if (pending === undefined) return;
+    if (entries !== undefined && entries.length === 0) {
+      this.#pending.delete(key);
+    }
+    pending.reject(error);
+  }
+
   remove<T>(key: string, promise: Promise<T>): void {
     const entries = this.#pending.get(key);
     if (entries === undefined) return;

--- a/packages/client/src/websockets/rfq/quote.ts
+++ b/packages/client/src/websockets/rfq/quote.ts
@@ -6,6 +6,8 @@ import {
 import {
   RfqDirection,
   type RfqQuoteRequest,
+  type RfqRequestedSize,
+  RfqRequestedSizeUnit,
   type RfqSignedOrder,
 } from '@polymarket/bindings/rfq';
 import type { EvmAddress } from '@polymarket/types';
@@ -64,8 +66,10 @@ async function createParsedRfqQuote(
   params: CreateParsedRfqQuoteParams,
 ): Promise<RfqQuote> {
   const priceE6 = decimalToE6(params.response.price, 'RFQ quote price');
-  const size = params.response.size ?? Number(params.request.size);
-  const sizeE6 = decimalToE6(size, 'RFQ quote size');
+  const sizeE6 =
+    params.response.size === undefined
+      ? defaultQuoteSizeE6(params.request.requestedSize, priceE6)
+      : decimalToE6(params.response.size, 'RFQ quote size');
   const signedOrder = await signRfqQuoteOrder({
     account: params.account,
     chainId: params.chainId,
@@ -111,6 +115,42 @@ function quoteOrderPriceE6(
 
 function quoteOrderSide(source: RfqQuoteSource): OrderSide {
   return source === 'collateral' ? OrderSide.BUY : OrderSide.SELL;
+}
+
+function defaultQuoteSizeE6(
+  requestedSize: RfqRequestedSize,
+  priceE6: number,
+): number {
+  const valueE6 = decimalStringToE6(requestedSize.value, 'RFQ requested size');
+
+  if (requestedSize.unit === RfqRequestedSizeUnit.Shares) {
+    return valueE6;
+  }
+
+  const sizeE6 = (BigInt(valueE6) * 1_000_000n) / BigInt(priceE6);
+
+  if (sizeE6 > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new UserInputError('RFQ quote size is too large.');
+  }
+
+  return Number(sizeE6);
+}
+
+function decimalStringToE6(value: string, field: string): number {
+  const [whole = '', fraction = ''] = value.split('.');
+
+  if (fraction.length > 6) {
+    throw new UserInputError(`${field} must have at most 6 decimal places.`);
+  }
+
+  const wireValue =
+    BigInt(whole) * 1_000_000n + BigInt(fraction.padEnd(6, '0'));
+
+  if (wireValue > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new UserInputError(`${field} is too large.`);
+  }
+
+  return Number(wireValue);
 }
 
 function decimalToE6(value: number, field: string): number {

--- a/packages/client/src/websockets/rfq/quote.ts
+++ b/packages/client/src/websockets/rfq/quote.ts
@@ -1,7 +1,8 @@
 import {
+  DecimalishSchema,
+  type DecimalString,
   OrderSide,
   type PositionId,
-  PositiveDecimalNumberSchema,
 } from '@polymarket/bindings';
 import {
   RfqDirection,
@@ -12,7 +13,6 @@ import {
 } from '@polymarket/bindings/rfq';
 import type { EvmAddress } from '@polymarket/types';
 import { z } from 'zod';
-import { decimalPlaces, parseAmount } from '../../actions/orders/math';
 import type { RfqQuoteResponse, RfqQuoteSource } from '../../actions/rfq';
 import { UserInputError } from '../../errors';
 import { parseUserInput } from '../../input';
@@ -20,17 +20,23 @@ import type { Signer } from '../../types';
 import type { AccountIdentity } from '../../wallet';
 import { signRfqQuoteOrder } from './signing';
 
+const DecimalishToBigIntSchema = DecimalishSchema.transform((value) =>
+  decimalToScaledInteger(value),
+).refine((value) => value <= BigInt(Number.MAX_SAFE_INTEGER), {
+  message: 'Value exceeds the temporary numeric wire limit.',
+});
+
 const RfqQuoteResponseSchema = z.strictObject({
-  price: PositiveDecimalNumberSchema.refine((price) => price < 1, {
+  price: DecimalishToBigIntSchema.refine((price) => price < 1_000_000n, {
     message: 'Price must be less than 1.',
   }),
-  size: PositiveDecimalNumberSchema.optional(),
+  size: DecimalishToBigIntSchema.optional(),
   source: z.enum(['collateral', 'inventory']).default('collateral'),
-}) satisfies z.ZodType<RfqQuoteResponse>;
+});
 
-type RfqQuoteParams = {
-  price: number;
-  size?: number;
+export type ParsedRfqQuoteResponse = {
+  price: bigint;
+  size?: bigint;
   source: RfqQuoteSource;
 };
 
@@ -39,53 +45,42 @@ export type CreateRfqQuoteParams = {
   chainId: number;
   exchange: EvmAddress;
   request: RfqQuoteRequest;
-  response: RfqQuoteResponse;
+  response: ParsedRfqQuoteResponse;
   signer: Signer;
 };
 
 export type RfqQuote = {
-  priceE6: number;
+  price: bigint;
   signedOrder: RfqSignedOrder;
-  sizeE6: number;
+  size: bigint;
 };
+
+export function parseRfqQuoteResponse(
+  response: RfqQuoteResponse,
+): ParsedRfqQuoteResponse {
+  return parseUserInput(response, RfqQuoteResponseSchema);
+}
 
 export async function createRfqQuote(
   params: CreateRfqQuoteParams,
 ): Promise<RfqQuote> {
-  const response = parseUserInput(params.response, RfqQuoteResponseSchema);
-  const quote = await createParsedRfqQuote({ ...params, response });
-
-  return quote;
-}
-
-type CreateParsedRfqQuoteParams = Omit<CreateRfqQuoteParams, 'response'> & {
-  response: RfqQuoteParams;
-};
-
-async function createParsedRfqQuote(
-  params: CreateParsedRfqQuoteParams,
-): Promise<RfqQuote> {
-  const priceE6 = decimalToE6(params.response.price, 'RFQ quote price');
-  const sizeE6 =
+  const price = params.response.price;
+  const size =
     params.response.size === undefined
-      ? defaultQuoteSizeE6(params.request.requestedSize, priceE6)
-      : decimalToE6(params.response.size, 'RFQ quote size');
+      ? defaultQuoteSize(params.request.requestedSize, price)
+      : params.response.size;
   const signedOrder = await signRfqQuoteOrder({
     account: params.account,
     chainId: params.chainId,
     exchange: params.exchange,
-    orderPriceE6: quoteOrderPriceE6(
-      params.request,
-      params.response.source,
-      priceE6,
-    ),
+    orderPrice: quoteOrderPrice(params.request, params.response.source, price),
     orderSide: quoteOrderSide(params.response.source),
     signer: params.signer,
-    sizeE6,
+    size,
     tokenId: quoteOrderTokenId(params.request, params.response.source),
   });
 
-  return { priceE6, signedOrder, sizeE6 };
+  return { price, signedOrder, size };
 }
 
 function quoteOrderTokenId(
@@ -101,68 +96,53 @@ function quoteOrderTokenId(
   return source === 'collateral' ? request.yesPositionId : request.noPositionId;
 }
 
-function quoteOrderPriceE6(
+function quoteOrderPrice(
   request: RfqQuoteRequest,
   source: RfqQuoteSource,
-  priceE6: number,
-): number {
+  price: bigint,
+): bigint {
   const usesComplementPrice =
     (request.direction === RfqDirection.Buy && source === 'collateral') ||
     (request.direction === RfqDirection.Sell && source === 'inventory');
 
-  return usesComplementPrice ? 1_000_000 - priceE6 : priceE6;
+  return usesComplementPrice ? 1_000_000n - price : price;
 }
 
 function quoteOrderSide(source: RfqQuoteSource): OrderSide {
   return source === 'collateral' ? OrderSide.BUY : OrderSide.SELL;
 }
 
-function defaultQuoteSizeE6(
+function defaultQuoteSize(
   requestedSize: RfqRequestedSize,
-  priceE6: number,
-): number {
-  const valueE6 = decimalStringToE6(requestedSize.value, 'RFQ requested size');
+  price: bigint,
+): bigint {
+  const value = decimalToScaledInteger(requestedSize.value);
 
   if (requestedSize.unit === RfqRequestedSizeUnit.Shares) {
-    return valueE6;
+    return value;
   }
 
-  const sizeE6 = (BigInt(valueE6) * 1_000_000n) / BigInt(priceE6);
-
-  if (sizeE6 > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new UserInputError('RFQ quote size is too large.');
-  }
-
-  return Number(sizeE6);
+  return (value * 1_000_000n) / price;
 }
 
-function decimalStringToE6(value: string, field: string): number {
-  const [whole = '', fraction = ''] = value.split('.');
+function decimalToScaledInteger(value: DecimalString): bigint {
+  const match = /^(\d+)(?:\.(\d*))?$/.exec(value);
+  if (match === null) {
+    throw new UserInputError('Value must be a valid decimal.');
+  }
+
+  const [, whole = '', fraction = ''] = match;
 
   if (fraction.length > 6) {
-    throw new UserInputError(`${field} must have at most 6 decimal places.`);
+    throw new UserInputError('Value must have at most 6 decimal places.');
   }
 
-  const wireValue =
+  const scaledValue =
     BigInt(whole) * 1_000_000n + BigInt(fraction.padEnd(6, '0'));
 
-  if (wireValue > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new UserInputError(`${field} is too large.`);
+  if (scaledValue <= 0n) {
+    throw new UserInputError('Value must be greater than 0.');
   }
 
-  return Number(wireValue);
-}
-
-function decimalToE6(value: number, field: string): number {
-  if (decimalPlaces(value) > 6) {
-    throw new UserInputError(`${field} must have at most 6 decimal places.`);
-  }
-
-  const wireValue = parseAmount(value);
-
-  if (wireValue > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new UserInputError(`${field} is too large.`);
-  }
-
-  return Number(wireValue);
+  return scaledValue;
 }

--- a/packages/client/src/websockets/rfq/quote.ts
+++ b/packages/client/src/websockets/rfq/quote.ts
@@ -1,0 +1,128 @@
+import {
+  OrderSide,
+  type PositionId,
+  PositiveDecimalNumberSchema,
+} from '@polymarket/bindings';
+import {
+  RfqDirection,
+  type RfqQuoteRequest,
+  type RfqSignedOrder,
+} from '@polymarket/bindings/rfq';
+import type { EvmAddress } from '@polymarket/types';
+import { z } from 'zod';
+import { decimalPlaces, parseAmount } from '../../actions/orders/math';
+import type { RfqQuoteResponse, RfqQuoteSource } from '../../actions/rfq';
+import { UserInputError } from '../../errors';
+import { parseUserInput } from '../../input';
+import type { Signer } from '../../types';
+import type { AccountIdentity } from '../../wallet';
+import { signRfqQuoteOrder } from './signing';
+
+const RfqQuoteResponseSchema = z.strictObject({
+  price: PositiveDecimalNumberSchema.refine((price) => price < 1, {
+    message: 'Price must be less than 1.',
+  }),
+  size: PositiveDecimalNumberSchema.optional(),
+  source: z.enum(['collateral', 'inventory']).default('collateral'),
+}) satisfies z.ZodType<RfqQuoteResponse>;
+
+type RfqQuoteParams = {
+  price: number;
+  size?: number;
+  source: RfqQuoteSource;
+};
+
+export type CreateRfqQuoteParams = {
+  account: AccountIdentity;
+  chainId: number;
+  exchange: EvmAddress;
+  request: RfqQuoteRequest;
+  response: RfqQuoteResponse;
+  signer: Signer;
+};
+
+export type RfqQuote = {
+  priceE6: number;
+  signedOrder: RfqSignedOrder;
+  sizeE6: number;
+};
+
+export async function createRfqQuote(
+  params: CreateRfqQuoteParams,
+): Promise<RfqQuote> {
+  const response = parseUserInput(params.response, RfqQuoteResponseSchema);
+  const quote = await createParsedRfqQuote({ ...params, response });
+
+  return quote;
+}
+
+type CreateParsedRfqQuoteParams = Omit<CreateRfqQuoteParams, 'response'> & {
+  response: RfqQuoteParams;
+};
+
+async function createParsedRfqQuote(
+  params: CreateParsedRfqQuoteParams,
+): Promise<RfqQuote> {
+  const priceE6 = decimalToE6(params.response.price, 'RFQ quote price');
+  const size = params.response.size ?? Number(params.request.size);
+  const sizeE6 = decimalToE6(size, 'RFQ quote size');
+  const signedOrder = await signRfqQuoteOrder({
+    account: params.account,
+    chainId: params.chainId,
+    exchange: params.exchange,
+    orderPriceE6: quoteOrderPriceE6(
+      params.request,
+      params.response.source,
+      priceE6,
+    ),
+    orderSide: quoteOrderSide(params.response.source),
+    signer: params.signer,
+    sizeE6,
+    tokenId: quoteOrderTokenId(params.request, params.response.source),
+  });
+
+  return { priceE6, signedOrder, sizeE6 };
+}
+
+function quoteOrderTokenId(
+  request: RfqQuoteRequest,
+  source: RfqQuoteSource,
+): PositionId {
+  if (request.direction === RfqDirection.Buy) {
+    return source === 'collateral'
+      ? request.noPositionId
+      : request.yesPositionId;
+  }
+
+  return source === 'collateral' ? request.yesPositionId : request.noPositionId;
+}
+
+function quoteOrderPriceE6(
+  request: RfqQuoteRequest,
+  source: RfqQuoteSource,
+  priceE6: number,
+): number {
+  const usesComplementPrice =
+    (request.direction === RfqDirection.Buy && source === 'collateral') ||
+    (request.direction === RfqDirection.Sell && source === 'inventory');
+
+  return usesComplementPrice ? 1_000_000 - priceE6 : priceE6;
+}
+
+function quoteOrderSide(source: RfqQuoteSource): OrderSide {
+  return source === 'collateral' ? OrderSide.BUY : OrderSide.SELL;
+}
+
+function decimalToE6(value: number, field: string): number {
+  if (decimalPlaces(value) > 6) {
+    throw new UserInputError(`${field} must have at most 6 decimal places.`);
+  }
+
+  const wireValue = parseAmount(value);
+
+  if (wireValue > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new UserInputError(`${field} is too large.`);
+  }
+
+  return Number(wireValue);
+}

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -11,13 +11,15 @@ import {
 import { type EvmAddress, setNonBlockingTimeout } from '@polymarket/types';
 import { type Pushable, pushable } from 'it-pushable';
 import type {
+  RfqCancelQuoteAck,
   RfqConfirmationAck,
   RfqEvent,
-  RfqQuoteAck,
+  RfqQuoteReference,
   RfqQuoteResponse,
   RfqSession,
 } from '../../actions/rfq';
 import {
+  RfqCancelQuoteRejectedError,
   RfqConfirmationRejectedError,
   RfqQuoteRejectedError,
 } from '../../actions/rfq';
@@ -31,11 +33,13 @@ import {
   toConfirmationRequestEvent,
   toExecutionUpdateEvent,
   toQuoteAck,
+  toQuoteCancelAck,
   toQuoteRequestEvent,
 } from './events';
 import {
   createAuthMessage,
   createConfirmationResponseMessage,
+  createQuoteCancelMessage,
   createQuoteMessage,
 } from './messages';
 import { PendingResponses } from './pending';
@@ -242,6 +246,12 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
       case 'quote_ack':
         this.#pending.resolve(quoteAckKey(message.rfqId), toQuoteAck(message));
         return;
+      case 'quote_cancel_ack':
+        this.#pending.resolve(
+          quoteCancelAckKey(message.rfqId, message.quoteId),
+          toQuoteCancelAck(message),
+        );
+        return;
       case 'confirmation_request':
         this.#queue.push(toConfirmationRequestEvent(this, message));
         return;
@@ -287,6 +297,22 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
     }
 
     if (
+      message.requestType === 'RFQ_QUOTE_CANCEL' &&
+      message.rfqId !== undefined &&
+      message.quoteId !== undefined
+    ) {
+      this.#pending.reject(
+        quoteCancelAckKey(message.rfqId, message.quoteId),
+        new RfqCancelQuoteRejectedError(message.message, {
+          code: message.code,
+          quoteId: message.quoteId,
+          rfqId: message.rfqId,
+        }),
+      );
+      return;
+    }
+
+    if (
       message.requestType === 'RFQ_CONFIRMATION_RESPONSE' &&
       message.rfqId !== undefined &&
       message.quoteId !== undefined
@@ -305,7 +331,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
   async quote(
     request: RfqQuoteRequest,
     response: RfqQuoteResponse,
-  ): Promise<RfqQuoteAck> {
+  ): Promise<RfqQuoteReference> {
     const parsedResponse = parseRfqQuoteResponse(response);
     const quote = await createRfqQuote({
       account: this.#account,
@@ -315,7 +341,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
       response: parsedResponse,
       signer: this.#signer,
     });
-    const pending = this.#pending.waitFor<RfqQuoteAck>(
+    const pending = this.#pending.waitFor<RfqQuoteReference>(
       quoteAckKey(request.rfqId),
       `Timed out waiting for RFQ quote acknowledgement for ${request.rfqId}.`,
     );
@@ -324,6 +350,27 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
       return await pending;
     } catch (error) {
       this.#pending.remove(quoteAckKey(request.rfqId), pending);
+      throw error;
+    }
+  }
+
+  async cancelQuote(reference: RfqQuoteReference): Promise<RfqCancelQuoteAck> {
+    const key = quoteCancelAckKey(reference.rfqId, reference.quoteId);
+    const pending = this.#pending.waitFor<RfqCancelQuoteAck>(
+      key,
+      `Timed out waiting for RFQ quote cancellation acknowledgement for ${reference.rfqId}.`,
+    );
+    try {
+      await this.#send(
+        createQuoteCancelMessage(
+          this.#account,
+          reference.rfqId,
+          reference.quoteId,
+        ),
+      );
+      return await pending;
+    } catch (error) {
+      this.#pending.remove(key, pending);
       throw error;
     }
   }
@@ -352,6 +399,10 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
 
 function quoteAckKey(rfqId: RfqId): string {
   return `ACK_RFQ_QUOTE:${rfqId}`;
+}
+
+function quoteCancelAckKey(rfqId: RfqId, quoteId: RfqQuoteId): string {
+  return `ACK_RFQ_QUOTE_CANCEL:${rfqId}:${quoteId}`;
 }
 
 function confirmationAckKey(rfqId: RfqId, quoteId: RfqQuoteId): string {

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -1,0 +1,807 @@
+import {
+  OrderSide,
+  PositiveDecimalNumberSchema,
+  toBaseUnits,
+} from '@polymarket/bindings';
+import type { ApiKeyCreds } from '@polymarket/bindings/clob';
+import { SignatureType } from '@polymarket/bindings/clob';
+import {
+  RfqConfirmationDecision,
+  type RfqConfirmationRequest,
+  RfqDirection,
+  type RfqExecutionUpdate,
+  type RfqQuoteRequest,
+  RfqQuoterInboundMessageSchema,
+  type RfqQuoterOutboundMessage,
+  type RfqSignedOrder,
+} from '@polymarket/bindings/rfq';
+import {
+  type Erc1271Signature,
+  type EvmAddress,
+  type EvmSignature,
+  expectErc1271Signature,
+  expectHexString,
+  type HexString,
+  setNonBlockingTimeout,
+} from '@polymarket/types';
+import { type Pushable, pushable } from 'it-pushable';
+import { AbiParameters, Bytes, Hash } from 'ox';
+import { z } from 'zod';
+import { decimalPlaces, parseAmount } from '../../actions/orders/math';
+import type {
+  RfqConfirmationAck,
+  RfqConfirmationRequestEvent,
+  RfqEvent,
+  RfqExecutionUpdateEvent,
+  RfqQuoteAck,
+  RfqQuoteRequestEvent,
+  RfqQuoteResponse,
+  RfqSession,
+} from '../../actions/rfq';
+import { SigningError, TransportError, UserInputError } from '../../errors';
+import { parseUserInput } from '../../input';
+import type { Signer, TypedDataPayload } from '../../types';
+import type { AccountIdentity } from '../../wallet';
+import { toSignatureType } from '../../wallet';
+import { WebSocketConnection } from '../lifecycle';
+
+const AUTH_TIMEOUT_MS = 30_000;
+const BYTES32_ZERO =
+  '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies HexString;
+const ORDER_TYPE_STRING =
+  'Order(uint256 salt,address maker,address signer,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,uint256 timestamp,bytes32 metadata,bytes32 builder)';
+const ORDER_TYPE_HASH = Hash.keccak256(Bytes.fromString(ORDER_TYPE_STRING), {
+  as: 'Hex',
+});
+const DOMAIN_TYPE_HASH = Hash.keccak256(
+  Bytes.fromString(
+    'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)',
+  ),
+  { as: 'Hex' },
+);
+const PROTOCOL_NAME = 'Polymarket CTF Exchange';
+const PROTOCOL_VERSION = '3';
+const PROTOCOL_NAME_HASH = Hash.keccak256(Bytes.fromString(PROTOCOL_NAME), {
+  as: 'Hex',
+});
+const PROTOCOL_VERSION_HASH = Hash.keccak256(
+  Bytes.fromString(PROTOCOL_VERSION),
+  { as: 'Hex' },
+);
+const DEPOSIT_WALLET_DOMAIN_NAME = 'DepositWallet';
+const DEPOSIT_WALLET_DOMAIN_VERSION = '1';
+const EIP712_DOMAIN = [
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+] as const;
+const ORDER_STRUCTURE = [
+  { name: 'salt', type: 'uint256' },
+  { name: 'maker', type: 'address' },
+  { name: 'signer', type: 'address' },
+  { name: 'tokenId', type: 'uint256' },
+  { name: 'makerAmount', type: 'uint256' },
+  { name: 'takerAmount', type: 'uint256' },
+  { name: 'side', type: 'uint8' },
+  { name: 'signatureType', type: 'uint8' },
+  { name: 'timestamp', type: 'uint256' },
+  { name: 'metadata', type: 'bytes32' },
+  { name: 'builder', type: 'bytes32' },
+] as const;
+const TYPED_DATA_SIGN_STRUCTURE = [
+  { name: 'contents', type: 'Order' },
+  { name: 'name', type: 'string' },
+  { name: 'version', type: 'string' },
+  { name: 'chainId', type: 'uint256' },
+  { name: 'verifyingContract', type: 'address' },
+  { name: 'salt', type: 'bytes32' },
+] as const;
+
+const RfqQuoteResponseSchema = z.strictObject({
+  price: PositiveDecimalNumberSchema.refine((price) => price < 1, {
+    message: 'Price must be less than 1.',
+  }),
+  size: PositiveDecimalNumberSchema.optional(),
+}) satisfies z.ZodType<RfqQuoteResponse>;
+
+type ApiKeyCredsProvider = () => ApiKeyCreds;
+type AccountProvider = () => AccountIdentity;
+type SignerProvider = () => Signer;
+
+export type RfqQuoterWebSocketManagerOptions = {
+  chainId: number;
+  exchangeV3: EvmAddress;
+  resolveAccount: AccountProvider;
+  resolveCredentials: ApiKeyCredsProvider;
+  resolveSigner: SignerProvider;
+  url: string;
+};
+
+type PendingResponse<T> = {
+  promise: Promise<T>;
+  reject(error: Error): void;
+  resolve(value: T): void;
+};
+
+export class RfqQuoterWebSocketManager {
+  readonly #resolveAccount: AccountProvider;
+  readonly #resolveCredentials: ApiKeyCredsProvider;
+  readonly #resolveSigner: SignerProvider;
+  readonly #chainId: number;
+  readonly #exchangeV3: EvmAddress;
+  readonly #url: string;
+  #session: RfqWebSocketSession | undefined;
+  #connectingSession: RfqWebSocketSession | undefined;
+  #connecting: Promise<RfqSession> | undefined;
+
+  constructor(options: RfqQuoterWebSocketManagerOptions) {
+    this.#chainId = options.chainId;
+    this.#exchangeV3 = options.exchangeV3;
+    this.#resolveAccount = options.resolveAccount;
+    this.#resolveCredentials = options.resolveCredentials;
+    this.#resolveSigner = options.resolveSigner;
+    this.#url = options.url;
+  }
+
+  async connect(): Promise<RfqSession> {
+    if (this.#session !== undefined) return this.#session;
+    if (this.#connecting !== undefined) return this.#connecting;
+
+    const session = new RfqWebSocketSession({
+      account: this.#resolveAccount(),
+      chainId: this.#chainId,
+      credentials: this.#resolveCredentials(),
+      exchangeV3: this.#exchangeV3,
+      onClose: () => this.#clearSession(session),
+      signer: this.#resolveSigner(),
+      url: this.#url,
+    });
+    this.#connectingSession = session;
+
+    let connecting!: Promise<RfqSession>;
+    connecting = (async () => {
+      try {
+        await session.connect();
+        this.#session = session;
+        return session;
+      } catch (error) {
+        await session.close();
+        throw error;
+      } finally {
+        if (this.#connecting === connecting) {
+          this.#connecting = undefined;
+        }
+        if (this.#connectingSession === session) {
+          this.#connectingSession = undefined;
+        }
+      }
+    })();
+
+    this.#connecting = connecting;
+    return connecting;
+  }
+
+  async close(): Promise<void> {
+    const session = this.#session;
+    const connectingSession = this.#connectingSession;
+    const connecting = this.#connecting;
+
+    this.#session = undefined;
+    this.#connectingSession = undefined;
+    this.#connecting = undefined;
+
+    await Promise.allSettled([
+      session?.close(),
+      connectingSession?.close(),
+      connecting?.catch(() => undefined),
+    ]).then(() => undefined);
+  }
+
+  #clearSession(session: RfqWebSocketSession): void {
+    if (this.#session === session) {
+      this.#session = undefined;
+    }
+    if (this.#connectingSession === session) {
+      this.#connectingSession = undefined;
+    }
+  }
+}
+
+type RfqWebSocketSessionOptions = {
+  account: AccountIdentity;
+  chainId: number;
+  credentials: ApiKeyCreds;
+  exchangeV3: EvmAddress;
+  onClose: () => void;
+  signer: Signer;
+  url: string;
+};
+
+class RfqWebSocketSession implements RfqSession {
+  readonly #account: AccountIdentity;
+  readonly #chainId: number;
+  readonly #credentials: ApiKeyCreds;
+  readonly #exchangeV3: EvmAddress;
+  readonly #onClose: () => void;
+  readonly #signer: Signer;
+  readonly #url: string;
+  readonly #connection = new WebSocketConnection();
+  readonly #queue: Pushable<RfqEvent> = pushable({ objectMode: true });
+  readonly #pending = new Map<string, PendingResponse<unknown>[]>();
+  #closing: Promise<void> | undefined;
+  #auth: PendingResponse<void> | undefined;
+
+  constructor(options: RfqWebSocketSessionOptions) {
+    this.#account = options.account;
+    this.#chainId = options.chainId;
+    this.#credentials = options.credentials;
+    this.#exchangeV3 = options.exchangeV3;
+    this.#onClose = options.onClose;
+    this.#signer = options.signer;
+    this.#url = options.url;
+  }
+
+  async connect(): Promise<void> {
+    const auth = createPending<void>();
+    this.#auth = auth;
+    const authTimeout = setNonBlockingTimeout(() => {
+      auth.reject(new TransportError('RFQ quoter authentication timed out.'));
+    }, AUTH_TIMEOUT_MS);
+
+    try {
+      await this.#connection.connect({
+        onClose: () => this.#handleClose(),
+        onError: () => undefined,
+        onMessage: (message) => this.#handleMessage(message),
+        onOpen: () => this.#sendAuthMessage(),
+        url: this.#url,
+      });
+      await auth.promise;
+    } finally {
+      clearTimeout(authTimeout);
+      this.#auth = undefined;
+    }
+  }
+
+  async #send(message: RfqQuoterOutboundMessage): Promise<void> {
+    if (!this.#connection.send(message)) {
+      throw new TransportError('RFQ quoter websocket is not open.');
+    }
+  }
+
+  async quote(
+    request: RfqQuoteRequest,
+    response: RfqQuoteResponse,
+  ): Promise<RfqQuoteAck> {
+    const params = parseUserInput(response, RfqQuoteResponseSchema);
+    const quote = await createRfqQuote({
+      account: this.#account,
+      chainId: this.#chainId,
+      exchangeV3: this.#exchangeV3,
+      request,
+      response: params,
+      signer: this.#signer,
+    });
+    const pending = this.#waitFor<RfqQuoteAck>(quoteAckKey(request.rfqId));
+    try {
+      await this.#send({
+        price_e6: quote.priceE6,
+        rfq_id: request.rfqId,
+        signed_order: quote.signedOrder,
+        size_e6: quote.sizeE6,
+        type: 'RFQ_QUOTE',
+      });
+      return await pending;
+    } catch (error) {
+      this.#removePending(quoteAckKey(request.rfqId), pending);
+      throw error;
+    }
+  }
+
+  async respondToConfirmation(
+    rfqId: RfqConfirmationAck['rfqId'],
+    quoteId: RfqConfirmationAck['quoteId'],
+    decision: RfqConfirmationAck['decision'],
+  ): Promise<RfqConfirmationAck> {
+    const key = confirmationAckKey(rfqId, quoteId);
+    const pending = this.#waitFor<RfqConfirmationAck>(key);
+    try {
+      await this.#send({
+        decision,
+        quote_id: quoteId,
+        rfq_id: rfqId,
+        type: 'RFQ_CONFIRMATION_RESPONSE',
+      });
+      return await pending;
+    } catch (error) {
+      this.#removePending(key, pending);
+      throw error;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.#closing === undefined) {
+      this.#closing = this.#shutdown();
+    }
+    await this.#closing;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<RfqEvent> {
+    return this.#queue[Symbol.asyncIterator]();
+  }
+
+  async #shutdown(): Promise<void> {
+    this.#rejectPending(new TransportError('RFQ quoter websocket closed.'));
+    this.#queue.end();
+    await this.#connection.close();
+    this.#onClose();
+  }
+
+  #sendAuthMessage(): void {
+    this.#connection.send({
+      auth: {
+        apiKey: this.#credentials.key,
+        passphrase: this.#credentials.passphrase,
+        secret: this.#credentials.secret,
+      },
+      identity: {
+        maker_address: this.#account.wallet,
+        signature_type: toSignatureType(this.#account.walletType),
+        signer_address: this.#account.signer,
+      },
+      type: 'auth',
+    });
+  }
+
+  #handleMessage(rawMessage: unknown): void {
+    const parsed = RfqQuoterInboundMessageSchema.safeParse(rawMessage);
+    if (!parsed.success) {
+      const error = new TransportError('Invalid RFQ quoter message.', {
+        cause: parsed.error,
+      });
+      this.#rejectPending(error);
+      return;
+    }
+
+    const message = parsed.data;
+    switch (message.type) {
+      case 'auth':
+        this.#handleAuthMessage(message);
+        return;
+      case 'quote_request':
+        this.#queue.push(toQuoteRequestEvent(this, message));
+        return;
+      case 'quote_ack':
+        this.#resolvePending(quoteAckKey(message.rfqId), message);
+        return;
+      case 'confirmation_request':
+        this.#queue.push(toConfirmationRequestEvent(this, message));
+        return;
+      case 'confirmation_ack':
+        this.#resolvePending(
+          confirmationAckKey(message.rfqId, message.quoteId),
+          message,
+        );
+        return;
+      case 'execution_update':
+        this.#queue.push(toExecutionUpdateEvent(message));
+        return;
+      case 'error':
+        return;
+    }
+  }
+
+  #handleAuthMessage(message: { error?: string; success: boolean }): void {
+    if (message.success === true) {
+      this.#auth?.resolve(undefined);
+      return;
+    }
+    this.#auth?.reject(
+      new TransportError(`RFQ quoter authentication failed: ${message.error}`),
+    );
+  }
+
+  #handleClose(): void {
+    void this.close();
+  }
+
+  #waitFor<T>(key: string): Promise<T> {
+    const pending = createPending<T>();
+    const entries = this.#pending.get(key) ?? [];
+    entries.push(pending as PendingResponse<unknown>);
+    this.#pending.set(key, entries);
+    return pending.promise;
+  }
+
+  #resolvePending<T>(key: string, value: T): void {
+    const entries = this.#pending.get(key);
+    const pending = entries?.shift();
+    if (pending === undefined) return;
+    if (entries !== undefined && entries.length === 0) {
+      this.#pending.delete(key);
+    }
+    pending.resolve(value);
+  }
+
+  #removePending<T>(key: string, promise: Promise<T>): void {
+    const entries = this.#pending.get(key);
+    if (entries === undefined) return;
+    const remaining = entries.filter((entry) => entry.promise !== promise);
+    if (remaining.length === 0) {
+      this.#pending.delete(key);
+    } else {
+      this.#pending.set(key, remaining);
+    }
+  }
+
+  #rejectPending(error: Error): void {
+    for (const entries of this.#pending.values()) {
+      for (const pending of entries) {
+        pending.reject(error);
+      }
+    }
+    this.#pending.clear();
+  }
+}
+
+function toQuoteRequestEvent(
+  session: RfqWebSocketSession,
+  message: RfqQuoteRequest,
+): RfqQuoteRequestEvent {
+  return {
+    ...message,
+    quote: (request) => session.quote(message, request),
+  };
+}
+
+function toConfirmationRequestEvent(
+  session: RfqWebSocketSession,
+  message: RfqConfirmationRequest,
+): RfqConfirmationRequestEvent {
+  const rfqId = message.rfqId;
+  const quoteId = message.quoteId;
+  return {
+    ...message,
+    confirm: () =>
+      session.respondToConfirmation(
+        rfqId,
+        quoteId,
+        RfqConfirmationDecision.Confirm,
+      ),
+    decline: () =>
+      session.respondToConfirmation(
+        rfqId,
+        quoteId,
+        RfqConfirmationDecision.Decline,
+      ),
+  };
+}
+
+function toExecutionUpdateEvent(
+  message: RfqExecutionUpdate,
+): RfqExecutionUpdateEvent {
+  return message;
+}
+
+function quoteAckKey(rfqId: string): string {
+  return `ACK_RFQ_QUOTE:${rfqId}`;
+}
+
+function confirmationAckKey(rfqId: string, quoteId: string): string {
+  return `ACK_RFQ_CONFIRMATION_RESPONSE:${rfqId}:${quoteId}`;
+}
+
+type RfqQuoteParams = {
+  price: number;
+  size?: number;
+};
+
+type CreateRfqQuoteParams = {
+  account: AccountIdentity;
+  chainId: number;
+  exchangeV3: EvmAddress;
+  request: RfqQuoteRequest;
+  response: RfqQuoteParams;
+  signer: Signer;
+};
+
+async function createRfqQuote(params: CreateRfqQuoteParams): Promise<{
+  priceE6: number;
+  signedOrder: RfqSignedOrder;
+  sizeE6: number;
+}> {
+  const priceE6 = decimalToE6(params.response.price, 'RFQ quote price');
+  const size = params.response.size ?? Number(params.request.size);
+  const sizeE6 = decimalToE6(size, 'RFQ quote size');
+  const signedOrder = await signRfqQuoteOrder({
+    account: params.account,
+    chainId: params.chainId,
+    exchangeV3: params.exchangeV3,
+    orderPriceE6: orderPriceE6(params.request, priceE6),
+    signer: params.signer,
+    sizeE6,
+    tokenId: quoteOrderTokenId(params.request),
+  });
+
+  return { priceE6, signedOrder, sizeE6 };
+}
+
+type SignRfqQuoteOrderParams = {
+  account: AccountIdentity;
+  chainId: number;
+  exchangeV3: EvmAddress;
+  orderPriceE6: number;
+  signer: Signer;
+  sizeE6: number;
+  tokenId: RfqQuoteRequest['yesPositionId'];
+};
+
+async function signRfqQuoteOrder(
+  params: SignRfqQuoteOrderParams,
+): Promise<RfqSignedOrder> {
+  const signatureType = toSignatureType(params.account.walletType);
+  const order: Omit<RfqSignedOrder, 'signature'> = {
+    builder: BYTES32_ZERO,
+    maker: params.account.wallet,
+    makerAmount: toBaseUnits(
+      ceilDiv(BigInt(params.orderPriceE6) * BigInt(params.sizeE6), 1_000_000n),
+    ),
+    metadata: BYTES32_ZERO,
+    salt: generateOrderSalt().toString(),
+    side: 0,
+    signatureType,
+    signer: params.account.signer,
+    takerAmount: toBaseUnits(String(params.sizeE6)),
+    timestamp: Math.floor(Date.now() / 1000).toString(),
+    tokenId: params.tokenId,
+  };
+
+  let signature: EvmSignature;
+  try {
+    signature = await params.signer.signTypedData(
+      createRfqOrderTypedDataPayload(params.chainId, params.exchangeV3, order),
+    );
+  } catch (error) {
+    throw SigningError.fromError(error, 'Could not sign the RFQ quote order.');
+  }
+
+  return {
+    ...order,
+    signature: createRfqOrderSignature(
+      params.chainId,
+      params.exchangeV3,
+      order,
+      signature,
+    ),
+  };
+}
+
+function quoteOrderTokenId(
+  request: RfqQuoteRequest,
+): RfqQuoteRequest['yesPositionId'] {
+  return request.direction === RfqDirection.Buy
+    ? request.noPositionId
+    : request.yesPositionId;
+}
+
+function orderPriceE6(request: RfqQuoteRequest, priceE6: number): number {
+  return request.direction === RfqDirection.Buy ? 1_000_000 - priceE6 : priceE6;
+}
+
+function createRfqOrderTypedDataPayload(
+  chainId: number,
+  exchangeV3: EvmAddress,
+  order: Omit<RfqSignedOrder, 'signature'>,
+): TypedDataPayload {
+  const orderPayload = createLegacyRfqOrderTypedDataPayload(
+    chainId,
+    exchangeV3,
+    order,
+  );
+
+  if (order.signatureType !== SignatureType.POLY_1271) {
+    return orderPayload;
+  }
+
+  return {
+    domain: {
+      chainId,
+      name: PROTOCOL_NAME,
+      verifyingContract: exchangeV3,
+      version: PROTOCOL_VERSION,
+    },
+    message: {
+      chainId,
+      contents: orderPayload.message,
+      name: DEPOSIT_WALLET_DOMAIN_NAME,
+      salt: BYTES32_ZERO,
+      verifyingContract: order.maker,
+      version: DEPOSIT_WALLET_DOMAIN_VERSION,
+    },
+    primaryType: 'TypedDataSign',
+    types: {
+      Order: ORDER_STRUCTURE,
+      TypedDataSign: TYPED_DATA_SIGN_STRUCTURE,
+    },
+  };
+}
+
+function createLegacyRfqOrderTypedDataPayload(
+  chainId: number,
+  exchangeV3: EvmAddress,
+  order: Omit<RfqSignedOrder, 'signature'>,
+): TypedDataPayload {
+  return {
+    domain: {
+      chainId,
+      name: PROTOCOL_NAME,
+      verifyingContract: exchangeV3,
+      version: PROTOCOL_VERSION,
+    },
+    message: createRfqOrderTypedDataMessage(order),
+    primaryType: 'Order',
+    types: {
+      EIP712Domain: EIP712_DOMAIN,
+      Order: ORDER_STRUCTURE,
+    },
+  };
+}
+
+type RfqOrderTypedDataMessage = {
+  builder: HexString;
+  maker: EvmAddress;
+  makerAmount: bigint;
+  metadata: HexString;
+  salt: bigint;
+  side: number;
+  signatureType: SignatureType;
+  signer: EvmAddress;
+  takerAmount: bigint;
+  timestamp: bigint;
+  tokenId: bigint;
+};
+
+function createRfqOrderTypedDataMessage(
+  order: Omit<RfqSignedOrder, 'signature'>,
+): RfqOrderTypedDataMessage {
+  return {
+    builder: order.builder ?? BYTES32_ZERO,
+    maker: order.maker,
+    makerAmount: BigInt(order.makerAmount),
+    metadata: order.metadata ?? BYTES32_ZERO,
+    salt: BigInt(order.salt),
+    side: OrderSide.BUY === order.side ? 0 : Number(order.side),
+    signatureType: order.signatureType,
+    signer: order.signer,
+    takerAmount: BigInt(order.takerAmount),
+    timestamp: BigInt(order.timestamp),
+    tokenId: BigInt(order.tokenId),
+  };
+}
+
+function createRfqOrderSignature(
+  chainId: number,
+  exchangeV3: EvmAddress,
+  order: Omit<RfqSignedOrder, 'signature'>,
+  signature: EvmSignature,
+): EvmSignature | Erc1271Signature {
+  if (order.signatureType !== SignatureType.POLY_1271) {
+    return signature;
+  }
+
+  const contentsType = Bytes.toHex(Bytes.fromString(ORDER_TYPE_STRING));
+  const contentsTypeLength = ORDER_TYPE_STRING.length
+    .toString(16)
+    .padStart(4, '0');
+
+  return expectErc1271Signature(
+    `0x${signature.slice(2)}${createAppDomainSeparator(chainId, exchangeV3).slice(2)}${createOrderContentsHash(order).slice(2)}${contentsType.slice(2)}${contentsTypeLength}`,
+  );
+}
+
+function createAppDomainSeparator(
+  chainId: number,
+  exchangeV3: EvmAddress,
+): HexString {
+  return expectHexString(
+    Hash.keccak256(
+      AbiParameters.encode(
+        [
+          { type: 'bytes32' },
+          { type: 'bytes32' },
+          { type: 'bytes32' },
+          { type: 'uint256' },
+          { type: 'address' },
+        ],
+        [
+          DOMAIN_TYPE_HASH,
+          PROTOCOL_NAME_HASH,
+          PROTOCOL_VERSION_HASH,
+          BigInt(chainId),
+          exchangeV3,
+        ],
+      ),
+      { as: 'Hex' },
+    ),
+  );
+}
+
+function createOrderContentsHash(
+  order: Omit<RfqSignedOrder, 'signature'>,
+): HexString {
+  const message = createRfqOrderTypedDataMessage(order);
+
+  return expectHexString(
+    Hash.keccak256(
+      AbiParameters.encode(
+        [
+          { type: 'bytes32' },
+          { type: 'uint256' },
+          { type: 'address' },
+          { type: 'address' },
+          { type: 'uint256' },
+          { type: 'uint256' },
+          { type: 'uint256' },
+          { type: 'uint8' },
+          { type: 'uint8' },
+          { type: 'uint256' },
+          { type: 'bytes32' },
+          { type: 'bytes32' },
+        ],
+        [
+          ORDER_TYPE_HASH,
+          message.salt,
+          message.maker,
+          message.signer,
+          message.tokenId,
+          message.makerAmount,
+          message.takerAmount,
+          message.side,
+          message.signatureType,
+          message.timestamp,
+          message.metadata,
+          message.builder,
+        ],
+      ),
+      { as: 'Hex' },
+    ),
+  );
+}
+
+function decimalToE6(value: number, field: string): number {
+  if (decimalPlaces(value) > 6) {
+    throw new UserInputError(`${field} must have at most 6 decimal places.`);
+  }
+
+  const wireValue = parseAmount(value);
+
+  if (wireValue > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new UserInputError(`${field} is too large.`);
+  }
+
+  return Number(wireValue);
+}
+
+function ceilDiv(numerator: bigint, denominator: bigint): string {
+  return ((numerator + denominator - 1n) / denominator).toString();
+}
+
+function generateOrderSalt(): bigint {
+  const bytes = new Uint8Array(8);
+  globalThis.crypto.getRandomValues(bytes);
+
+  return BigInt(
+    `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`,
+  );
+}
+
+function createPending<T>(): PendingResponse<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -21,7 +21,7 @@ import {
   RfqConfirmationRejectedError,
   RfqQuoteRejectedError,
 } from '../../actions/rfq';
-import { TransportError, UserInputError } from '../../errors';
+import { TransportError } from '../../errors';
 import type { Signer } from '../../types';
 import type { AccountIdentity } from '../../wallet';
 import { WebSocketConnection } from '../lifecycle';
@@ -39,7 +39,7 @@ import {
   createQuoteMessage,
 } from './messages';
 import { PendingResponses } from './pending';
-import { createRfqQuote } from './quote';
+import { createRfqQuote, parseRfqQuoteResponse } from './quote';
 
 const AUTH_TIMEOUT_MS = 30_000;
 const ACK_TIMEOUT_MS = 30_000;
@@ -49,7 +49,7 @@ export type RfqQuoterWebSocketManagerOptions = {
   chainId: number;
   credentials: ApiKeyCreds;
   exchange: EvmAddress;
-  signer?: Signer;
+  signer: Signer;
   url: string;
 };
 
@@ -58,7 +58,7 @@ export class RfqQuoterWebSocketManager {
   readonly #chainId: number;
   readonly #credentials: ApiKeyCreds;
   readonly #exchange: EvmAddress;
-  readonly #signer: Signer | undefined;
+  readonly #signer: Signer;
   readonly #url: string;
   #session: RfqWebSocketSession | undefined;
   #connectingSession: RfqWebSocketSession | undefined;
@@ -76,11 +76,6 @@ export class RfqQuoterWebSocketManager {
   async connect(): Promise<RfqSession> {
     if (this.#session !== undefined) return this.#session;
     if (this.#connecting !== undefined) return this.#connecting;
-    if (this.#signer === undefined) {
-      throw new UserInputError(
-        'RFQ quoter sessions require a signer. Create a secure client with a signer to use openRfqSession().',
-      );
-    }
 
     const session = new RfqWebSocketSession({
       account: this.#account,
@@ -311,12 +306,13 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
     request: RfqQuoteRequest,
     response: RfqQuoteResponse,
   ): Promise<RfqQuoteAck> {
+    const parsedResponse = parseRfqQuoteResponse(response);
     const quote = await createRfqQuote({
       account: this.#account,
       chainId: this.#chainId,
       exchange: this.#exchange,
       request,
-      response,
+      response: parsedResponse,
       signer: this.#signer,
     });
     const pending = this.#pending.waitFor<RfqQuoteAck>(

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -1,6 +1,7 @@
 import type { ApiKeyCreds } from '@polymarket/bindings/clob';
 import {
   type RfqConfirmationDecision,
+  type RfqErrorMessage,
   type RfqId,
   type RfqQuoteId,
   type RfqQuoteRequest,
@@ -15,6 +16,10 @@ import type {
   RfqQuoteAck,
   RfqQuoteResponse,
   RfqSession,
+} from '../../actions/rfq';
+import {
+  RfqConfirmationRejectedError,
+  RfqQuoteRejectedError,
 } from '../../actions/rfq';
 import { TransportError, UserInputError } from '../../errors';
 import type { Signer } from '../../types';
@@ -254,7 +259,8 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
       case 'execution_update':
         this.#queue.push(toExecutionUpdateEvent(message));
         return;
-      case 'error':
+      case 'rfq_error':
+        this.#handleRfqError(message);
         return;
     }
   }
@@ -271,6 +277,34 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
 
   #handleClose(): void {
     void this.close();
+  }
+
+  #handleRfqError(message: RfqErrorMessage): void {
+    if (message.requestType === 'RFQ_QUOTE' && message.rfqId !== undefined) {
+      this.#pending.reject(
+        quoteAckKey(message.rfqId),
+        new RfqQuoteRejectedError(message.message, {
+          code: message.code,
+          rfqId: message.rfqId,
+        }),
+      );
+      return;
+    }
+
+    if (
+      message.requestType === 'RFQ_CONFIRMATION_RESPONSE' &&
+      message.rfqId !== undefined &&
+      message.quoteId !== undefined
+    ) {
+      this.#pending.reject(
+        confirmationAckKey(message.rfqId, message.quoteId),
+        new RfqConfirmationRejectedError(message.message, {
+          code: message.code,
+          quoteId: message.quoteId,
+          rfqId: message.rfqId,
+        }),
+      );
+    }
   }
 
   async quote(

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -1,169 +1,89 @@
-import {
-  OrderSide,
-  type PositionId,
-  PositiveDecimalNumberSchema,
-  toBaseUnits,
-} from '@polymarket/bindings';
 import type { ApiKeyCreds } from '@polymarket/bindings/clob';
-import { SignatureType } from '@polymarket/bindings/clob';
 import {
-  RfqConfirmationDecision,
-  type RfqConfirmationRequest,
-  RfqDirection,
-  type RfqExecutionUpdate,
+  type RfqConfirmationDecision,
   type RfqId,
   type RfqQuoteId,
   type RfqQuoteRequest,
   RfqQuoterInboundMessageSchema,
   type RfqQuoterOutboundMessage,
-  type RfqSignedOrder,
 } from '@polymarket/bindings/rfq';
-import {
-  type Erc1271Signature,
-  type EvmAddress,
-  type EvmSignature,
-  expectErc1271Signature,
-  expectHexString,
-  type HexString,
-  setNonBlockingTimeout,
-} from '@polymarket/types';
+import { type EvmAddress, setNonBlockingTimeout } from '@polymarket/types';
 import { type Pushable, pushable } from 'it-pushable';
-import { AbiParameters, Bytes, Hash } from 'ox';
-import { z } from 'zod';
-import { decimalPlaces, parseAmount } from '../../actions/orders/math';
 import type {
   RfqConfirmationAck,
-  RfqConfirmationRequestEvent,
   RfqEvent,
-  RfqExecutionUpdateEvent,
   RfqQuoteAck,
-  RfqQuoteRequestEvent,
   RfqQuoteResponse,
   RfqSession,
 } from '../../actions/rfq';
-import {
-  SigningError,
-  TimeoutError,
-  TransportError,
-  UserInputError,
-} from '../../errors';
-import { parseUserInput } from '../../input';
-import type { Signer, TypedDataPayload } from '../../types';
+import { TransportError, UserInputError } from '../../errors';
+import type { Signer } from '../../types';
 import type { AccountIdentity } from '../../wallet';
-import { toSignatureType } from '../../wallet';
 import { WebSocketConnection } from '../lifecycle';
+import {
+  type RfqEventController,
+  toConfirmationAck,
+  toConfirmationRequestEvent,
+  toExecutionUpdateEvent,
+  toQuoteAck,
+  toQuoteRequestEvent,
+} from './events';
+import {
+  createAuthMessage,
+  createConfirmationResponseMessage,
+  createQuoteMessage,
+} from './messages';
+import { PendingResponses } from './pending';
+import { createRfqQuote } from './quote';
 
 const AUTH_TIMEOUT_MS = 30_000;
 const ACK_TIMEOUT_MS = 30_000;
-const BYTES32_ZERO =
-  '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies HexString;
-const ORDER_TYPE_STRING =
-  'Order(uint256 salt,address maker,address signer,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,uint256 timestamp,bytes32 metadata,bytes32 builder)';
-const ORDER_TYPE_HASH = Hash.keccak256(Bytes.fromString(ORDER_TYPE_STRING), {
-  as: 'Hex',
-});
-const DOMAIN_TYPE_HASH = Hash.keccak256(
-  Bytes.fromString(
-    'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)',
-  ),
-  { as: 'Hex' },
-);
-const PROTOCOL_NAME = 'Polymarket CTF Exchange';
-const PROTOCOL_VERSION = '3';
-const PROTOCOL_NAME_HASH = Hash.keccak256(Bytes.fromString(PROTOCOL_NAME), {
-  as: 'Hex',
-});
-const PROTOCOL_VERSION_HASH = Hash.keccak256(
-  Bytes.fromString(PROTOCOL_VERSION),
-  { as: 'Hex' },
-);
-const DEPOSIT_WALLET_DOMAIN_NAME = 'DepositWallet';
-const DEPOSIT_WALLET_DOMAIN_VERSION = '1';
-const EIP712_DOMAIN = [
-  { name: 'name', type: 'string' },
-  { name: 'version', type: 'string' },
-  { name: 'chainId', type: 'uint256' },
-  { name: 'verifyingContract', type: 'address' },
-] as const;
-const ORDER_STRUCTURE = [
-  { name: 'salt', type: 'uint256' },
-  { name: 'maker', type: 'address' },
-  { name: 'signer', type: 'address' },
-  { name: 'tokenId', type: 'uint256' },
-  { name: 'makerAmount', type: 'uint256' },
-  { name: 'takerAmount', type: 'uint256' },
-  { name: 'side', type: 'uint8' },
-  { name: 'signatureType', type: 'uint8' },
-  { name: 'timestamp', type: 'uint256' },
-  { name: 'metadata', type: 'bytes32' },
-  { name: 'builder', type: 'bytes32' },
-] as const;
-const TYPED_DATA_SIGN_STRUCTURE = [
-  { name: 'contents', type: 'Order' },
-  { name: 'name', type: 'string' },
-  { name: 'version', type: 'string' },
-  { name: 'chainId', type: 'uint256' },
-  { name: 'verifyingContract', type: 'address' },
-  { name: 'salt', type: 'bytes32' },
-] as const;
-
-const RfqQuoteResponseSchema = z.strictObject({
-  price: PositiveDecimalNumberSchema.refine((price) => price < 1, {
-    message: 'Price must be less than 1.',
-  }),
-  size: PositiveDecimalNumberSchema.optional(),
-}) satisfies z.ZodType<RfqQuoteResponse>;
-
-type ApiKeyCredsProvider = () => ApiKeyCreds;
-type AccountProvider = () => AccountIdentity;
-type SignerProvider = () => Signer;
 
 export type RfqQuoterWebSocketManagerOptions = {
+  account: AccountIdentity;
   chainId: number;
-  exchangeV3: EvmAddress;
-  resolveAccount: AccountProvider;
-  resolveCredentials: ApiKeyCredsProvider;
-  resolveSigner: SignerProvider;
+  credentials: ApiKeyCreds;
+  exchange: EvmAddress;
+  signer?: Signer;
   url: string;
 };
 
-type PendingResponse<T> = {
-  promise: Promise<T>;
-  reject(error: Error): void;
-  resolve(value: T): void;
-};
-
 export class RfqQuoterWebSocketManager {
-  readonly #resolveAccount: AccountProvider;
-  readonly #resolveCredentials: ApiKeyCredsProvider;
-  readonly #resolveSigner: SignerProvider;
+  readonly #account: AccountIdentity;
   readonly #chainId: number;
-  readonly #exchangeV3: EvmAddress;
+  readonly #credentials: ApiKeyCreds;
+  readonly #exchange: EvmAddress;
+  readonly #signer: Signer | undefined;
   readonly #url: string;
   #session: RfqWebSocketSession | undefined;
   #connectingSession: RfqWebSocketSession | undefined;
   #connecting: Promise<RfqSession> | undefined;
 
   constructor(options: RfqQuoterWebSocketManagerOptions) {
+    this.#account = options.account;
     this.#chainId = options.chainId;
-    this.#exchangeV3 = options.exchangeV3;
-    this.#resolveAccount = options.resolveAccount;
-    this.#resolveCredentials = options.resolveCredentials;
-    this.#resolveSigner = options.resolveSigner;
+    this.#credentials = options.credentials;
+    this.#exchange = options.exchange;
+    this.#signer = options.signer;
     this.#url = options.url;
   }
 
   async connect(): Promise<RfqSession> {
     if (this.#session !== undefined) return this.#session;
     if (this.#connecting !== undefined) return this.#connecting;
+    if (this.#signer === undefined) {
+      throw new UserInputError(
+        'RFQ quoter sessions require a signer. Create a secure client with a signer to use openRfqSession().',
+      );
+    }
 
     const session = new RfqWebSocketSession({
-      account: this.#resolveAccount(),
+      account: this.#account,
       chainId: this.#chainId,
-      credentials: this.#resolveCredentials(),
-      exchangeV3: this.#exchangeV3,
+      credentials: this.#credentials,
+      exchange: this.#exchange,
       onClose: () => this.#clearSession(session),
-      signer: this.#resolveSigner(),
+      signer: this.#signer,
       url: this.#url,
     });
     this.#connectingSession = session;
@@ -217,35 +137,35 @@ export class RfqQuoterWebSocketManager {
   }
 }
 
-type RfqWebSocketSessionOptions = {
+type RfqWebSocketSessionConfig = {
   account: AccountIdentity;
   chainId: number;
   credentials: ApiKeyCreds;
-  exchangeV3: EvmAddress;
+  exchange: EvmAddress;
   onClose: () => void;
   signer: Signer;
   url: string;
 };
 
-class RfqWebSocketSession implements RfqSession {
+class RfqWebSocketSession implements RfqSession, RfqEventController {
   readonly #account: AccountIdentity;
   readonly #chainId: number;
   readonly #credentials: ApiKeyCreds;
-  readonly #exchangeV3: EvmAddress;
+  readonly #exchange: EvmAddress;
   readonly #onClose: () => void;
   readonly #signer: Signer;
   readonly #url: string;
   readonly #connection = new WebSocketConnection();
   readonly #queue: Pushable<RfqEvent> = pushable({ objectMode: true });
-  readonly #pending = new Map<string, PendingResponse<unknown>[]>();
+  readonly #pending = new PendingResponses(ACK_TIMEOUT_MS);
   #closing: Promise<void> | undefined;
   #auth: PendingResponse<void> | undefined;
 
-  constructor(options: RfqWebSocketSessionOptions) {
+  constructor(options: RfqWebSocketSessionConfig) {
     this.#account = options.account;
     this.#chainId = options.chainId;
     this.#credentials = options.credentials;
-    this.#exchangeV3 = options.exchangeV3;
+    this.#exchange = options.exchange;
     this.#onClose = options.onClose;
     this.#signer = options.signer;
     this.#url = options.url;
@@ -279,62 +199,6 @@ class RfqWebSocketSession implements RfqSession {
     }
   }
 
-  async quote(
-    request: RfqQuoteRequest,
-    response: RfqQuoteResponse,
-  ): Promise<RfqQuoteAck> {
-    const params = parseUserInput(response, RfqQuoteResponseSchema);
-    const quote = await createRfqQuote({
-      account: this.#account,
-      chainId: this.#chainId,
-      exchangeV3: this.#exchangeV3,
-      request,
-      response: params,
-      signer: this.#signer,
-    });
-    const pending = this.#waitFor<RfqQuoteAck>(
-      quoteAckKey(request.rfqId),
-      `Timed out waiting for RFQ quote acknowledgement for ${request.rfqId}.`,
-    );
-    try {
-      await this.#send({
-        price_e6: quote.priceE6,
-        rfq_id: request.rfqId,
-        signed_order: quote.signedOrder,
-        size_e6: quote.sizeE6,
-        type: 'RFQ_QUOTE',
-      });
-      return await pending;
-    } catch (error) {
-      this.#removePending(quoteAckKey(request.rfqId), pending);
-      throw error;
-    }
-  }
-
-  async respondToConfirmation(
-    rfqId: RfqId,
-    quoteId: RfqQuoteId,
-    decision: RfqConfirmationDecision,
-  ): Promise<RfqConfirmationAck> {
-    const key = confirmationAckKey(rfqId, quoteId);
-    const pending = this.#waitFor<RfqConfirmationAck>(
-      key,
-      `Timed out waiting for RFQ confirmation acknowledgement for ${rfqId}.`,
-    );
-    try {
-      await this.#send({
-        decision,
-        quote_id: quoteId,
-        rfq_id: rfqId,
-        type: 'RFQ_CONFIRMATION_RESPONSE',
-      });
-      return await pending;
-    } catch (error) {
-      this.#removePending(key, pending);
-      throw error;
-    }
-  }
-
   async close(): Promise<void> {
     if (this.#closing === undefined) {
       this.#closing = this.#shutdown();
@@ -347,26 +211,14 @@ class RfqWebSocketSession implements RfqSession {
   }
 
   async #shutdown(): Promise<void> {
-    this.#rejectPending(new TransportError('RFQ quoter websocket closed.'));
+    this.#pending.rejectAll(new TransportError('RFQ quoter websocket closed.'));
     this.#queue.end();
     await this.#connection.close();
     this.#onClose();
   }
 
   #sendAuthMessage(): void {
-    this.#connection.send({
-      auth: {
-        apiKey: this.#credentials.key,
-        passphrase: this.#credentials.passphrase,
-        secret: this.#credentials.secret,
-      },
-      identity: {
-        maker_address: this.#account.wallet,
-        signature_type: toSignatureType(this.#account.walletType),
-        signer_address: this.#account.signer,
-      },
-      type: 'auth',
-    });
+    this.#connection.send(createAuthMessage(this.#account, this.#credentials));
   }
 
   #handleMessage(rawMessage: unknown): void {
@@ -375,7 +227,7 @@ class RfqWebSocketSession implements RfqSession {
       const error = new TransportError('Invalid RFQ quoter message.', {
         cause: parsed.error,
       });
-      this.#rejectPending(error);
+      this.#pending.rejectAll(error);
       return;
     }
 
@@ -388,13 +240,13 @@ class RfqWebSocketSession implements RfqSession {
         this.#queue.push(toQuoteRequestEvent(this, message));
         return;
       case 'quote_ack':
-        this.#resolvePending(quoteAckKey(message.rfqId), toQuoteAck(message));
+        this.#pending.resolve(quoteAckKey(message.rfqId), toQuoteAck(message));
         return;
       case 'confirmation_request':
         this.#queue.push(toConfirmationRequestEvent(this, message));
         return;
       case 'confirmation_ack':
-        this.#resolvePending(
+        this.#pending.resolve(
           confirmationAckKey(message.rfqId, message.quoteId),
           toConfirmationAck(message),
         );
@@ -421,419 +273,66 @@ class RfqWebSocketSession implements RfqSession {
     void this.close();
   }
 
-  #waitFor<T>(key: string, timeoutMessage: string): Promise<T> {
-    const pending = createPending<T>();
-    let promise!: Promise<T>;
-    const timeout = setNonBlockingTimeout(() => {
-      this.#removePending(key, promise);
-      pending.reject(new TimeoutError(timeoutMessage));
-    }, ACK_TIMEOUT_MS);
-    promise = pending.promise.finally(() => clearTimeout(timeout));
-    const entries = this.#pending.get(key) ?? [];
-    entries.push({ ...pending, promise } as PendingResponse<unknown>);
-    this.#pending.set(key, entries);
-    return promise;
-  }
-
-  #resolvePending<T>(key: string, value: T): void {
-    const entries = this.#pending.get(key);
-    const pending = entries?.shift();
-    if (pending === undefined) return;
-    if (entries !== undefined && entries.length === 0) {
-      this.#pending.delete(key);
-    }
-    pending.resolve(value);
-  }
-
-  #removePending<T>(key: string, promise: Promise<T>): void {
-    const entries = this.#pending.get(key);
-    if (entries === undefined) return;
-    const remaining = entries.filter((entry) => entry.promise !== promise);
-    if (remaining.length === 0) {
-      this.#pending.delete(key);
-    } else {
-      this.#pending.set(key, remaining);
+  async quote(
+    request: RfqQuoteRequest,
+    response: RfqQuoteResponse,
+  ): Promise<RfqQuoteAck> {
+    const quote = await createRfqQuote({
+      account: this.#account,
+      chainId: this.#chainId,
+      exchange: this.#exchange,
+      request,
+      response,
+      signer: this.#signer,
+    });
+    const pending = this.#pending.waitFor<RfqQuoteAck>(
+      quoteAckKey(request.rfqId),
+      `Timed out waiting for RFQ quote acknowledgement for ${request.rfqId}.`,
+    );
+    try {
+      await this.#send(createQuoteMessage(request, quote));
+      return await pending;
+    } catch (error) {
+      this.#pending.remove(quoteAckKey(request.rfqId), pending);
+      throw error;
     }
   }
 
-  #rejectPending(error: Error): void {
-    for (const entries of this.#pending.values()) {
-      for (const pending of entries) {
-        pending.reject(error);
-      }
+  async respondToConfirmation(
+    rfqId: RfqId,
+    quoteId: RfqQuoteId,
+    decision: RfqConfirmationDecision,
+  ): Promise<RfqConfirmationAck> {
+    const key = confirmationAckKey(rfqId, quoteId);
+    const pending = this.#pending.waitFor<RfqConfirmationAck>(
+      key,
+      `Timed out waiting for RFQ confirmation acknowledgement for ${rfqId}.`,
+    );
+    try {
+      await this.#send(
+        createConfirmationResponseMessage(rfqId, quoteId, decision),
+      );
+      return await pending;
+    } catch (error) {
+      this.#pending.remove(key, pending);
+      throw error;
     }
-    this.#pending.clear();
   }
 }
 
-function toQuoteRequestEvent(
-  session: RfqWebSocketSession,
-  message: RfqQuoteRequest,
-): RfqQuoteRequestEvent {
-  return {
-    ...message,
-    quote: (request) => session.quote(message, request),
-  };
-}
-
-function toConfirmationRequestEvent(
-  session: RfqWebSocketSession,
-  message: RfqConfirmationRequest,
-): RfqConfirmationRequestEvent {
-  const rfqId = message.rfqId;
-  const quoteId = message.quoteId;
-  return {
-    ...message,
-    confirm: () =>
-      session.respondToConfirmation(
-        rfqId,
-        quoteId,
-        RfqConfirmationDecision.Confirm,
-      ),
-    decline: () =>
-      session.respondToConfirmation(
-        rfqId,
-        quoteId,
-        RfqConfirmationDecision.Decline,
-      ),
-  };
-}
-
-function toExecutionUpdateEvent(
-  message: RfqExecutionUpdate,
-): RfqExecutionUpdateEvent {
-  return message;
-}
-
-function toQuoteAck(message: {
-  quoteId: RfqQuoteId;
-  rfqId: RfqId;
-}): RfqQuoteAck {
-  return {
-    quoteId: message.quoteId,
-    rfqId: message.rfqId,
-  };
-}
-
-function toConfirmationAck(message: {
-  quoteId: RfqQuoteId;
-  rfqId: RfqId;
-}): RfqConfirmationAck {
-  return {
-    quoteId: message.quoteId,
-    rfqId: message.rfqId,
-  };
-}
-
-function quoteAckKey(rfqId: string): string {
+function quoteAckKey(rfqId: RfqId): string {
   return `ACK_RFQ_QUOTE:${rfqId}`;
 }
 
-function confirmationAckKey(rfqId: string, quoteId: string): string {
+function confirmationAckKey(rfqId: RfqId, quoteId: RfqQuoteId): string {
   return `ACK_RFQ_CONFIRMATION_RESPONSE:${rfqId}:${quoteId}`;
 }
 
-type RfqQuoteParams = {
-  price: number;
-  size?: number;
+type PendingResponse<T> = {
+  promise: Promise<T>;
+  reject(error: Error): void;
+  resolve(value: T): void;
 };
-
-type CreateRfqQuoteParams = {
-  account: AccountIdentity;
-  chainId: number;
-  exchangeV3: EvmAddress;
-  request: RfqQuoteRequest;
-  response: RfqQuoteParams;
-  signer: Signer;
-};
-
-async function createRfqQuote(params: CreateRfqQuoteParams): Promise<{
-  priceE6: number;
-  signedOrder: RfqSignedOrder;
-  sizeE6: number;
-}> {
-  const priceE6 = decimalToE6(params.response.price, 'RFQ quote price');
-  const size = params.response.size ?? Number(params.request.size);
-  const sizeE6 = decimalToE6(size, 'RFQ quote size');
-  const signedOrder = await signRfqQuoteOrder({
-    account: params.account,
-    chainId: params.chainId,
-    exchangeV3: params.exchangeV3,
-    orderPriceE6: orderPriceE6(params.request, priceE6),
-    signer: params.signer,
-    sizeE6,
-    tokenId: quoteOrderTokenId(params.request),
-  });
-
-  return { priceE6, signedOrder, sizeE6 };
-}
-
-type SignRfqQuoteOrderParams = {
-  account: AccountIdentity;
-  chainId: number;
-  exchangeV3: EvmAddress;
-  orderPriceE6: number;
-  signer: Signer;
-  sizeE6: number;
-  tokenId: PositionId;
-};
-
-async function signRfqQuoteOrder(
-  params: SignRfqQuoteOrderParams,
-): Promise<RfqSignedOrder> {
-  const signatureType = toSignatureType(params.account.walletType);
-  const order: Omit<RfqSignedOrder, 'signature'> = {
-    builder: BYTES32_ZERO,
-    maker: params.account.wallet,
-    makerAmount: toBaseUnits(
-      ceilDiv(BigInt(params.orderPriceE6) * BigInt(params.sizeE6), 1_000_000n),
-    ),
-    metadata: BYTES32_ZERO,
-    salt: generateOrderSalt().toString(),
-    side: 0,
-    signatureType,
-    signer: params.account.signer,
-    takerAmount: toBaseUnits(String(params.sizeE6)),
-    timestamp: Math.floor(Date.now() / 1000).toString(),
-    tokenId: params.tokenId,
-  };
-
-  let signature: EvmSignature;
-  try {
-    signature = await params.signer.signTypedData(
-      createRfqOrderTypedDataPayload(params.chainId, params.exchangeV3, order),
-    );
-  } catch (error) {
-    throw SigningError.fromError(error, 'Could not sign the RFQ quote order.');
-  }
-
-  return {
-    ...order,
-    signature: createRfqOrderSignature(
-      params.chainId,
-      params.exchangeV3,
-      order,
-      signature,
-    ),
-  };
-}
-
-function quoteOrderTokenId(request: RfqQuoteRequest): PositionId {
-  return request.direction === RfqDirection.Buy
-    ? request.noPositionId
-    : request.yesPositionId;
-}
-
-function orderPriceE6(request: RfqQuoteRequest, priceE6: number): number {
-  return request.direction === RfqDirection.Buy ? 1_000_000 - priceE6 : priceE6;
-}
-
-function createRfqOrderTypedDataPayload(
-  chainId: number,
-  exchangeV3: EvmAddress,
-  order: Omit<RfqSignedOrder, 'signature'>,
-): TypedDataPayload {
-  const orderPayload = createLegacyRfqOrderTypedDataPayload(
-    chainId,
-    exchangeV3,
-    order,
-  );
-
-  if (order.signatureType !== SignatureType.POLY_1271) {
-    return orderPayload;
-  }
-
-  return {
-    domain: {
-      chainId,
-      name: PROTOCOL_NAME,
-      verifyingContract: exchangeV3,
-      version: PROTOCOL_VERSION,
-    },
-    message: {
-      chainId,
-      contents: orderPayload.message,
-      name: DEPOSIT_WALLET_DOMAIN_NAME,
-      salt: BYTES32_ZERO,
-      verifyingContract: order.maker,
-      version: DEPOSIT_WALLET_DOMAIN_VERSION,
-    },
-    primaryType: 'TypedDataSign',
-    types: {
-      Order: ORDER_STRUCTURE,
-      TypedDataSign: TYPED_DATA_SIGN_STRUCTURE,
-    },
-  };
-}
-
-function createLegacyRfqOrderTypedDataPayload(
-  chainId: number,
-  exchangeV3: EvmAddress,
-  order: Omit<RfqSignedOrder, 'signature'>,
-): TypedDataPayload {
-  return {
-    domain: {
-      chainId,
-      name: PROTOCOL_NAME,
-      verifyingContract: exchangeV3,
-      version: PROTOCOL_VERSION,
-    },
-    message: createRfqOrderTypedDataMessage(order),
-    primaryType: 'Order',
-    types: {
-      EIP712Domain: EIP712_DOMAIN,
-      Order: ORDER_STRUCTURE,
-    },
-  };
-}
-
-type RfqOrderTypedDataMessage = {
-  builder: HexString;
-  maker: EvmAddress;
-  makerAmount: bigint;
-  metadata: HexString;
-  salt: bigint;
-  side: number;
-  signatureType: SignatureType;
-  signer: EvmAddress;
-  takerAmount: bigint;
-  timestamp: bigint;
-  tokenId: bigint;
-};
-
-function createRfqOrderTypedDataMessage(
-  order: Omit<RfqSignedOrder, 'signature'>,
-): RfqOrderTypedDataMessage {
-  return {
-    builder: order.builder ?? BYTES32_ZERO,
-    maker: order.maker,
-    makerAmount: BigInt(order.makerAmount),
-    metadata: order.metadata ?? BYTES32_ZERO,
-    salt: BigInt(order.salt),
-    side: OrderSide.BUY === order.side ? 0 : Number(order.side),
-    signatureType: order.signatureType,
-    signer: order.signer,
-    takerAmount: BigInt(order.takerAmount),
-    timestamp: BigInt(order.timestamp),
-    tokenId: BigInt(order.tokenId),
-  };
-}
-
-function createRfqOrderSignature(
-  chainId: number,
-  exchangeV3: EvmAddress,
-  order: Omit<RfqSignedOrder, 'signature'>,
-  signature: EvmSignature,
-): EvmSignature | Erc1271Signature {
-  if (order.signatureType !== SignatureType.POLY_1271) {
-    return signature;
-  }
-
-  const contentsType = Bytes.toHex(Bytes.fromString(ORDER_TYPE_STRING));
-  const contentsTypeLength = ORDER_TYPE_STRING.length
-    .toString(16)
-    .padStart(4, '0');
-
-  return expectErc1271Signature(
-    `0x${signature.slice(2)}${createAppDomainSeparator(chainId, exchangeV3).slice(2)}${createOrderContentsHash(order).slice(2)}${contentsType.slice(2)}${contentsTypeLength}`,
-  );
-}
-
-function createAppDomainSeparator(
-  chainId: number,
-  exchangeV3: EvmAddress,
-): HexString {
-  return expectHexString(
-    Hash.keccak256(
-      AbiParameters.encode(
-        [
-          { type: 'bytes32' },
-          { type: 'bytes32' },
-          { type: 'bytes32' },
-          { type: 'uint256' },
-          { type: 'address' },
-        ],
-        [
-          DOMAIN_TYPE_HASH,
-          PROTOCOL_NAME_HASH,
-          PROTOCOL_VERSION_HASH,
-          BigInt(chainId),
-          exchangeV3,
-        ],
-      ),
-      { as: 'Hex' },
-    ),
-  );
-}
-
-function createOrderContentsHash(
-  order: Omit<RfqSignedOrder, 'signature'>,
-): HexString {
-  const message = createRfqOrderTypedDataMessage(order);
-
-  return expectHexString(
-    Hash.keccak256(
-      AbiParameters.encode(
-        [
-          { type: 'bytes32' },
-          { type: 'uint256' },
-          { type: 'address' },
-          { type: 'address' },
-          { type: 'uint256' },
-          { type: 'uint256' },
-          { type: 'uint256' },
-          { type: 'uint8' },
-          { type: 'uint8' },
-          { type: 'uint256' },
-          { type: 'bytes32' },
-          { type: 'bytes32' },
-        ],
-        [
-          ORDER_TYPE_HASH,
-          message.salt,
-          message.maker,
-          message.signer,
-          message.tokenId,
-          message.makerAmount,
-          message.takerAmount,
-          message.side,
-          message.signatureType,
-          message.timestamp,
-          message.metadata,
-          message.builder,
-        ],
-      ),
-      { as: 'Hex' },
-    ),
-  );
-}
-
-function decimalToE6(value: number, field: string): number {
-  if (decimalPlaces(value) > 6) {
-    throw new UserInputError(`${field} must have at most 6 decimal places.`);
-  }
-
-  const wireValue = parseAmount(value);
-
-  if (wireValue > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new UserInputError(`${field} is too large.`);
-  }
-
-  return Number(wireValue);
-}
-
-function ceilDiv(numerator: bigint, denominator: bigint): string {
-  return ((numerator + denominator - 1n) / denominator).toString();
-}
-
-function generateOrderSalt(): bigint {
-  const bytes = new Uint8Array(8);
-  globalThis.crypto.getRandomValues(bytes);
-
-  return BigInt(
-    `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`,
-  );
-}
 
 function createPending<T>(): PendingResponse<T> {
   let resolve!: (value: T) => void;

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -53,6 +53,7 @@ export type RfqQuoterWebSocketManagerOptions = {
   chainId: number;
   credentials: ApiKeyCreds;
   exchange: EvmAddress;
+  headers?: Record<string, string>;
   signer: Signer;
   url: string;
 };
@@ -62,6 +63,7 @@ export class RfqQuoterWebSocketManager {
   readonly #chainId: number;
   readonly #credentials: ApiKeyCreds;
   readonly #exchange: EvmAddress;
+  readonly #headers: Record<string, string> | undefined;
   readonly #signer: Signer;
   readonly #url: string;
   #session: RfqWebSocketSession | undefined;
@@ -73,6 +75,7 @@ export class RfqQuoterWebSocketManager {
     this.#chainId = options.chainId;
     this.#credentials = options.credentials;
     this.#exchange = options.exchange;
+    this.#headers = options.headers;
     this.#signer = options.signer;
     this.#url = options.url;
   }
@@ -86,6 +89,7 @@ export class RfqQuoterWebSocketManager {
       chainId: this.#chainId,
       credentials: this.#credentials,
       exchange: this.#exchange,
+      headers: this.#headers,
       onClose: () => this.#clearSession(session),
       signer: this.#signer,
       url: this.#url,
@@ -146,6 +150,7 @@ type RfqWebSocketSessionConfig = {
   chainId: number;
   credentials: ApiKeyCreds;
   exchange: EvmAddress;
+  headers?: Record<string, string>;
   onClose: () => void;
   signer: Signer;
   url: string;
@@ -156,6 +161,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
   readonly #chainId: number;
   readonly #credentials: ApiKeyCreds;
   readonly #exchange: EvmAddress;
+  readonly #headers: Record<string, string> | undefined;
   readonly #onClose: () => void;
   readonly #signer: Signer;
   readonly #url: string;
@@ -170,6 +176,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
     this.#chainId = options.chainId;
     this.#credentials = options.credentials;
     this.#exchange = options.exchange;
+    this.#headers = options.headers;
     this.#onClose = options.onClose;
     this.#signer = options.signer;
     this.#url = options.url;
@@ -184,6 +191,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
 
     try {
       await this.#connection.connect({
+        headers: this.#headers,
         onClose: () => this.#handleClose(),
         onError: () => undefined,
         onMessage: (message) => this.#handleMessage(message),

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -1,5 +1,6 @@
 import {
   OrderSide,
+  type PositionId,
   PositiveDecimalNumberSchema,
   toBaseUnits,
 } from '@polymarket/bindings';
@@ -10,6 +11,8 @@ import {
   type RfqConfirmationRequest,
   RfqDirection,
   type RfqExecutionUpdate,
+  type RfqId,
+  type RfqQuoteId,
   type RfqQuoteRequest,
   RfqQuoterInboundMessageSchema,
   type RfqQuoterOutboundMessage,
@@ -38,7 +41,12 @@ import type {
   RfqQuoteResponse,
   RfqSession,
 } from '../../actions/rfq';
-import { SigningError, TransportError, UserInputError } from '../../errors';
+import {
+  SigningError,
+  TimeoutError,
+  TransportError,
+  UserInputError,
+} from '../../errors';
 import { parseUserInput } from '../../input';
 import type { Signer, TypedDataPayload } from '../../types';
 import type { AccountIdentity } from '../../wallet';
@@ -46,6 +54,7 @@ import { toSignatureType } from '../../wallet';
 import { WebSocketConnection } from '../lifecycle';
 
 const AUTH_TIMEOUT_MS = 30_000;
+const ACK_TIMEOUT_MS = 30_000;
 const BYTES32_ZERO =
   '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies HexString;
 const ORDER_TYPE_STRING =
@@ -283,7 +292,10 @@ class RfqWebSocketSession implements RfqSession {
       response: params,
       signer: this.#signer,
     });
-    const pending = this.#waitFor<RfqQuoteAck>(quoteAckKey(request.rfqId));
+    const pending = this.#waitFor<RfqQuoteAck>(
+      quoteAckKey(request.rfqId),
+      `Timed out waiting for RFQ quote acknowledgement for ${request.rfqId}.`,
+    );
     try {
       await this.#send({
         price_e6: quote.priceE6,
@@ -300,12 +312,15 @@ class RfqWebSocketSession implements RfqSession {
   }
 
   async respondToConfirmation(
-    rfqId: RfqConfirmationAck['rfqId'],
-    quoteId: RfqConfirmationAck['quoteId'],
-    decision: RfqConfirmationAck['decision'],
+    rfqId: RfqId,
+    quoteId: RfqQuoteId,
+    decision: RfqConfirmationDecision,
   ): Promise<RfqConfirmationAck> {
     const key = confirmationAckKey(rfqId, quoteId);
-    const pending = this.#waitFor<RfqConfirmationAck>(key);
+    const pending = this.#waitFor<RfqConfirmationAck>(
+      key,
+      `Timed out waiting for RFQ confirmation acknowledgement for ${rfqId}.`,
+    );
     try {
       await this.#send({
         decision,
@@ -373,7 +388,7 @@ class RfqWebSocketSession implements RfqSession {
         this.#queue.push(toQuoteRequestEvent(this, message));
         return;
       case 'quote_ack':
-        this.#resolvePending(quoteAckKey(message.rfqId), message);
+        this.#resolvePending(quoteAckKey(message.rfqId), toQuoteAck(message));
         return;
       case 'confirmation_request':
         this.#queue.push(toConfirmationRequestEvent(this, message));
@@ -381,7 +396,7 @@ class RfqWebSocketSession implements RfqSession {
       case 'confirmation_ack':
         this.#resolvePending(
           confirmationAckKey(message.rfqId, message.quoteId),
-          message,
+          toConfirmationAck(message),
         );
         return;
       case 'execution_update':
@@ -406,12 +421,18 @@ class RfqWebSocketSession implements RfqSession {
     void this.close();
   }
 
-  #waitFor<T>(key: string): Promise<T> {
+  #waitFor<T>(key: string, timeoutMessage: string): Promise<T> {
     const pending = createPending<T>();
+    let promise!: Promise<T>;
+    const timeout = setNonBlockingTimeout(() => {
+      this.#removePending(key, promise);
+      pending.reject(new TimeoutError(timeoutMessage));
+    }, ACK_TIMEOUT_MS);
+    promise = pending.promise.finally(() => clearTimeout(timeout));
     const entries = this.#pending.get(key) ?? [];
-    entries.push(pending as PendingResponse<unknown>);
+    entries.push({ ...pending, promise } as PendingResponse<unknown>);
     this.#pending.set(key, entries);
-    return pending.promise;
+    return promise;
   }
 
   #resolvePending<T>(key: string, value: T): void {
@@ -484,6 +505,26 @@ function toExecutionUpdateEvent(
   return message;
 }
 
+function toQuoteAck(message: {
+  quoteId: RfqQuoteId;
+  rfqId: RfqId;
+}): RfqQuoteAck {
+  return {
+    quoteId: message.quoteId,
+    rfqId: message.rfqId,
+  };
+}
+
+function toConfirmationAck(message: {
+  quoteId: RfqQuoteId;
+  rfqId: RfqId;
+}): RfqConfirmationAck {
+  return {
+    quoteId: message.quoteId,
+    rfqId: message.rfqId,
+  };
+}
+
 function quoteAckKey(rfqId: string): string {
   return `ACK_RFQ_QUOTE:${rfqId}`;
 }
@@ -534,7 +575,7 @@ type SignRfqQuoteOrderParams = {
   orderPriceE6: number;
   signer: Signer;
   sizeE6: number;
-  tokenId: RfqQuoteRequest['yesPositionId'];
+  tokenId: PositionId;
 };
 
 async function signRfqQuoteOrder(
@@ -577,9 +618,7 @@ async function signRfqQuoteOrder(
   };
 }
 
-function quoteOrderTokenId(
-  request: RfqQuoteRequest,
-): RfqQuoteRequest['yesPositionId'] {
+function quoteOrderTokenId(request: RfqQuoteRequest): PositionId {
   return request.direction === RfqDirection.Buy
     ? request.noPositionId
     : request.yesPositionId;

--- a/packages/client/src/websockets/rfq/signing.ts
+++ b/packages/client/src/websockets/rfq/signing.ts
@@ -1,0 +1,113 @@
+import { OrderSide, type PositionId, toBaseUnits } from '@polymarket/bindings';
+import type { RfqSignedOrder } from '@polymarket/bindings/rfq';
+import type { EvmAddress, EvmSignature, HexString } from '@polymarket/types';
+import { SigningError } from '../../errors';
+import {
+  createExchangeOrderSignature,
+  createExchangeOrderTypedDataPayload,
+  ExchangeOrderProtocolVersion,
+} from '../../exchange';
+import type { Signer } from '../../types';
+import type { AccountIdentity } from '../../wallet';
+import { resolveOrderIdentity } from '../../wallet';
+
+const BYTES32_ZERO =
+  '0x0000000000000000000000000000000000000000000000000000000000000000' satisfies HexString;
+
+export type SignRfqQuoteOrderParams = {
+  account: AccountIdentity;
+  chainId: number;
+  exchange: EvmAddress;
+  orderPriceE6: number;
+  orderSide: OrderSide;
+  signer: Signer;
+  sizeE6: number;
+  tokenId: PositionId;
+};
+
+export async function signRfqQuoteOrder(
+  params: SignRfqQuoteOrderParams,
+): Promise<RfqSignedOrder> {
+  const identity = resolveOrderIdentity(params.account);
+  const order: Omit<RfqSignedOrder, 'signature'> = {
+    builder: BYTES32_ZERO,
+    maker: identity.maker,
+    makerAmount: toBaseUnits(
+      makerAmount(params.orderSide, params.orderPriceE6, params.sizeE6),
+    ),
+    metadata: BYTES32_ZERO,
+    salt: generateOrderSalt().toString(),
+    side: encodeOrderSide(params.orderSide),
+    signatureType: identity.signatureType,
+    signer: identity.signer,
+    takerAmount: toBaseUnits(
+      takerAmount(params.orderSide, params.orderPriceE6, params.sizeE6),
+    ),
+    timestamp: Math.floor(Date.now() / 1000).toString(),
+    tokenId: params.tokenId,
+  };
+
+  let signature: EvmSignature;
+  try {
+    signature = await params.signer.signTypedData(
+      createExchangeOrderTypedDataPayload({
+        domain: createRfqExchangeDomain(params),
+        order,
+      }),
+    );
+  } catch (error) {
+    throw SigningError.fromError(error, 'Could not sign the RFQ quote order.');
+  }
+
+  return {
+    ...order,
+    signature: createExchangeOrderSignature({
+      domain: createRfqExchangeDomain(params),
+      order,
+      signature,
+    }),
+  };
+}
+
+function createRfqExchangeDomain(params: SignRfqQuoteOrderParams) {
+  return {
+    chainId: params.chainId,
+    exchange: params.exchange,
+    protocolVersion: ExchangeOrderProtocolVersion.V3,
+  };
+}
+
+function ceilDiv(numerator: bigint, denominator: bigint): string {
+  return ((numerator + denominator - 1n) / denominator).toString();
+}
+
+function floorDiv(numerator: bigint, denominator: bigint): string {
+  return (numerator / denominator).toString();
+}
+
+function makerAmount(side: OrderSide, priceE6: number, sizeE6: number): string {
+  if (side === OrderSide.SELL) return String(sizeE6);
+
+  return ceilDiv(BigInt(priceE6) * BigInt(sizeE6), 1_000_000n);
+}
+
+function takerAmount(side: OrderSide, priceE6: number, sizeE6: number): string {
+  if (side === OrderSide.SELL) {
+    return floorDiv(BigInt(priceE6) * BigInt(sizeE6), 1_000_000n);
+  }
+
+  return String(sizeE6);
+}
+
+function encodeOrderSide(side: OrderSide): 0 | 1 {
+  return side === OrderSide.BUY ? 0 : 1;
+}
+
+function generateOrderSalt(): bigint {
+  const bytes = new Uint8Array(8);
+  globalThis.crypto.getRandomValues(bytes);
+
+  return BigInt(
+    `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`,
+  );
+}

--- a/packages/client/src/websockets/rfq/signing.ts
+++ b/packages/client/src/websockets/rfq/signing.ts
@@ -18,10 +18,10 @@ export type SignRfqQuoteOrderParams = {
   account: AccountIdentity;
   chainId: number;
   exchange: EvmAddress;
-  orderPriceE6: number;
+  orderPrice: bigint;
   orderSide: OrderSide;
   signer: Signer;
-  sizeE6: number;
+  size: bigint;
   tokenId: PositionId;
 };
 
@@ -33,7 +33,7 @@ export async function signRfqQuoteOrder(
     builder: BYTES32_ZERO,
     maker: identity.maker,
     makerAmount: toBaseUnits(
-      makerAmount(params.orderSide, params.orderPriceE6, params.sizeE6),
+      makerAmount(params.orderSide, params.orderPrice, params.size),
     ),
     metadata: BYTES32_ZERO,
     salt: generateOrderSalt().toString(),
@@ -41,7 +41,7 @@ export async function signRfqQuoteOrder(
     signatureType: identity.signatureType,
     signer: identity.signer,
     takerAmount: toBaseUnits(
-      takerAmount(params.orderSide, params.orderPriceE6, params.sizeE6),
+      takerAmount(params.orderSide, params.orderPrice, params.size),
     ),
     timestamp: Math.floor(Date.now() / 1000).toString(),
     tokenId: params.tokenId,
@@ -77,26 +77,18 @@ function createRfqExchangeDomain(params: SignRfqQuoteOrderParams) {
   };
 }
 
-function ceilDiv(numerator: bigint, denominator: bigint): string {
-  return ((numerator + denominator - 1n) / denominator).toString();
+function makerAmount(side: OrderSide, price: bigint, size: bigint): string {
+  if (side === OrderSide.SELL) return size.toString();
+
+  return ((price * size + 999_999n) / 1_000_000n).toString();
 }
 
-function floorDiv(numerator: bigint, denominator: bigint): string {
-  return (numerator / denominator).toString();
-}
-
-function makerAmount(side: OrderSide, priceE6: number, sizeE6: number): string {
-  if (side === OrderSide.SELL) return String(sizeE6);
-
-  return ceilDiv(BigInt(priceE6) * BigInt(sizeE6), 1_000_000n);
-}
-
-function takerAmount(side: OrderSide, priceE6: number, sizeE6: number): string {
+function takerAmount(side: OrderSide, price: bigint, size: bigint): string {
   if (side === OrderSide.SELL) {
-    return floorDiv(BigInt(priceE6) * BigInt(sizeE6), 1_000_000n);
+    return ((price * size) / 1_000_000n).toString();
   }
 
-  return String(sizeE6);
+  return size.toString();
 }
 
 function encodeOrderSide(side: OrderSide): 0 | 1 {

--- a/packages/client/src/websockets/rtds.ts
+++ b/packages/client/src/websockets/rtds.ts
@@ -23,7 +23,7 @@ import {
   type SubscriptionRegistryChange,
   type SubscriptionRegistryEntry,
 } from './registry';
-import type { WebSocketManager } from './types';
+import type { WebSocketSubscriptionManager } from './types';
 
 type RtdsSpec =
   | CommentsSubscription
@@ -45,12 +45,12 @@ type RtdsServerState = Map<string, RtdsServerSubscription>;
 /**
  * Realtime Data Service (RTDS) WebSocket manager.
  *
- * Implements {@link WebSocketManager} for the comments, crypto prices, and
+ * Implements {@link WebSocketSubscriptionManager} for the comments, crypto prices, and
  * equity prices topics multiplexed over a single shared upstream socket
  * opened lazily on the first subscribe.
  */
 export class RtdsWebSocketManager
-  implements WebSocketManager<RtdsSpec, RtdsEvent>
+  implements WebSocketSubscriptionManager<RtdsSpec, RtdsEvent>
 {
   readonly #url: string;
   #closing: Promise<void> | undefined;

--- a/packages/client/src/websockets/sports.ts
+++ b/packages/client/src/websockets/sports.ts
@@ -17,7 +17,7 @@ import {
   SubscriptionRegistry,
   type SubscriptionRegistryEntry,
 } from './registry';
-import type { WebSocketManager } from './types';
+import type { WebSocketSubscriptionManager } from './types';
 
 type SportsSubscriptionEntry = SubscriptionRegistryEntry<
   SportsSubscription,
@@ -36,7 +36,7 @@ export type SportsWebSocketManagerOptions = {
  * with `pong` to keep the socket alive.
  */
 export class SportsWebSocketManager
-  implements WebSocketManager<SportsSubscription, SportsEvent>
+  implements WebSocketSubscriptionManager<SportsSubscription, SportsEvent>
 {
   readonly #url: string;
   #closing: Promise<void> | undefined;

--- a/packages/client/src/websockets/types.ts
+++ b/packages/client/src/websockets/types.ts
@@ -6,6 +6,7 @@ import type {
   SportsEvent,
   UserEvent,
 } from '@polymarket/bindings/subscriptions';
+import type { RfqSession } from '../actions/rfq';
 import type {
   CommentsSubscription,
   CryptoPricesSubscription,
@@ -15,6 +16,27 @@ import type {
   SubscriptionHandle,
   UserSubscription,
 } from '../actions/subscriptions';
+
+/**
+ * An authenticated bidirectional WebSocket session.
+ *
+ * The session is an async iterable of server-initiated events and also exposes
+ * `send` for protocol messages that respond to, update, or otherwise interact
+ * with that stream. Callers control processing semantics: await event handlers
+ * inline for sequential handling, or dispatch work without awaiting to fan out.
+ */
+export interface WebSocketSession<TEvent, TMessage>
+  extends AsyncIterable<TEvent> {
+  /**
+   * Closes the session. Idempotent: subsequent calls resolve without effect.
+   */
+  close(): Promise<void>;
+
+  /**
+   * Sends a protocol message on this authenticated websocket session.
+   */
+  send(message: TMessage): Promise<void>;
+}
 
 /**
  * A WebSocket manager owns a single upstream socket surface and exposes a
@@ -32,6 +54,12 @@ import type {
  */
 export interface WebSocketSubscriptionManager<TSpec, TEvent> {
   subscribe(subscription: TSpec): Promise<SubscriptionHandle<TEvent>>;
+
+  close(): Promise<void>;
+}
+
+export interface WebSocketSessionManager<TSession> {
+  connect(): Promise<TSession>;
 
   close(): Promise<void>;
 }
@@ -55,4 +83,5 @@ export type PublicWebSocketManagers = {
 // Secure client additionally exposes the user surface.
 export type SecureWebSocketManagers = PublicWebSocketManagers & {
   readonly clobUser: WebSocketSubscriptionManager<UserSubscription, UserEvent>;
+  readonly rfqQuoter: WebSocketSessionManager<RfqSession>;
 };

--- a/packages/client/src/websockets/types.ts
+++ b/packages/client/src/websockets/types.ts
@@ -30,7 +30,7 @@ import type {
  *
  * `close()` is best-effort and idempotent.
  */
-export interface WebSocketManager<TSpec, TEvent> {
+export interface WebSocketSubscriptionManager<TSpec, TEvent> {
   subscribe(subscription: TSpec): Promise<SubscriptionHandle<TEvent>>;
 
   close(): Promise<void>;
@@ -38,9 +38,15 @@ export interface WebSocketManager<TSpec, TEvent> {
 
 // Surfaces available on the public client.
 export type PublicWebSocketManagers = {
-  readonly clobMarket: WebSocketManager<MarketSubscription, MarketEvent>;
-  readonly sports: WebSocketManager<SportsSubscription, SportsEvent>;
-  readonly rtds: WebSocketManager<
+  readonly clobMarket: WebSocketSubscriptionManager<
+    MarketSubscription,
+    MarketEvent
+  >;
+  readonly sports: WebSocketSubscriptionManager<
+    SportsSubscription,
+    SportsEvent
+  >;
+  readonly rtds: WebSocketSubscriptionManager<
     CommentsSubscription | CryptoPricesSubscription | EquityPricesSubscription,
     CommentsEvent | CryptoPricesEvent | EquityPricesEvent
   >;
@@ -48,5 +54,5 @@ export type PublicWebSocketManagers = {
 
 // Secure client additionally exposes the user surface.
 export type SecureWebSocketManagers = PublicWebSocketManagers & {
-  readonly clobUser: WebSocketManager<UserSubscription, UserEvent>;
+  readonly clobUser: WebSocketSubscriptionManager<UserSubscription, UserEvent>;
 };

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -30,12 +30,12 @@ export function recordOutboundFrame(
 }
 
 export function quoteAmounts(frame: OutboundFrame) {
-  invariant(typeof frame.price_e6 === 'number', 'Expected RFQ quote price.');
-  invariant(typeof frame.size_e6 === 'number', 'Expected RFQ quote size.');
+  invariant(typeof frame.price_e6 === 'string', 'Expected RFQ quote price.');
+  invariant(typeof frame.size_e6 === 'string', 'Expected RFQ quote size.');
 
   return {
-    priceE6: frame.price_e6,
-    sizeE6: frame.size_e6,
+    priceE6: Number(frame.price_e6),
+    sizeE6: Number(frame.size_e6),
   };
 }
 
@@ -71,10 +71,12 @@ function quoteRequestFrame(options: { direction?: 'BUY' | 'SELL' } = {}) {
     leg_position_ids: ['1', '2'],
     no_position_id: '456',
     requestor_public_id: 'req-1',
+    requested_size: {
+      unit: direction === 'BUY' ? 'notional' : 'shares',
+      value_e6: String(QUOTE_SIZE_E6),
+    },
     rfq_id: RFQ_ID,
     side: 'YES',
-    size_notional_e6: direction === 'BUY' ? QUOTE_SIZE_E6 : undefined,
-    size_shares_e6: direction === 'SELL' ? QUOTE_SIZE_E6 : undefined,
     submission_deadline: 123,
     type: 'RFQ_REQUEST',
     yes_position_id: '123',
@@ -107,9 +109,9 @@ function confirmationRequestFrame(
   return {
     ...quoteRequestFrame(options),
     confirm_by: 456,
-    fill_size_e6: fillSizeE6,
+    fill_size_e6: String(fillSizeE6),
     maker_address: makerAddress,
-    price_e6: priceE6,
+    price_e6: String(priceE6),
     quote_id: QUOTE_ID,
     signature_type: SignatureType.EOA,
     signer_address: signerAddress,

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -1,7 +1,10 @@
 import { SignatureType } from '@polymarket/bindings/clob';
+import { RfqExecutionStatus } from '@polymarket/bindings/rfq';
 
 export const QUOTE_ID = 'quote-1';
 export const QUOTE_SIZE_E6 = 1_000_000;
+export const TX_HASH =
+  '0x1111111111111111111111111111111111111111111111111111111111111111';
 
 const RFQ_ID = 'rfq-1';
 
@@ -56,11 +59,20 @@ export function confirmationRequestFrame(priceE6: number, fillSizeE6: number) {
   };
 }
 
-export function confirmationAckFrame() {
+export function confirmationAckFrame(decision: string) {
   return {
-    decision: 'CONFIRM',
+    decision,
     quote_id: QUOTE_ID,
     rfq_id: RFQ_ID,
     type: 'ACK_RFQ_CONFIRMATION_RESPONSE',
+  };
+}
+
+export function executionUpdateFrame() {
+  return {
+    rfq_id: RFQ_ID,
+    status: RfqExecutionStatus.Confirmed,
+    tx_hash: TX_HASH,
+    type: 'RFQ_EXECUTION_UPDATE',
   };
 }

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -14,7 +14,11 @@ const makerAddress = '0x2222222222222222222222222222222222222222';
 
 export type OutboundFrame = {
   decision?: unknown;
+  maker_address?: unknown;
   price_e6?: unknown;
+  quote_id?: unknown;
+  rfq_id?: unknown;
+  signer_address?: unknown;
   size_e6?: unknown;
   signed_order?: unknown;
   type?: string;
@@ -99,6 +103,18 @@ function quoteAckFrame() {
 
 export function quoteAckMessage() {
   return JSON.stringify(quoteAckFrame());
+}
+
+function quoteCancelAckFrame(options: { quoteId?: string } = {}) {
+  return {
+    quote_id: options.quoteId ?? QUOTE_ID,
+    rfq_id: RFQ_ID,
+    type: 'ACK_RFQ_QUOTE_CANCEL',
+  };
+}
+
+export function quoteCancelAckMessage(options: { quoteId?: string } = {}) {
+  return JSON.stringify(quoteCancelAckFrame(options));
 }
 
 function confirmationRequestFrame(

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -5,6 +5,7 @@ import { invariant } from '@polymarket/types';
 export const RFQ_ID = 'rfq-1';
 export const QUOTE_ID = 'quote-1';
 export const QUOTE_SIZE_E6 = 1_000_000;
+export const BUY_QUOTE_SIZE_E6 = 2_222_222;
 export const TX_HASH =
   '0x1111111111111111111111111111111111111111111111111111111111111111';
 
@@ -61,16 +62,19 @@ export function authAckMessage() {
 }
 
 function quoteRequestFrame(options: { direction?: 'BUY' | 'SELL' } = {}) {
+  const direction = options.direction ?? 'BUY';
+
   return {
     condition_id:
       '0x032def24bfb0c5c57fb236fac08b94236a000000000000000000000000000000',
-    direction: options.direction ?? 'BUY',
+    direction,
     leg_position_ids: ['1', '2'],
     no_position_id: '456',
     requestor_public_id: 'req-1',
     rfq_id: RFQ_ID,
     side: 'YES',
-    size_e6: QUOTE_SIZE_E6,
+    size_notional_e6: direction === 'BUY' ? QUOTE_SIZE_E6 : undefined,
+    size_shares_e6: direction === 'SELL' ? QUOTE_SIZE_E6 : undefined,
     submission_deadline: 123,
     type: 'RFQ_REQUEST',
     yes_position_id: '123',

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -1,15 +1,51 @@
 import { SignatureType } from '@polymarket/bindings/clob';
 import { RfqExecutionStatus } from '@polymarket/bindings/rfq';
+import { invariant } from '@polymarket/types';
 
+export const RFQ_ID = 'rfq-1';
 export const QUOTE_ID = 'quote-1';
 export const QUOTE_SIZE_E6 = 1_000_000;
 export const TX_HASH =
   '0x1111111111111111111111111111111111111111111111111111111111111111';
 
-const RFQ_ID = 'rfq-1';
-
 const signerAddress = '0x1111111111111111111111111111111111111111';
 const makerAddress = '0x2222222222222222222222222222222222222222';
+
+export type OutboundFrame = {
+  decision?: unknown;
+  price_e6?: unknown;
+  size_e6?: unknown;
+  signed_order?: unknown;
+  type?: string;
+};
+
+export function recordOutboundFrame(
+  data: unknown,
+  frames: OutboundFrame[],
+): OutboundFrame {
+  const frame = JSON.parse(String(data)) as OutboundFrame;
+  frames.push(frame);
+  return frame;
+}
+
+export function quoteAmounts(frame: OutboundFrame) {
+  invariant(typeof frame.price_e6 === 'number', 'Expected RFQ quote price.');
+  invariant(typeof frame.size_e6 === 'number', 'Expected RFQ quote size.');
+
+  return {
+    priceE6: frame.price_e6,
+    sizeE6: frame.size_e6,
+  };
+}
+
+export function confirmationDecision(frame: OutboundFrame) {
+  invariant(
+    typeof frame.decision === 'string',
+    'Expected RFQ confirmation decision.',
+  );
+
+  return frame.decision;
+}
 
 export function authAckFrame() {
   return {
@@ -20,11 +56,17 @@ export function authAckFrame() {
   };
 }
 
-export function quoteRequestFrame() {
+export function authAckMessage() {
+  return JSON.stringify(authAckFrame());
+}
+
+export function quoteRequestFrame(
+  options: { direction?: 'BUY' | 'SELL' } = {},
+) {
   return {
     condition_id:
       '0x032def24bfb0c5c57fb236fac08b94236a000000000000000000000000000000',
-    direction: 'BUY',
+    direction: options.direction ?? 'BUY',
     leg_position_ids: ['1', '2'],
     no_position_id: '456',
     requestor_public_id: 'req-1',
@@ -37,6 +79,12 @@ export function quoteRequestFrame() {
   };
 }
 
+export function quoteRequestMessage(
+  options: { direction?: 'BUY' | 'SELL' } = {},
+) {
+  return JSON.stringify(quoteRequestFrame(options));
+}
+
 export function quoteAckFrame() {
   return {
     quote_id: QUOTE_ID,
@@ -45,9 +93,17 @@ export function quoteAckFrame() {
   };
 }
 
-export function confirmationRequestFrame(priceE6: number, fillSizeE6: number) {
+export function quoteAckMessage() {
+  return JSON.stringify(quoteAckFrame());
+}
+
+export function confirmationRequestFrame(
+  priceE6: number,
+  fillSizeE6: number,
+  options: { direction?: 'BUY' | 'SELL' } = {},
+) {
   return {
-    ...quoteRequestFrame(),
+    ...quoteRequestFrame(options),
     confirm_by: 456,
     fill_size_e6: fillSizeE6,
     maker_address: makerAddress,
@@ -59,6 +115,14 @@ export function confirmationRequestFrame(priceE6: number, fillSizeE6: number) {
   };
 }
 
+export function confirmationRequestMessage(
+  priceE6: number,
+  fillSizeE6: number,
+  options: { direction?: 'BUY' | 'SELL' } = {},
+) {
+  return JSON.stringify(confirmationRequestFrame(priceE6, fillSizeE6, options));
+}
+
 export function confirmationAckFrame(decision: string) {
   return {
     decision,
@@ -68,6 +132,10 @@ export function confirmationAckFrame(decision: string) {
   };
 }
 
+export function confirmationAckMessage(decision: string) {
+  return JSON.stringify(confirmationAckFrame(decision));
+}
+
 export function executionUpdateFrame() {
   return {
     rfq_id: RFQ_ID,
@@ -75,4 +143,8 @@ export function executionUpdateFrame() {
     tx_hash: TX_HASH,
     type: 'RFQ_EXECUTION_UPDATE',
   };
+}
+
+export function executionUpdateMessage() {
+  return JSON.stringify(executionUpdateFrame());
 }

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -1,0 +1,66 @@
+import { SignatureType } from '@polymarket/bindings/clob';
+
+export const QUOTE_ID = 'quote-1';
+
+const RFQ_ID = 'rfq-1';
+const QUOTE_SIZE_E6 = 1_000_000;
+
+const signerAddress = '0x1111111111111111111111111111111111111111';
+const makerAddress = '0x2222222222222222222222222222222222222222';
+
+export function authAckFrame() {
+  return {
+    address: signerAddress,
+    role: 'maker',
+    success: true,
+    type: 'auth',
+  };
+}
+
+export function quoteRequestFrame() {
+  return {
+    condition_id:
+      '0x032def24bfb0c5c57fb236fac08b94236a000000000000000000000000000000',
+    direction: 'BUY',
+    leg_position_ids: ['1', '2'],
+    no_position_id: '456',
+    requestor_public_id: 'req-1',
+    rfq_id: RFQ_ID,
+    side: 'YES',
+    size_e6: QUOTE_SIZE_E6,
+    submission_deadline: 123,
+    type: 'RFQ_REQUEST',
+    yes_position_id: '123',
+  };
+}
+
+export function quoteAckFrame() {
+  return {
+    quote_id: QUOTE_ID,
+    rfq_id: RFQ_ID,
+    type: 'ACK_RFQ_QUOTE',
+  };
+}
+
+export function confirmationRequestFrame(priceE6: number, fillSizeE6: number) {
+  return {
+    ...quoteRequestFrame(),
+    confirm_by: 456,
+    fill_size_e6: fillSizeE6,
+    maker_address: makerAddress,
+    price_e6: priceE6,
+    quote_id: QUOTE_ID,
+    signature_type: SignatureType.EOA,
+    signer_address: signerAddress,
+    type: 'RFQ_CONFIRMATION_REQUEST',
+  };
+}
+
+export function confirmationAckFrame() {
+  return {
+    decision: 'CONFIRM',
+    quote_id: QUOTE_ID,
+    rfq_id: RFQ_ID,
+    type: 'ACK_RFQ_CONFIRMATION_RESPONSE',
+  };
+}

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -1,9 +1,9 @@
 import { SignatureType } from '@polymarket/bindings/clob';
 
 export const QUOTE_ID = 'quote-1';
+export const QUOTE_SIZE_E6 = 1_000_000;
 
 const RFQ_ID = 'rfq-1';
-const QUOTE_SIZE_E6 = 1_000_000;
 
 const signerAddress = '0x1111111111111111111111111111111111111111';
 const makerAddress = '0x2222222222222222222222222222222222222222';

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -47,7 +47,7 @@ export function confirmationDecision(frame: OutboundFrame) {
   return frame.decision;
 }
 
-export function authAckFrame() {
+function authAckFrame() {
   return {
     address: signerAddress,
     role: 'maker',
@@ -60,9 +60,7 @@ export function authAckMessage() {
   return JSON.stringify(authAckFrame());
 }
 
-export function quoteRequestFrame(
-  options: { direction?: 'BUY' | 'SELL' } = {},
-) {
+function quoteRequestFrame(options: { direction?: 'BUY' | 'SELL' } = {}) {
   return {
     condition_id:
       '0x032def24bfb0c5c57fb236fac08b94236a000000000000000000000000000000',
@@ -85,7 +83,7 @@ export function quoteRequestMessage(
   return JSON.stringify(quoteRequestFrame(options));
 }
 
-export function quoteAckFrame() {
+function quoteAckFrame() {
   return {
     quote_id: QUOTE_ID,
     rfq_id: RFQ_ID,
@@ -97,7 +95,7 @@ export function quoteAckMessage() {
   return JSON.stringify(quoteAckFrame());
 }
 
-export function confirmationRequestFrame(
+function confirmationRequestFrame(
   priceE6: number,
   fillSizeE6: number,
   options: { direction?: 'BUY' | 'SELL' } = {},
@@ -123,7 +121,7 @@ export function confirmationRequestMessage(
   return JSON.stringify(confirmationRequestFrame(priceE6, fillSizeE6, options));
 }
 
-export function confirmationAckFrame(decision: string) {
+function confirmationAckFrame(decision: string) {
   return {
     decision,
     quote_id: QUOTE_ID,
@@ -136,7 +134,7 @@ export function confirmationAckMessage(decision: string) {
   return JSON.stringify(confirmationAckFrame(decision));
 }
 
-export function executionUpdateFrame() {
+function executionUpdateFrame() {
   return {
     rfq_id: RFQ_ID,
     status: RfqExecutionStatus.Confirmed,
@@ -147,4 +145,31 @@ export function executionUpdateFrame() {
 
 export function executionUpdateMessage() {
   return JSON.stringify(executionUpdateFrame());
+}
+
+function rfqErrorFrame(options: {
+  code: string;
+  error: string;
+  quoteId?: string;
+  requestType: string;
+  rfqId?: string;
+}) {
+  return {
+    code: options.code,
+    error: options.error,
+    quote_id: options.quoteId,
+    request_type: options.requestType,
+    rfq_id: options.rfqId,
+    type: 'RFQ_ERROR',
+  };
+}
+
+export function rfqErrorMessage(options: {
+  code: string;
+  error: string;
+  quoteId?: string;
+  requestType: string;
+  rfqId?: string;
+}) {
+  return JSON.stringify(rfqErrorFrame(options));
 }

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -21,6 +21,7 @@ import {
   QUOTE_SIZE_E6,
   quoteAckMessage,
   quoteAmounts,
+  quoteCancelAckMessage,
   quoteRequestMessage,
   RFQ_ID,
   recordOutboundFrame,
@@ -403,6 +404,144 @@ describe('RFQ sessions', () => {
                 type: 'RFQ_QUOTE',
               }),
             );
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when cancelling a submitted quote', () => {
+    beforeEach(() => {
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              quoteAmounts(frame);
+              socket.send(quoteAckMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE_CANCEL') {
+              socket.send(quoteCancelAckMessage());
+            }
+          });
+        }),
+      );
+    });
+
+    it('sends quote cancellation identity and resolves on acknowledgement', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const quote = await event.quote({ price: 0.45 });
+            const ack = await session.cancelQuote(quote);
+
+            expect(quote).toEqual({
+              quoteId: QUOTE_ID,
+              rfqId: event.rfqId,
+            });
+            expect(ack).toEqual(quote);
+            expect(outboundFrames).toContainEqual(
+              expect.objectContaining({
+                maker_address: secureClientWithDepositWallet.account.wallet,
+                quote_id: quote.quoteId,
+                rfq_id: quote.rfqId,
+                signer_address: secureClientWithDepositWallet.account.wallet,
+                type: 'RFQ_QUOTE_CANCEL',
+              }),
+            );
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when the server rejects a quote cancellation', () => {
+    beforeEach(() => {
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              quoteAmounts(frame);
+              socket.send(quoteAckMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE_CANCEL') {
+              socket.send(
+                rfqErrorMessage({
+                  code: 'INVALID_RFQ_STATE',
+                  error: 'unrelated cancellation',
+                  quoteId: 'quote-other',
+                  requestType: 'RFQ_QUOTE_CANCEL',
+                  rfqId: RFQ_ID,
+                }),
+              );
+              socket.send(
+                rfqErrorMessage({
+                  code: 'INVALID_RFQ_STATE',
+                  error: 'invalid cancellation',
+                  quoteId: QUOTE_ID,
+                  requestType: 'RFQ_QUOTE_CANCEL',
+                  rfqId: RFQ_ID,
+                }),
+              );
+            }
+          });
+        }),
+      );
+    });
+
+    it('rejects only the matching pending cancellation', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const quote = await event.quote({ price: 0.45 });
+            const cancellation = session.cancelQuote(quote);
+
+            await expect(cancellation).rejects.toMatchObject({
+              code: 'INVALID_RFQ_STATE',
+              message: 'invalid cancellation',
+              name: 'RfqCancelQuoteRejectedError',
+              quoteId: quote.quoteId,
+              rfqId: quote.rfqId,
+            });
 
             await session.close();
             break;

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -1,4 +1,9 @@
-import { production, TimeoutError } from '@polymarket/client';
+import {
+  production,
+  TimeoutError,
+  TransportError,
+  UserInputError,
+} from '@polymarket/client';
 import { invariant } from '@polymarket/types';
 import { ws } from 'msw';
 import { setupServer } from 'msw/node';
@@ -18,7 +23,12 @@ import {
 
 const rfq = ws.link(production.rfqQuoterWs);
 const server = setupServer();
-let responseMode: 'happy' | 'quoteTimeout' = 'happy';
+let responseMode:
+  | 'closeAfterConfirmation'
+  | 'closeAfterQuote'
+  | 'confirmationTimeout'
+  | 'happy'
+  | 'quoteTimeout' = 'happy';
 let outboundFrames: unknown[] = [];
 let connectionCount = 0;
 
@@ -70,6 +80,10 @@ describe('RFQ sessions', () => {
                 'Expected RFQ quote size.',
               );
               if (responseMode === 'quoteTimeout') return;
+              if (responseMode === 'closeAfterQuote') {
+                socket.close();
+                return;
+              }
 
               socket.send(JSON.stringify(quoteAckFrame()));
               socket.send(
@@ -85,6 +99,12 @@ describe('RFQ sessions', () => {
                 typeof frame.decision === 'string',
                 'Expected RFQ confirmation decision.',
               );
+              if (responseMode === 'confirmationTimeout') return;
+              if (responseMode === 'closeAfterConfirmation') {
+                socket.close();
+                return;
+              }
+
               socket.send(JSON.stringify(confirmationAckFrame(frame.decision)));
               if (frame.decision === 'CONFIRM') {
                 socket.send(JSON.stringify(executionUpdateFrame()));
@@ -320,6 +340,151 @@ describe('RFQ sessions', () => {
             await vi.advanceTimersByTimeAsync(30_000);
 
             await quoteRejection;
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when confirmation acknowledgement times out', () => {
+    beforeEach(() => {
+      responseMode = 'confirmationTimeout';
+    });
+
+    it('rejects the confirmation response', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+      vi.useFakeTimers();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            await event.quote({ price: 0.45 });
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            const confirmation = event.confirm();
+            const confirmationRejection =
+              expect(confirmation).rejects.toBeInstanceOf(TimeoutError);
+
+            await vi.waitFor(() => {
+              expect(outboundFrames).toContainEqual(
+                expect.objectContaining({
+                  type: 'RFQ_CONFIRMATION_RESPONSE',
+                }),
+              );
+            });
+            await vi.advanceTimersByTimeAsync(30_000);
+
+            await confirmationRejection;
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when the connection closes before quote acknowledgement', () => {
+    beforeEach(() => {
+      responseMode = 'closeAfterQuote';
+    });
+
+    it('rejects the quote response', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const quote = event.quote({ price: 0.45 });
+            const quoteRejection =
+              expect(quote).rejects.toBeInstanceOf(TransportError);
+
+            await vi.waitFor(() => {
+              expect(outboundFrames).toContainEqual(
+                expect.objectContaining({ type: 'RFQ_QUOTE' }),
+              );
+            });
+
+            await quoteRejection;
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when the connection closes before confirmation acknowledgement', () => {
+    beforeEach(() => {
+      responseMode = 'closeAfterConfirmation';
+    });
+
+    it('rejects the confirmation response', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            await event.quote({ price: 0.45 });
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            const confirmation = event.confirm();
+            const confirmationRejection =
+              expect(confirmation).rejects.toBeInstanceOf(TransportError);
+
+            await vi.waitFor(() => {
+              expect(outboundFrames).toContainEqual(
+                expect.objectContaining({
+                  type: 'RFQ_CONFIRMATION_RESPONSE',
+                }),
+              );
+            });
+
+            await confirmationRejection;
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when quote input is invalid', () => {
+    it('rejects before sending a quote response', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            await expect(event.quote({ price: 1 })).rejects.toBeInstanceOf(
+              UserInputError,
+            );
+
+            expect(outboundFrames).not.toContainEqual(
+              expect.objectContaining({ type: 'RFQ_QUOTE' }),
+            );
+
             await session.close();
             break;
           }

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -1,0 +1,130 @@
+import { production } from '@polymarket/client';
+import { invariant } from '@polymarket/types';
+import { ws } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, beforeAll, beforeEach } from 'vitest';
+import { describe, expect, it } from './fixtures';
+import {
+  authAckFrame,
+  confirmationAckFrame,
+  confirmationRequestFrame,
+  QUOTE_ID,
+  quoteAckFrame,
+  quoteRequestFrame,
+} from './rfq-frames';
+
+const rfq = ws.link(production.rfqQuoterWs);
+const server = setupServer();
+let outboundFrames: unknown[] = [];
+
+describe('RFQ sessions', () => {
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'bypass' });
+  });
+
+  beforeEach(() => {
+    outboundFrames = [];
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  describe('when the server completes the happy-path quoter flow', () => {
+    beforeAll(() => {
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = JSON.parse(String(event.data)) as {
+              price_e6?: unknown;
+              size_e6?: unknown;
+              type?: string;
+            };
+            outboundFrames.push(frame);
+
+            if (frame.type === 'auth') {
+              socket.send(JSON.stringify(authAckFrame()));
+              socket.send(JSON.stringify(quoteRequestFrame()));
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              invariant(
+                typeof frame.price_e6 === 'number',
+                'Expected RFQ quote price.',
+              );
+              invariant(
+                typeof frame.size_e6 === 'number',
+                'Expected RFQ quote size.',
+              );
+              socket.send(JSON.stringify(quoteAckFrame()));
+              socket.send(
+                JSON.stringify(
+                  confirmationRequestFrame(frame.price_e6, frame.size_e6),
+                ),
+              );
+              return;
+            }
+
+            if (frame.type === 'RFQ_CONFIRMATION_RESPONSE') {
+              socket.send(JSON.stringify(confirmationAckFrame()));
+            }
+          });
+        }),
+      );
+    });
+
+    it('quotes and confirms through the secure client session', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const ack = await event.quote({ price: 0.45 });
+
+            expect(ack).toEqual({
+              rfqId: event.rfqId,
+              quoteId: QUOTE_ID,
+            });
+
+            expect(outboundFrames).toContainEqual(
+              expect.objectContaining({
+                price_e6: 450_000,
+                rfq_id: event.rfqId,
+                size_e6: 1_000_000,
+                type: 'RFQ_QUOTE',
+              }),
+            );
+
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            const ack = await event.confirm();
+
+            expect(ack).toEqual({
+              rfqId: event.rfqId,
+              quoteId: event.quoteId,
+            });
+
+            expect(outboundFrames).toContainEqual(
+              expect.objectContaining({
+                decision: 'CONFIRM',
+                quote_id: event.quoteId,
+                rfq_id: event.rfqId,
+                type: 'RFQ_CONFIRMATION_RESPONSE',
+              }),
+            );
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+});

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -8,10 +8,12 @@ import {
   authAckFrame,
   confirmationAckFrame,
   confirmationRequestFrame,
+  executionUpdateFrame,
   QUOTE_ID,
   QUOTE_SIZE_E6,
   quoteAckFrame,
   quoteRequestFrame,
+  TX_HASH,
 } from './rfq-frames';
 
 const rfq = ws.link(production.rfqQuoterWs);
@@ -37,6 +39,7 @@ describe('RFQ sessions', () => {
         rfq.addEventListener('connection', ({ client: socket }) => {
           socket.addEventListener('message', (event) => {
             const frame = JSON.parse(String(event.data)) as {
+              decision?: unknown;
               price_e6?: unknown;
               size_e6?: unknown;
               type?: string;
@@ -68,7 +71,14 @@ describe('RFQ sessions', () => {
             }
 
             if (frame.type === 'RFQ_CONFIRMATION_RESPONSE') {
-              socket.send(JSON.stringify(confirmationAckFrame()));
+              invariant(
+                typeof frame.decision === 'string',
+                'Expected RFQ confirmation decision.',
+              );
+              socket.send(JSON.stringify(confirmationAckFrame(frame.decision)));
+              if (frame.decision === 'CONFIRM') {
+                socket.send(JSON.stringify(executionUpdateFrame()));
+              }
             }
           });
         }),
@@ -169,6 +179,77 @@ describe('RFQ sessions', () => {
                 type: 'RFQ_CONFIRMATION_RESPONSE',
               }),
             );
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+
+    it('declines confirmation requests', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            await event.quote({ price: 0.45 });
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            const ack = await event.decline();
+
+            expect(ack).toEqual({
+              rfqId: event.rfqId,
+              quoteId: event.quoteId,
+            });
+
+            expect(outboundFrames).toContainEqual(
+              expect.objectContaining({
+                decision: 'DECLINE',
+                quote_id: event.quoteId,
+                rfq_id: event.rfqId,
+                type: 'RFQ_CONFIRMATION_RESPONSE',
+              }),
+            );
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+
+    it('yields execution updates', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            await event.quote({ price: 0.45 });
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            await event.confirm();
+            continue;
+          }
+
+          if (event.type === 'execution_update') {
+            expect(event).toMatchObject({
+              rfqId: quoteRequestFrame().rfq_id,
+              status: 'CONFIRMED',
+              txHash: TX_HASH,
+            });
 
             await session.close();
             break;

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -11,6 +11,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 import { describe, expect, it } from './fixtures';
 import {
   authAckMessage,
+  BUY_QUOTE_SIZE_E6,
   confirmationAckMessage,
   confirmationDecision,
   confirmationRequestMessage,
@@ -121,6 +122,11 @@ describe('RFQ sessions', () => {
       try {
         for await (const event of session) {
           if (event.type === 'quote_request') {
+            expect(event.requestedSize).toEqual({
+              unit: 'notional',
+              value: '1',
+            });
+
             const ack = await event.quote({ price: 0.45 });
 
             expect(ack).toEqual({
@@ -133,15 +139,15 @@ describe('RFQ sessions', () => {
                 price_e6: 450_000,
                 rfq_id: event.rfqId,
                 signed_order: expect.objectContaining({
-                  makerAmount: '550000',
+                  makerAmount: '1222223',
                   maker: secureClientWithDepositWallet.account.wallet,
                   side: 0,
                   signatureType: SignatureType.POLY_1271,
                   signer: secureClientWithDepositWallet.account.wallet,
-                  takerAmount: '1000000',
+                  takerAmount: '2222222',
                   tokenId: event.noPositionId,
                 }),
-                size_e6: QUOTE_SIZE_E6,
+                size_e6: BUY_QUOTE_SIZE_E6,
                 type: 'RFQ_QUOTE',
               }),
             );
@@ -183,6 +189,11 @@ describe('RFQ sessions', () => {
       try {
         for await (const event of session) {
           if (event.type === 'quote_request') {
+            expect(event.requestedSize).toEqual({
+              unit: 'notional',
+              value: '1',
+            });
+
             const ack = await event.quote({ price: 0.45, source: 'inventory' });
 
             expect(ack).toEqual({
@@ -195,12 +206,12 @@ describe('RFQ sessions', () => {
                 price_e6: 450_000,
                 rfq_id: event.rfqId,
                 signed_order: expect.objectContaining({
-                  makerAmount: '1000000',
+                  makerAmount: '2222222',
                   side: 1,
-                  takerAmount: '450000',
+                  takerAmount: '999999',
                   tokenId: event.yesPositionId,
                 }),
-                size_e6: QUOTE_SIZE_E6,
+                size_e6: BUY_QUOTE_SIZE_E6,
                 type: 'RFQ_QUOTE',
               }),
             );
@@ -366,6 +377,11 @@ describe('RFQ sessions', () => {
       try {
         for await (const event of session) {
           if (event.type === 'quote_request') {
+            expect(event.requestedSize).toEqual({
+              unit: 'shares',
+              value: '1',
+            });
+
             const ack = await event.quote({ price: 0.45, source: 'inventory' });
 
             expect(ack).toEqual({

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -136,7 +136,7 @@ describe('RFQ sessions', () => {
 
             expect(outboundFrames).toContainEqual(
               expect.objectContaining({
-                price_e6: 450_000,
+                price_e6: '450000',
                 rfq_id: event.rfqId,
                 signed_order: expect.objectContaining({
                   makerAmount: '1222223',
@@ -147,7 +147,7 @@ describe('RFQ sessions', () => {
                   takerAmount: '2222222',
                   tokenId: event.noPositionId,
                 }),
-                size_e6: BUY_QUOTE_SIZE_E6,
+                size_e6: String(BUY_QUOTE_SIZE_E6),
                 type: 'RFQ_QUOTE',
               }),
             );
@@ -203,7 +203,7 @@ describe('RFQ sessions', () => {
 
             expect(outboundFrames).toContainEqual(
               expect.objectContaining({
-                price_e6: 450_000,
+                price_e6: '450000',
                 rfq_id: event.rfqId,
                 signed_order: expect.objectContaining({
                   makerAmount: '2222222',
@@ -211,7 +211,7 @@ describe('RFQ sessions', () => {
                   takerAmount: '999999',
                   tokenId: event.yesPositionId,
                 }),
-                size_e6: BUY_QUOTE_SIZE_E6,
+                size_e6: String(BUY_QUOTE_SIZE_E6),
                 type: 'RFQ_QUOTE',
               }),
             );
@@ -240,9 +240,9 @@ describe('RFQ sessions', () => {
 
             expect(outboundFrames).toContainEqual(
               expect.objectContaining({
-                price_e6: 450_000,
+                price_e6: '450000',
                 rfq_id: event.rfqId,
-                size_e6: 500_000,
+                size_e6: '500000',
                 type: 'RFQ_QUOTE',
               }),
             );
@@ -391,7 +391,7 @@ describe('RFQ sessions', () => {
 
             expect(outboundFrames).toContainEqual(
               expect.objectContaining({
-                price_e6: 450_000,
+                price_e6: '450000',
                 rfq_id: event.rfqId,
                 signed_order: expect.objectContaining({
                   makerAmount: '1000000',
@@ -399,7 +399,7 @@ describe('RFQ sessions', () => {
                   takerAmount: '550000',
                   tokenId: event.noPositionId,
                 }),
-                size_e6: QUOTE_SIZE_E6,
+                size_e6: String(QUOTE_SIZE_E6),
                 type: 'RFQ_QUOTE',
               }),
             );

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -1,8 +1,8 @@
-import { production } from '@polymarket/client';
+import { production, TimeoutError } from '@polymarket/client';
 import { invariant } from '@polymarket/types';
 import { ws } from 'msw';
 import { setupServer } from 'msw/node';
-import { afterAll, beforeAll, beforeEach } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 import { describe, expect, it } from './fixtures';
 import {
   authAckFrame,
@@ -18,6 +18,7 @@ import {
 
 const rfq = ws.link(production.rfqQuoterWs);
 const server = setupServer();
+let responseMode: 'happy' | 'quoteTimeout' = 'happy';
 let outboundFrames: unknown[] = [];
 let connectionCount = 0;
 
@@ -29,6 +30,11 @@ describe('RFQ sessions', () => {
   beforeEach(() => {
     connectionCount = 0;
     outboundFrames = [];
+    responseMode = 'happy';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   afterAll(() => {
@@ -63,6 +69,8 @@ describe('RFQ sessions', () => {
                 typeof frame.size_e6 === 'number',
                 'Expected RFQ quote size.',
               );
+              if (responseMode === 'quoteTimeout') return;
+
               socket.send(JSON.stringify(quoteAckFrame()));
               socket.send(
                 JSON.stringify(
@@ -276,6 +284,42 @@ describe('RFQ sessions', () => {
               txHash: TX_HASH,
             });
 
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when quote acknowledgement times out', () => {
+    beforeEach(() => {
+      responseMode = 'quoteTimeout';
+    });
+
+    it('rejects the quote response', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+      vi.useFakeTimers();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const quote = event.quote({ price: 0.45 });
+            const quoteRejection =
+              expect(quote).rejects.toBeInstanceOf(TimeoutError);
+
+            await vi.waitFor(() => {
+              expect(outboundFrames).toContainEqual(
+                expect.objectContaining({ type: 'RFQ_QUOTE' }),
+              );
+            });
+            await vi.advanceTimersByTimeAsync(30_000);
+
+            await quoteRejection;
             await session.close();
             break;
           }

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -19,6 +19,7 @@ import {
 const rfq = ws.link(production.rfqQuoterWs);
 const server = setupServer();
 let outboundFrames: unknown[] = [];
+let connectionCount = 0;
 
 describe('RFQ sessions', () => {
   beforeAll(() => {
@@ -26,6 +27,7 @@ describe('RFQ sessions', () => {
   });
 
   beforeEach(() => {
+    connectionCount = 0;
     outboundFrames = [];
   });
 
@@ -255,6 +257,42 @@ describe('RFQ sessions', () => {
             break;
           }
         }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when opening repeated RFQ sessions', () => {
+    beforeAll(() => {
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          connectionCount += 1;
+
+          socket.addEventListener('message', (event) => {
+            const frame = JSON.parse(String(event.data)) as { type?: string };
+
+            if (frame.type === 'auth') {
+              socket.send(JSON.stringify(authAckFrame()));
+            }
+          });
+        }),
+      );
+    });
+
+    it('reuses the connecting session', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      try {
+        const [first, second] = await Promise.all([
+          secureClientWithDepositWallet.openRfqSession(),
+          secureClientWithDepositWallet.openRfqSession(),
+        ]);
+
+        expect(second).toBe(first);
+        expect(connectionCount).toBe(1);
+
+        await first.close();
       } finally {
         await secureClientWithDepositWallet.closeSubscriptions();
       }

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -9,6 +9,7 @@ import {
   confirmationAckFrame,
   confirmationRequestFrame,
   QUOTE_ID,
+  QUOTE_SIZE_E6,
   quoteAckFrame,
   quoteRequestFrame,
 } from './rfq-frames';
@@ -74,7 +75,7 @@ describe('RFQ sessions', () => {
       );
     });
 
-    it('quotes and confirms through the secure client session', async ({
+    it('quotes the requested size when no size is provided', async ({
       secureClientWithDepositWallet,
     }) => {
       const session = await secureClientWithDepositWallet.openRfqSession();
@@ -93,7 +94,58 @@ describe('RFQ sessions', () => {
               expect.objectContaining({
                 price_e6: 450_000,
                 rfq_id: event.rfqId,
-                size_e6: 1_000_000,
+                size_e6: QUOTE_SIZE_E6,
+                type: 'RFQ_QUOTE',
+              }),
+            );
+
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            const ack = await event.confirm();
+
+            expect(ack).toEqual({
+              rfqId: event.rfqId,
+              quoteId: event.quoteId,
+            });
+
+            expect(outboundFrames).toContainEqual(
+              expect.objectContaining({
+                decision: 'CONFIRM',
+                quote_id: event.quoteId,
+                rfq_id: event.rfqId,
+                type: 'RFQ_CONFIRMATION_RESPONSE',
+              }),
+            );
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+
+    it('quotes an explicit size', async ({ secureClientWithDepositWallet }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const ack = await event.quote({ price: 0.45, size: 0.5 });
+
+            expect(ack).toEqual({
+              rfqId: event.rfqId,
+              quoteId: QUOTE_ID,
+            });
+
+            expect(outboundFrames).toContainEqual(
+              expect.objectContaining({
+                price_e6: 450_000,
+                rfq_id: event.rfqId,
+                size_e6: 500_000,
                 type: 'RFQ_QUOTE',
               }),
             );

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -23,6 +23,7 @@ import {
   quoteRequestMessage,
   RFQ_ID,
   recordOutboundFrame,
+  rfqErrorMessage,
   TX_HASH,
 } from './rfq-frames';
 
@@ -450,6 +451,63 @@ describe('RFQ sessions', () => {
     });
   });
 
+  describe('when the server rejects a quote response', () => {
+    beforeEach(() => {
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              quoteAmounts(frame);
+              socket.send(
+                rfqErrorMessage({
+                  code: 'INVALID_QUOTE',
+                  error: 'invalid quote',
+                  requestType: 'RFQ_QUOTE',
+                  rfqId: RFQ_ID,
+                }),
+              );
+            }
+          });
+        }),
+      );
+    });
+
+    it('rejects the quote response with the correlated RFQ error', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const quote = event.quote({ price: 0.45 });
+
+            await expect(quote).rejects.toMatchObject({
+              code: 'INVALID_QUOTE',
+              message: 'invalid quote',
+              name: 'RfqQuoteRejectedError',
+              rfqId: event.rfqId,
+            });
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
   describe('when confirmation acknowledgement times out', () => {
     beforeEach(() => {
       server.resetHandlers();
@@ -509,6 +567,79 @@ describe('RFQ sessions', () => {
             await vi.advanceTimersByTimeAsync(30_000);
 
             await confirmationRejection;
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when the server rejects a confirmation response', () => {
+    beforeEach(() => {
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              const quote = quoteAmounts(frame);
+              socket.send(quoteAckMessage());
+              socket.send(
+                confirmationRequestMessage(quote.priceE6, quote.sizeE6),
+              );
+              return;
+            }
+
+            if (frame.type === 'RFQ_CONFIRMATION_RESPONSE') {
+              confirmationDecision(frame);
+              socket.send(
+                rfqErrorMessage({
+                  code: 'INVALID_CONFIRMATION',
+                  error: 'invalid confirmation',
+                  quoteId: QUOTE_ID,
+                  requestType: 'RFQ_CONFIRMATION_RESPONSE',
+                  rfqId: RFQ_ID,
+                }),
+              );
+            }
+          });
+        }),
+      );
+    });
+
+    it('rejects the confirmation response with the correlated RFQ error', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            await event.quote({ price: 0.45 });
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            const confirmation = event.confirm();
+
+            await expect(confirmation).rejects.toMatchObject({
+              code: 'INVALID_CONFIRMATION',
+              message: 'invalid confirmation',
+              name: 'RfqConfirmationRejectedError',
+              quoteId: event.quoteId,
+              rfqId: event.rfqId,
+            });
+
             await session.close();
             break;
           }

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -87,6 +87,29 @@ describe('RFQ sessions', () => {
       );
     });
 
+    it('authenticates with the secure client credentials', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      try {
+        const session = await secureClientWithDepositWallet.openRfqSession();
+
+        expect(outboundFrames).toContainEqual(
+          expect.objectContaining({
+            auth: {
+              apiKey: secureClientWithDepositWallet.credentials.key,
+              passphrase: secureClientWithDepositWallet.credentials.passphrase,
+              secret: secureClientWithDepositWallet.credentials.secret,
+            },
+            type: 'auth',
+          }),
+        );
+
+        await session.close();
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+
     it('quotes the requested size when no size is provided', async ({
       secureClientWithDepositWallet,
     }) => {

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -1,35 +1,34 @@
 import {
   production,
+  SignatureType,
   TimeoutError,
   TransportError,
   UserInputError,
 } from '@polymarket/client';
-import { invariant } from '@polymarket/types';
 import { ws } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, vi } from 'vitest';
 import { describe, expect, it } from './fixtures';
 import {
-  authAckFrame,
-  confirmationAckFrame,
-  confirmationRequestFrame,
-  executionUpdateFrame,
+  authAckMessage,
+  confirmationAckMessage,
+  confirmationDecision,
+  confirmationRequestMessage,
+  executionUpdateMessage,
+  type OutboundFrame,
   QUOTE_ID,
   QUOTE_SIZE_E6,
-  quoteAckFrame,
-  quoteRequestFrame,
+  quoteAckMessage,
+  quoteAmounts,
+  quoteRequestMessage,
+  RFQ_ID,
+  recordOutboundFrame,
   TX_HASH,
 } from './rfq-frames';
 
 const rfq = ws.link(production.rfqQuoterWs);
 const server = setupServer();
-let responseMode:
-  | 'closeAfterConfirmation'
-  | 'closeAfterQuote'
-  | 'confirmationTimeout'
-  | 'happy'
-  | 'quoteTimeout' = 'happy';
-let outboundFrames: unknown[] = [];
+let outboundFrames: OutboundFrame[] = [];
 let connectionCount = 0;
 
 describe('RFQ sessions', () => {
@@ -40,7 +39,6 @@ describe('RFQ sessions', () => {
   beforeEach(() => {
     connectionCount = 0;
     outboundFrames = [];
-    responseMode = 'happy';
   });
 
   afterEach(() => {
@@ -52,62 +50,33 @@ describe('RFQ sessions', () => {
   });
 
   describe('when the server completes the happy-path quoter flow', () => {
-    beforeAll(() => {
+    beforeEach(() => {
+      server.resetHandlers();
       server.use(
         rfq.addEventListener('connection', ({ client: socket }) => {
           socket.addEventListener('message', (event) => {
-            const frame = JSON.parse(String(event.data)) as {
-              decision?: unknown;
-              price_e6?: unknown;
-              size_e6?: unknown;
-              type?: string;
-            };
-            outboundFrames.push(frame);
+            const frame = recordOutboundFrame(event.data, outboundFrames);
 
             if (frame.type === 'auth') {
-              socket.send(JSON.stringify(authAckFrame()));
-              socket.send(JSON.stringify(quoteRequestFrame()));
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
               return;
             }
 
             if (frame.type === 'RFQ_QUOTE') {
-              invariant(
-                typeof frame.price_e6 === 'number',
-                'Expected RFQ quote price.',
-              );
-              invariant(
-                typeof frame.size_e6 === 'number',
-                'Expected RFQ quote size.',
-              );
-              if (responseMode === 'quoteTimeout') return;
-              if (responseMode === 'closeAfterQuote') {
-                socket.close();
-                return;
-              }
-
-              socket.send(JSON.stringify(quoteAckFrame()));
+              const quote = quoteAmounts(frame);
+              socket.send(quoteAckMessage());
               socket.send(
-                JSON.stringify(
-                  confirmationRequestFrame(frame.price_e6, frame.size_e6),
-                ),
+                confirmationRequestMessage(quote.priceE6, quote.sizeE6),
               );
               return;
             }
 
             if (frame.type === 'RFQ_CONFIRMATION_RESPONSE') {
-              invariant(
-                typeof frame.decision === 'string',
-                'Expected RFQ confirmation decision.',
-              );
-              if (responseMode === 'confirmationTimeout') return;
-              if (responseMode === 'closeAfterConfirmation') {
-                socket.close();
-                return;
-              }
-
-              socket.send(JSON.stringify(confirmationAckFrame(frame.decision)));
-              if (frame.decision === 'CONFIRM') {
-                socket.send(JSON.stringify(executionUpdateFrame()));
+              const decision = confirmationDecision(frame);
+              socket.send(confirmationAckMessage(decision));
+              if (decision === 'CONFIRM') {
+                socket.send(executionUpdateMessage());
               }
             }
           });
@@ -127,6 +96,11 @@ describe('RFQ sessions', () => {
               apiKey: secureClientWithDepositWallet.credentials.key,
               passphrase: secureClientWithDepositWallet.credentials.passphrase,
               secret: secureClientWithDepositWallet.credentials.secret,
+            },
+            identity: {
+              maker_address: secureClientWithDepositWallet.account.wallet,
+              signature_type: SignatureType.POLY_1271,
+              signer_address: secureClientWithDepositWallet.account.wallet,
             },
             type: 'auth',
           }),
@@ -157,6 +131,15 @@ describe('RFQ sessions', () => {
               expect.objectContaining({
                 price_e6: 450_000,
                 rfq_id: event.rfqId,
+                signed_order: expect.objectContaining({
+                  makerAmount: '550000',
+                  maker: secureClientWithDepositWallet.account.wallet,
+                  side: 0,
+                  signatureType: SignatureType.POLY_1271,
+                  signer: secureClientWithDepositWallet.account.wallet,
+                  takerAmount: '1000000',
+                  tokenId: event.noPositionId,
+                }),
                 size_e6: QUOTE_SIZE_E6,
                 type: 'RFQ_QUOTE',
               }),
@@ -179,6 +162,45 @@ describe('RFQ sessions', () => {
                 quote_id: event.quoteId,
                 rfq_id: event.rfqId,
                 type: 'RFQ_CONFIRMATION_RESPONSE',
+              }),
+            );
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+
+    it('quotes from inventory for buy requests', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const ack = await event.quote({ price: 0.45, source: 'inventory' });
+
+            expect(ack).toEqual({
+              rfqId: event.rfqId,
+              quoteId: QUOTE_ID,
+            });
+
+            expect(outboundFrames).toContainEqual(
+              expect.objectContaining({
+                price_e6: 450_000,
+                rfq_id: event.rfqId,
+                signed_order: expect.objectContaining({
+                  makerAmount: '1000000',
+                  side: 1,
+                  takerAmount: '450000',
+                  tokenId: event.yesPositionId,
+                }),
+                size_e6: QUOTE_SIZE_E6,
+                type: 'RFQ_QUOTE',
               }),
             );
 
@@ -299,7 +321,7 @@ describe('RFQ sessions', () => {
 
           if (event.type === 'execution_update') {
             expect(event).toMatchObject({
-              rfqId: quoteRequestFrame().rfq_id,
+              rfqId: RFQ_ID,
               status: 'CONFIRMED',
               txHash: TX_HASH,
             });
@@ -314,9 +336,87 @@ describe('RFQ sessions', () => {
     });
   });
 
+  describe('when the RFQ request direction is sell', () => {
+    beforeEach(() => {
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage({ direction: 'SELL' }));
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              quoteAmounts(frame);
+              socket.send(quoteAckMessage());
+            }
+          });
+        }),
+      );
+    });
+
+    it('quotes from inventory', async ({ secureClientWithDepositWallet }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            const ack = await event.quote({ price: 0.45, source: 'inventory' });
+
+            expect(ack).toEqual({
+              rfqId: event.rfqId,
+              quoteId: QUOTE_ID,
+            });
+
+            expect(outboundFrames).toContainEqual(
+              expect.objectContaining({
+                price_e6: 450_000,
+                rfq_id: event.rfqId,
+                signed_order: expect.objectContaining({
+                  makerAmount: '1000000',
+                  side: 1,
+                  takerAmount: '550000',
+                  tokenId: event.noPositionId,
+                }),
+                size_e6: QUOTE_SIZE_E6,
+                type: 'RFQ_QUOTE',
+              }),
+            );
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
   describe('when quote acknowledgement times out', () => {
     beforeEach(() => {
-      responseMode = 'quoteTimeout';
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              quoteAmounts(frame);
+            }
+          });
+        }),
+      );
     });
 
     it('rejects the quote response', async ({
@@ -352,7 +452,33 @@ describe('RFQ sessions', () => {
 
   describe('when confirmation acknowledgement times out', () => {
     beforeEach(() => {
-      responseMode = 'confirmationTimeout';
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              const quote = quoteAmounts(frame);
+              socket.send(quoteAckMessage());
+              socket.send(
+                confirmationRequestMessage(quote.priceE6, quote.sizeE6),
+              );
+              return;
+            }
+
+            if (frame.type === 'RFQ_CONFIRMATION_RESPONSE') {
+              confirmationDecision(frame);
+            }
+          });
+        }),
+      );
     });
 
     it('rejects the confirmation response', async ({
@@ -395,7 +521,25 @@ describe('RFQ sessions', () => {
 
   describe('when the connection closes before quote acknowledgement', () => {
     beforeEach(() => {
-      responseMode = 'closeAfterQuote';
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              quoteAmounts(frame);
+              socket.close();
+            }
+          });
+        }),
+      );
     });
 
     it('rejects the quote response', async ({
@@ -429,7 +573,34 @@ describe('RFQ sessions', () => {
 
   describe('when the connection closes before confirmation acknowledgement', () => {
     beforeEach(() => {
-      responseMode = 'closeAfterConfirmation';
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              const quote = quoteAmounts(frame);
+              socket.send(quoteAckMessage());
+              socket.send(
+                confirmationRequestMessage(quote.priceE6, quote.sizeE6),
+              );
+              return;
+            }
+
+            if (frame.type === 'RFQ_CONFIRMATION_RESPONSE') {
+              confirmationDecision(frame);
+              socket.close();
+            }
+          });
+        }),
+      );
     });
 
     it('rejects the confirmation response', async ({
@@ -469,6 +640,22 @@ describe('RFQ sessions', () => {
   });
 
   describe('when quote input is invalid', () => {
+    beforeEach(() => {
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+            }
+          });
+        }),
+      );
+    });
+
     it('rejects before sending a quote response', async ({
       secureClientWithDepositWallet,
     }) => {
@@ -496,16 +683,17 @@ describe('RFQ sessions', () => {
   });
 
   describe('when opening repeated RFQ sessions', () => {
-    beforeAll(() => {
+    beforeEach(() => {
+      server.resetHandlers();
       server.use(
         rfq.addEventListener('connection', ({ client: socket }) => {
           connectionCount += 1;
 
           socket.addEventListener('message', (event) => {
-            const frame = JSON.parse(String(event.data)) as { type?: string };
+            const frame = recordOutboundFrame(event.data, outboundFrames);
 
             if (frame.type === 'auth') {
-              socket.send(JSON.stringify(authAckFrame()));
+              socket.send(authAckMessage());
             }
           });
         }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
       "@polymarket/bindings/data": ["./packages/bindings/src/data"],
       "@polymarket/bindings/gamma": ["./packages/bindings/src/gamma"],
       "@polymarket/bindings/relayer": ["./packages/bindings/src/relayer"],
+      "@polymarket/bindings/rfq": ["./packages/bindings/src/rfq.ts"],
       "@polymarket/bindings/subscriptions": [
         "./packages/bindings/src/subscriptions"
       ],


### PR DESCRIPTION
## Summary
- Rename the subscription-shaped WebSocket manager interface to `WebSocketSubscriptionManager`
- Keep the existing subscription handle and `client.subscribe(...)` surface receive-only

## Verification
- `pnpm lint`
- `pnpm typecheck`

## Next
- Add RFQ quoter-side bidirectional event stream abstractions and role-specific manager support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authenticated trading flows, on-chain approvals for new exchange/router contracts, and order signing—mistakes can block trading or submit invalid quotes.
> 
> **Overview**
> Adds **maker-side RFQ** support on secure clients via `openRfqSession()`: an authenticated quoter WebSocket that streams quote requests, confirmation (last-look) prompts, and execution updates, with `quote` / `confirm` / `decline` / `cancelQuote` helpers and typed rejection errors.
> 
> Introduces `@polymarket/bindings/rfq` (wire schemas, enums, inbound/outbound message unions) plus shared **`PositionId`** / RFQ ids on markets and list filters. Refactors subscription WebSocket managers to **`WebSocketSubscriptionManager`** and adds a separate **session** abstraction for bidirectional RFQ traffic; connections can pass optional **WebSocket headers** (e.g. preprod access).
> 
> **Protocol v2** touches: production env adds `exchangeV3`, `protocolV2Router`, `positionManager`, RFQ WS URL; **`prepareTradingApprovals`** gains collateral and ERC-1155 approvals for those contracts (16 checks). Order EIP-712 signing moves into shared **`exchange`** helpers (CLOB orders v2, RFQ quotes v3); order identity uses **`resolveOrderIdentity`**. Secure clients now require a **signer** (no optional signer on auth).
> 
> Docs/tests: AGENTS rule against indexed-access types in public surfaces; broad RFQ integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d27d4a75ee66559023ca543b448a3819fe34e4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->