### PR TITLE
Fix GTD limit order expiration boundary

### DIFF
--- a/.changeset/fix-gtd-expiration-boundary.md
+++ b/.changeset/fix-gtd-expiration-boundary.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Allow GTD limit order expirations exactly 60 seconds in the future and document using an additional latency buffer.

--- a/packages/client/src/actions/orders/limit.test.ts
+++ b/packages/client/src/actions/orders/limit.test.ts
@@ -1,0 +1,39 @@
+import { OrderSide } from '@polymarket/bindings';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PrepareLimitOrderParamsSchema } from './limit';
+
+describe('PrepareLimitOrderParamsSchema', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('accepts a GTD expiration exactly 60 seconds in the future', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    expect(
+      PrepareLimitOrderParamsSchema.safeParse({
+        expiration: Math.floor(Date.now() / 1000) + 60,
+        price: 0.52,
+        side: OrderSide.BUY,
+        size: 10,
+        tokenId: '123',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a GTD expiration less than 60 seconds in the future', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+    expect(
+      PrepareLimitOrderParamsSchema.safeParse({
+        expiration: Math.floor(Date.now() / 1000) + 59,
+        price: 0.52,
+        side: OrderSide.BUY,
+        size: 10,
+        tokenId: '123',
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/client/src/actions/orders/limit.ts
+++ b/packages/client/src/actions/orders/limit.ts
@@ -36,7 +36,7 @@ export const PrepareLimitOrderParamsSchema = z
     if (params.expiration !== undefined) {
       const minimumExpiration = Math.floor(Date.now() / 1000) + 60;
 
-      if (params.expiration <= minimumExpiration) {
+      if (params.expiration < minimumExpiration) {
         context.addIssue({
           code: 'custom',
           message: 'Expiration must be at least 60 seconds in the future.',

--- a/packages/client/src/actions/orders/trade.ts
+++ b/packages/client/src/actions/orders/trade.ts
@@ -110,6 +110,11 @@ export const CreateLimitOrderError = makeErrorGuard(
 /**
  * Creates a signed limit order for the authenticated account.
  *
+ * @remarks
+ * GTD expirations must be at least 60 seconds in the future. Add your own
+ * buffer for network latency and clock skew when deriving an expiration from
+ * the current time.
+ *
  * @throws {@link CreateLimitOrderError}
  * Thrown on failure.
  */
@@ -139,6 +144,11 @@ export const PlaceLimitOrderError = makeErrorGuard(
 
 /**
  * Creates and posts a limit order for the authenticated account.
+ *
+ * @remarks
+ * GTD expirations must be at least 60 seconds in the future. Add your own
+ * buffer for network latency and clock skew when deriving an expiration from
+ * the current time.
  *
  * @throws {@link PlaceLimitOrderError}
  * Thrown on failure.

--- a/packages/client/src/actions/orders/types.ts
+++ b/packages/client/src/actions/orders/types.ts
@@ -102,6 +102,10 @@ export type PrepareLimitOrderRequest = {
    * When provided, the SDK prepares a Good-Til-Date (GTD) limit order that
    * expires at the given timestamp.
    *
+   * The timestamp must be at least 60 seconds in the future. Add your own
+   * buffer for network latency and clock skew when deriving it from the
+   * current time.
+   *
    * When omitted, the SDK prepares a Good-Til-Cancelled (GTC) limit order.
    */
   expiration?: number;

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -68,6 +68,11 @@ export type SecureTradingActions = {
   /**
    * Creates a signed limit order for the authenticated account.
    *
+   * @remarks
+   * GTD expirations must be at least 60 seconds in the future. Add your own
+   * buffer for network latency and clock skew when deriving an expiration from
+   * the current time.
+   *
    * @throws {@link CreateLimitOrderError}
    * Thrown on failure.
    *
@@ -85,6 +90,11 @@ export type SecureTradingActions = {
   createLimitOrder(request: PrepareLimitOrderRequest): Promise<SignedOrder>;
   /**
    * Creates and posts a limit order for the authenticated account.
+   *
+   * @remarks
+   * GTD expirations must be at least 60 seconds in the future. Add your own
+   * buffer for network latency and clock skew when deriving an expiration from
+   * the current time.
    *
    * @throws {@link PlaceLimitOrderError}
    * Thrown on failure.


### PR DESCRIPTION
## Summary
- allow GTD limit order expirations exactly 60 seconds in the future
- add schema tests for the 60-second boundary
- document adding caller-side buffer for latency and clock skew

Closes DEV-147

## Verification
- pnpm test:client
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation and documentation change in order prep with targeted tests; no auth or posting logic changes.
> 
> **Overview**
> Fixes **GTD limit order** validation so an `expiration` exactly **60 seconds** ahead is accepted (`<` instead of `<=` on the minimum timestamp in `PrepareLimitOrderParamsSchema`).
> 
> Adds **Vitest** coverage for the 60s accept / 59s reject cases and updates **JSDoc** on limit-order APIs and `PrepareLimitOrderRequest` to note the 60s rule and recommend a **caller-side buffer** for latency and clock skew.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d0ecf39176f8054e07c4c353d6ee1a7cbd1141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->