### PR TITLE
docs: clarify order book and subscription types

### DIFF
--- a/.changeset/clever-books-cheer.md
+++ b/.changeset/clever-books-cheer.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Document order book level ordering and custom market subscription events.

--- a/packages/bindings/src/clob/order-book.ts
+++ b/packages/bindings/src/clob/order-book.ts
@@ -15,6 +15,9 @@ export type OrderBookLevel = {
   size: DecimalString;
 };
 
+/** SHA-1 hash of the serialized order book summary, encoded as bare lowercase hex. */
+export type OrderBookHash = string & { readonly __tag: 'OrderBookHash' };
+
 export type OrderBook = {
   market: ConditionId;
   tokenId: TokenId;
@@ -30,13 +33,18 @@ export type OrderBook = {
   tickSize: DecimalString;
   negRisk: boolean;
   lastTradePrice?: DecimalString | null;
-  hash: string;
+  hash: OrderBookHash;
 };
 
 export const OrderBookLevelSchema = z.object({
   price: DecimalStringSchema,
   size: DecimalStringSchema,
 }) satisfies z.ZodType<OrderBookLevel>;
+
+export const OrderBookHashSchema = z
+  .string()
+  .regex(/^[a-f0-9]{40}$/)
+  .transform((value) => value as OrderBookHash);
 
 export const OrderBookSchema = z
   .object({
@@ -49,7 +57,7 @@ export const OrderBookSchema = z
     tick_size: DecimalStringSchema,
     neg_risk: z.boolean(),
     last_trade_price: DecimalStringSchema.nullish(),
-    hash: z.string(),
+    hash: OrderBookHashSchema,
   })
   .transform(
     ({

--- a/packages/bindings/src/clob/order-book.ts
+++ b/packages/bindings/src/clob/order-book.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import {
+  type ConditionId,
+  ConditionIdSchema,
   type DecimalString,
   DecimalStringSchema,
   type EpochMilliseconds,
@@ -14,7 +16,7 @@ export type OrderBookLevel = {
 };
 
 export type OrderBook = {
-  market: string;
+  market: ConditionId;
   tokenId: TokenId;
   timestamp?: EpochMilliseconds | null;
 
@@ -38,7 +40,7 @@ export const OrderBookLevelSchema = z.object({
 
 export const OrderBookSchema = z
   .object({
-    market: z.string(),
+    market: ConditionIdSchema,
     asset_id: TokenIdSchema,
     timestamp: EpochMillisecondsStringSchema.nullish(),
     bids: z.array(OrderBookLevelSchema),

--- a/packages/bindings/src/clob/order-book.ts
+++ b/packages/bindings/src/clob/order-book.ts
@@ -1,14 +1,40 @@
 import { z } from 'zod';
 import {
+  type DecimalString,
   DecimalStringSchema,
+  type EpochMilliseconds,
   EpochMillisecondsStringSchema,
+  type TokenId,
   TokenIdSchema,
 } from '../shared';
+
+export type OrderBookLevel = {
+  price: DecimalString;
+  size: DecimalString;
+};
+
+export type OrderBook = {
+  market: string;
+  tokenId: TokenId;
+  timestamp?: EpochMilliseconds | null;
+
+  /** Bid levels in ascending price order, lowest bid first. */
+  bids: OrderBookLevel[];
+
+  /** Ask levels in descending price order, highest ask first. */
+  asks: OrderBookLevel[];
+
+  minOrderSize: DecimalString;
+  tickSize: DecimalString;
+  negRisk: boolean;
+  lastTradePrice?: DecimalString | null;
+  hash: string;
+};
 
 export const OrderBookLevelSchema = z.object({
   price: DecimalStringSchema,
   size: DecimalStringSchema,
-});
+}) satisfies z.ZodType<OrderBookLevel>;
 
 export const OrderBookSchema = z
   .object({
@@ -39,14 +65,10 @@ export const OrderBookSchema = z
       negRisk: neg_risk,
       lastTradePrice: last_trade_price,
     }),
-  );
+  ) satisfies z.ZodType<OrderBook>;
 
 export const FetchOrderBookResponseSchema = OrderBookSchema;
 export const OrderBooksSchema = z.array(OrderBookSchema);
 
-export type OrderBookLevel = z.infer<typeof OrderBookLevelSchema>;
-export type OrderBook = z.infer<typeof OrderBookSchema>;
-export type OrderBooks = z.infer<typeof OrderBooksSchema>;
-export type FetchOrderBookResponse = z.infer<
-  typeof FetchOrderBookResponseSchema
->;
+export type OrderBooks = OrderBook[];
+export type FetchOrderBookResponse = OrderBook;

--- a/packages/client/src/actions/subscriptions.ts
+++ b/packages/client/src/actions/subscriptions.ts
@@ -46,7 +46,13 @@ export type EquityPricesEventType = EquityPricesEvent['type'];
 // Subscription specs.
 export type MarketSubscription = {
   topic: 'market';
+  /** Token IDs whose market events should be delivered. */
   tokenIds: readonly string[];
+
+  /**
+   * When `true`, the server additionally emits `MarketBestBidAskEvent`,
+   * `NewMarketEvent`, and `MarketResolvedEvent`.
+   */
   customFeatureEnabled?: boolean;
 };
 


### PR DESCRIPTION
## Summary
- document `OrderBook.bids` and `OrderBook.asks` ordering on explicit public types
- type `OrderBook.market` as a branded `ConditionId` and validate it with `ConditionIdSchema`
- type `OrderBook.hash` as a branded `OrderBookHash` and validate the backend SHA-1 hex format
- type-check the Zod order-book schemas against those documented types
- document which market events `customFeatureEnabled` enables

Closes DEV-145
Closes DEV-146

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm changeset status --since=origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and compile-time typing with slightly stricter Zod validation on order book fields; no auth, payments, or broad behavioral refactors.
> 
> **Overview**
> This PR tightens **public typings and docs** for CLOB order books and market subscriptions without changing runtime behavior beyond stricter parsing.
> 
> In `@polymarket/bindings`, order book types are now **explicit interfaces** (not `z.infer`) with JSDoc stating **bids ascend** (lowest first) and **asks descend** (highest first). `market` is a branded **`ConditionId`** and `hash` a branded **`OrderBookHash`** validated as **40-char lowercase hex** (SHA-1). Zod schemas use **`satisfies z.ZodType<...>`** so parsers stay aligned with those types.
> 
> In `@polymarket/client`, **`MarketSubscription`** documents `tokenIds` and that **`customFeatureEnabled: true`** also delivers `MarketBestBidAskEvent`, `NewMarketEvent`, and `MarketResolvedEvent`. A changeset records patch releases for both packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b9084128bf9b54cbdb094476a4347b2fc8a68e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->