### PR TITLE
Drop unsupported tag/series request params and response fields; normalize related-tag id casing

### DIFF
--- a/.changeset/lemon-pumas-cheer.md
+++ b/.changeset/lemon-pumas-cheer.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Drop unsupported tag/series request params and response fields, and normalize related tag id fields to camelCase.

--- a/packages/bindings/src/gamma/series.ts
+++ b/packages/bindings/src/gamma/series.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
-import { CategoryReferenceSchema } from './common';
 import {
-  ChatSchema,
   CollectionReferenceSchema,
   EventSchema,
   SeriesReferenceSchema,
@@ -11,8 +9,6 @@ import { TagSchema } from './tag';
 export const SeriesSchema = SeriesReferenceSchema.extend({
   events: z.array(EventSchema).nullish(),
   collections: z.array(CollectionReferenceSchema).nullish(),
-  categories: z.array(CategoryReferenceSchema).nullish(),
-  chats: z.array(ChatSchema).nullish(),
   tags: z.array(TagSchema).nullish(),
 });
 

--- a/packages/bindings/src/gamma/tag.test.ts
+++ b/packages/bindings/src/gamma/tag.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { RelatedTagSchema } from './tag';
+
+describe('RelatedTagSchema', () => {
+  it('normalizes the related tag id fields to camelCase output', () => {
+    const result = RelatedTagSchema.parse({
+      id: 'rel-1',
+      tagID: 42,
+      relatedTagID: 99,
+      rank: 3,
+    });
+
+    expect(result).toEqual({
+      id: 'rel-1',
+      tagId: 42,
+      relatedTagId: 99,
+      rank: 3,
+    });
+    expect(result).not.toHaveProperty('tagID');
+    expect(result).not.toHaveProperty('relatedTagID');
+  });
+});

--- a/packages/bindings/src/gamma/tag.ts
+++ b/packages/bindings/src/gamma/tag.ts
@@ -1,19 +1,24 @@
 import { z } from 'zod';
 import { TagIdSchema } from '../shared';
 import { TagReferenceSchema } from './common';
-import { ChatSchema, TemplateReferenceSchema } from './event';
+import { TemplateReferenceSchema } from './event';
 
 export const TagSchema = TagReferenceSchema.extend({
-  chats: z.array(ChatSchema).nullish(),
   templates: z.array(TemplateReferenceSchema).nullish(),
 });
 
-export const RelatedTagSchema = z.object({
-  id: z.string(),
-  tagID: z.number().int().nullish(),
-  relatedTagID: z.number().int().nullish(),
-  rank: z.number().int().nullish(),
-});
+export const RelatedTagSchema = z
+  .object({
+    id: z.string(),
+    tagID: z.number().int().nullish(),
+    relatedTagID: z.number().int().nullish(),
+    rank: z.number().int().nullish(),
+  })
+  .transform(({ tagID, relatedTagID, ...rest }) => ({
+    ...rest,
+    tagId: tagID,
+    relatedTagId: relatedTagID,
+  }));
 
 export const ListTagsResponseSchema = z.array(TagSchema);
 export const ListRelatedTagsResponseSchema = z.array(RelatedTagSchema);

--- a/packages/client/src/actions/series.ts
+++ b/packages/client/src/actions/series.ts
@@ -28,12 +28,9 @@ import { snakeCase, toSearchParams } from './params';
 
 const ListSeriesRequestSchema = z.object({
   ascending: z.boolean().optional(),
-  categoriesIds: z.array(z.number().int()).optional(),
-  categoriesLabels: z.array(z.string()).optional(),
   closed: z.boolean().optional(),
   cursor: PaginationCursorSchema.optional(),
   excludeEvents: z.boolean().optional(),
-  includeChat: z.boolean().optional(),
   locale: z.string().optional(),
   order: z.string().optional(),
   pageSize: PageSizeSchema.default(20),
@@ -43,13 +40,11 @@ const ListSeriesRequestSchema = z.object({
 
 const FetchSeriesRequestSchema = z.object({
   id: z.string(),
-  includeChat: z.boolean().optional(),
   locale: z.string().optional(),
 });
 
 export type ListSeriesRequest = z.input<typeof ListSeriesRequestSchema>;
 export type FetchSeriesRequest = z.input<typeof FetchSeriesRequestSchema>;
-type ListSeriesParams = z.output<typeof ListSeriesRequestSchema>;
 
 export type ListSeriesError =
   | RateLimitError
@@ -120,10 +115,7 @@ export function listSeries(
             limit: decoded.pageSize + 1,
             offset: decoded.offset,
           },
-          snakeCase<ListSeriesParams>({
-            categoriesIds: 'categories_ids',
-            categoriesLabels: 'categories_labels',
-          }),
+          snakeCase(),
         ),
       })
       .andThen(validateWith(ListSeriesResponseSchema))
@@ -168,7 +160,7 @@ export const FetchSeriesError = makeErrorGuard(
  * ```ts
  * const series = await fetchSeries(client, {
  *   id: 'fed-daily-series',
- *   includeChat: true,
+ *   locale: 'en',
  * });
  *
  * // series === Series
@@ -185,7 +177,6 @@ export async function fetchSeries(
       .get(`series/${params.id}`, {
         params: toSearchParams(
           {
-            includeChat: params.includeChat,
             locale: params.locale,
           },
           snakeCase(),

--- a/packages/client/src/actions/tags.ts
+++ b/packages/client/src/actions/tags.ts
@@ -32,7 +32,6 @@ import { snakeCase, toSearchParams } from './params';
 const ListTagsRequestSchema = z.object({
   ascending: z.boolean().optional(),
   cursor: PaginationCursorSchema.optional(),
-  includeChat: z.boolean().optional(),
   includeTemplate: z.boolean().optional(),
   isCarousel: z.boolean().optional(),
   locale: z.string().optional(),
@@ -43,7 +42,6 @@ const ListTagsRequestSchema = z.object({
 const FetchTagRequestSchema = z.union([
   z.object({
     id: z.string(),
-    includeChat: z.boolean().optional(),
     includeTemplate: z.boolean().optional(),
     locale: z.string().optional(),
   }),
@@ -218,7 +216,6 @@ export async function fetchTag(
         .get(`tags/${params.id}`, {
           params: toSearchParams(
             {
-              includeChat: params.includeChat,
               includeTemplate: params.includeTemplate,
               locale: params.locale,
             },


### PR DESCRIPTION
Removes tag/series request params (`includeChat`, `categoriesIds`, `categoriesLabels`) the request schemas accept but the upstream never binds, and response fields (`Tag.chats`, `Series.categories`, `Series.chats`) it never populates — so the surface matches what's actually supported.

`RelatedTag` ids are normalized to camelCase `tagId`/`relatedTagId` on output via a zod `.transform`; the upstream `tagID`/`relatedTagID` wire keys are still read, so parsing is unaffected. `patch` changeset for `@polymarket/bindings` + `@polymarket/client`; new `RelatedTagSchema` test covers the casing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public SDK types and request options are removed or renamed (RelatedTag id fields), which can break consumers still using the old surface even though it matched unsupported API behavior.
> 
> **Overview**
> Aligns **gamma tag/series** bindings and client actions with what the API actually supports by removing request options and response shapes that were never wired or populated upstream.
> 
> **Series & tags clients** no longer accept `includeChat`, and series listing no longer accepts `categoriesIds` / `categoriesLabels` or sends custom snake_case mappings for those keys. **Bindings** drop `Tag.chats`, `Series.categories`, and `Series.chats` from parsed models.
> 
> **Related tags** still parse upstream `tagID` / `relatedTagID` from JSON, but **`RelatedTag` output** is normalized to camelCase `tagId` / `relatedTagId` via a Zod transform; a new unit test locks in that behavior. Patch **changeset** for `@polymarket/bindings` and `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7a88581e0b464b0e6d9bfb9d15fe6d1ba11699f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->