### PR TITLE
fix: add package repository metadata

### DIFF
--- a/.changeset/fuzzy-hornets-report.md
+++ b/.changeset/fuzzy-hornets-report.md
@@ -1,0 +1,7 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+"@polymarket/types": patch
+---
+
+Add repository metadata required for npm trusted publishing provenance validation.

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -2,6 +2,11 @@
   "name": "@polymarket/bindings",
   "version": "0.1.0-beta.2",
   "description": "Internal package. Contains generated bindings for the Polymarket API. Not intended for direct use.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Polymarket/ts-sdk",
+    "directory": "packages/bindings"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,6 +2,11 @@
   "name": "@polymarket/client",
   "version": "0.1.0-beta.2",
   "description": "The Polymarket TypeScript client",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Polymarket/ts-sdk",
+    "directory": "packages/client"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -2,6 +2,11 @@
   "name": "@polymarket/types",
   "version": "0.1.0-beta.2",
   "description": "Shared TypeScript types for the Polymarket SDK.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Polymarket/ts-sdk",
+    "directory": "packages/types"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Adds repository metadata to the published package manifests so npm trusted publishing provenance can validate the GitHub source repository.\n\nVerification:\n- pnpm lint\n- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only metadata and a changeset; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Adds **`repository`** metadata to **`@polymarket/bindings`**, **`@polymarket/client`**, and **`@polymarket/types`** `package.json` files, pointing at `https://github.com/Polymarket/ts-sdk` with per-package **`directory`** paths. A changeset records patch releases for all three packages so published manifests satisfy **npm trusted publishing provenance** validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e0f923af12c716d9e4fe8b24b8d4d8d77893dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->