### PR TITLE
docs(client): mark action helpers low-level

### DIFF
--- a/.changeset/low-level-action-helpers.md
+++ b/.changeset/low-level-action-helpers.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Mark public action entry point helpers as low-level functions and point consumers to client instance APIs.

--- a/packages/client/src/actions/account.ts
+++ b/packages/client/src/actions/account.ts
@@ -62,6 +62,9 @@ export const FetchClosedOnlyModeError = makeErrorGuard(
 /**
  * Fetches whether the account is restricted to closed-only trading.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchClosedOnlyModeError}
  *
  * @example
@@ -109,6 +112,9 @@ export const ListOpenOrdersError = makeErrorGuard(
 
 /**
  * Lists open orders for the authenticated account across all pages.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListOpenOrdersError}
  *
@@ -195,6 +201,9 @@ export const FetchOrderError = makeErrorGuard(
 /**
  * Fetches a single order for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchOrderError}
  *
  * @example
@@ -252,6 +261,9 @@ export const ListAccountTradesError = makeErrorGuard(
 
 /**
  * Lists trades for the authenticated account across all pages.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListAccountTradesError}
  *
@@ -339,6 +351,9 @@ export type DropNotificationsRequest = z.input<
 /**
  * Fetches notifications for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchNotificationsError}
  *
  * @example
@@ -378,6 +393,9 @@ export const DropNotificationsError = makeErrorGuard(
 
 /**
  * Drops notifications for the authenticated account.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link DropNotificationsError}
  * Thrown on failure.
@@ -439,7 +457,7 @@ export const FetchBalanceAllowanceError = makeErrorGuard(
  * Fetches balance and allowance for the authenticated account.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchBalanceAllowanceError}
  * Thrown on failure.
@@ -496,7 +514,7 @@ export const UpdateBalanceAllowanceError = makeErrorGuard(
  * Refreshes balance and allowance for the authenticated account.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link UpdateBalanceAllowanceError}
  * Thrown on failure.
@@ -554,6 +572,9 @@ export const FetchOrderScoringError = makeErrorGuard(
 /**
  * Fetches whether a single order is currently scoring.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchOrderScoringError}
  *
  * @example
@@ -604,6 +625,9 @@ export const FetchOrdersScoringError = makeErrorGuard(
 
 /**
  * Fetches scoring state for multiple orders.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchOrdersScoringError}
  *
@@ -656,6 +680,9 @@ export const ListUserEarningsForDayError = makeErrorGuard(
 
 /**
  * Lists per-market earnings for the authenticated account on a given day.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListUserEarningsForDayError}
  *
@@ -745,6 +772,9 @@ export const FetchTotalEarningsForUserForDayError = makeErrorGuard(
 /**
  * Fetches total earnings for the authenticated account on a given day.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchTotalEarningsForUserForDayError}
  *
  * @example
@@ -806,6 +836,9 @@ export const ListUserEarningsAndMarketsConfigError = makeErrorGuard(
 
 /**
  * Lists market reward configuration and earnings for the authenticated account on a given day.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListUserEarningsAndMarketsConfigError}
  *
@@ -889,6 +922,9 @@ export const FetchRewardPercentagesError = makeErrorGuard(
 
 /**
  * Fetches reward percentages for the authenticated account.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchRewardPercentagesError}
  *

--- a/packages/client/src/actions/activity.ts
+++ b/packages/client/src/actions/activity.ts
@@ -96,6 +96,9 @@ export const ListTradesError = makeErrorGuard(
 /**
  * Lists trades for a wallet, market, or event.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListTradesError}
  * Thrown on failure.
  *
@@ -182,6 +185,9 @@ export const ListActivityError = makeErrorGuard(
 
 /**
  * Lists wallet activity.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListActivityError}
  * Thrown on failure.

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -60,7 +60,7 @@ export const PrepareErc20ApprovalError = makeErrorGuard(UserInputError);
  * Starts an ERC-20 approval workflow.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -121,6 +121,9 @@ export const ApproveErc20Error = makeErrorGuard(
 /**
  * Approves ERC-20 token spending for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ApproveErc20Error}
  * Thrown on failure.
  */
@@ -161,7 +164,7 @@ export const PrepareErc1155ApprovalForAllError = makeErrorGuard(UserInputError);
  * Starts an ERC-1155 approval-for-all workflow.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -227,6 +230,9 @@ export const ApproveErc1155ForAllError = makeErrorGuard(
 /**
  * Approves or revokes ERC-1155 operator access for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ApproveErc1155ForAllError}
  * Thrown on failure.
  */
@@ -257,7 +263,7 @@ export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
  * Starts a trading-setup approval workflow.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * Prepares all approvals required for trading, including collateral and
  * position token approvals for both standard and neg-risk market flows.
@@ -381,6 +387,9 @@ export const SetupTradingApprovalsError = makeErrorGuard(
 
 /**
  * Sets up the approvals required for trading.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link SetupTradingApprovalsError}
  * Thrown on failure.

--- a/packages/client/src/actions/auth.ts
+++ b/packages/client/src/actions/auth.ts
@@ -44,7 +44,7 @@ export const CreateApiKeyError = makeErrorGuard(
  * Creates a new API key from a signed L1 auth payload.
  *
  * @remarks
- * This is a low-level auth action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -83,7 +83,7 @@ export const DeriveApiKeyError = makeErrorGuard(
  * Derives an existing API key from a signed L1 auth payload.
  *
  * @remarks
- * This is a low-level auth action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -122,7 +122,7 @@ export const CreateOrDeriveApiKeyError = makeErrorGuard(
  * Creates an API key and falls back to derivation when it already exists.
  *
  * @remarks
- * This is a low-level auth action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -165,7 +165,7 @@ export const FetchApiKeysError = makeErrorGuard(
  * Fetches all API keys associated with the authenticated client.
  *
  * @remarks
- * This is a low-level auth action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -205,7 +205,7 @@ export const DeleteApiKeyError = makeErrorGuard(
  * Deletes the authenticated API key.
  *
  * @remarks
- * This is a low-level auth action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -242,7 +242,7 @@ export const CreateBuilderApiKeyError = makeErrorGuard(
  * Creates a new builder API key for the authenticated client.
  *
  * @remarks
- * This is a low-level auth action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -281,7 +281,7 @@ export const FetchBuilderApiKeysError = makeErrorGuard(
  * Fetches builder API keys associated with the authenticated client.
  *
  * @remarks
- * This is a low-level auth action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -320,7 +320,7 @@ export const RevokeBuilderApiKeyError = makeErrorGuard(
  * Revokes a builder API key.
  *
  * @remarks
- * This is a low-level auth action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts

--- a/packages/client/src/actions/builders.ts
+++ b/packages/client/src/actions/builders.ts
@@ -54,6 +54,9 @@ export const ListBuilderTradesError = makeErrorGuard(
 /**
  * Lists builder-attributed trades.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListBuilderTradesError}
  * Thrown on failure.
  *

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -78,6 +78,9 @@ export const FetchMidpointError = makeErrorGuard(
 /**
  * Fetches the midpoint price for a token.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchMidpointError}
  * Thrown on failure.
  *
@@ -135,6 +138,9 @@ export const FetchMidpointsError = makeErrorGuard(
 /**
  * Fetches midpoint prices for multiple tokens.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchMidpointsError}
  * Thrown on failure.
  *
@@ -190,7 +196,7 @@ export const FetchTickSizeError = makeErrorGuard(
  * Fetches the minimum price tick size for a token's order book.
  *
  * @remarks
- * This is a low-level market action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchTickSizeError}
  * Thrown on failure.
@@ -245,7 +251,7 @@ export const FetchNegRiskError = makeErrorGuard(
  * Fetches whether a token is in a negative-risk market.
  *
  * @remarks
- * This is a low-level market action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchNegRiskError}
  * Thrown on failure.
@@ -302,7 +308,7 @@ export const ResolveConditionByTokenError = makeErrorGuard(
  * Resolves the condition ID for a token.
  *
  * @remarks
- * This is a low-level market action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ResolveConditionByTokenError}
  * Thrown on failure.
@@ -346,7 +352,7 @@ export const FetchMarketInfoError = makeErrorGuard(
  * Fetches market-level metadata for a condition.
  *
  * @remarks
- * This is a low-level market action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchMarketInfoError}
  * Thrown on failure.
@@ -390,7 +396,7 @@ export const FetchBuilderFeeRatesError = makeErrorGuard(
  * Fetches builder maker and taker fee rates.
  *
  * @remarks
- * This is a low-level market action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchBuilderFeeRatesError}
  * Thrown on failure.
@@ -431,6 +437,9 @@ export const FetchPriceError = makeErrorGuard(
 
 /**
  * Fetches the current quoted price for a token and side.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchPriceError}
  * Thrown on failure.
@@ -491,6 +500,9 @@ export const FetchPricesError = makeErrorGuard(
 /**
  * Fetches quoted prices for multiple tokens.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchPricesError}
  * Thrown on failure.
  *
@@ -545,6 +557,9 @@ export const FetchOrderBookError = makeErrorGuard(
 
 /**
  * Fetches the current order book for a token.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchOrderBookError}
  * Thrown on failure.
@@ -603,6 +618,9 @@ export const FetchOrderBooksError = makeErrorGuard(
 /**
  * Fetches order books for multiple tokens.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchOrderBooksError}
  * Thrown on failure.
  *
@@ -655,6 +673,9 @@ export const FetchSpreadError = makeErrorGuard(
 
 /**
  * Fetches the spread for a token.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchSpreadError}
  * Thrown on failure.
@@ -713,6 +734,9 @@ export const FetchSpreadsError = makeErrorGuard(
 /**
  * Fetches spreads for multiple tokens.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchSpreadsError}
  * Thrown on failure.
  *
@@ -768,6 +792,9 @@ export const FetchLastTradePriceError = makeErrorGuard(
 
 /**
  * Fetches the last traded price for a token.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchLastTradePriceError}
  * Thrown on failure.
@@ -826,6 +853,9 @@ export const FetchLastTradePricesError = makeErrorGuard(
 
 /**
  * Fetches last traded prices for multiple tokens.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchLastTradePricesError}
  * Thrown on failure.
@@ -886,6 +916,9 @@ export const FetchPriceHistoryError = makeErrorGuard(
 
 /**
  * Fetches historical price points for a token.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchPriceHistoryError}
  * Thrown on failure.
@@ -952,6 +985,9 @@ export const ListCurrentRewardsError = makeErrorGuard(
 
 /**
  * Lists current active market rewards.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListCurrentRewardsError}
  * Thrown on failure.
@@ -1040,6 +1076,9 @@ export const ListMarketRewardsError = makeErrorGuard(
 
 /**
  * Lists reward configurations for a market.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListMarketRewardsError}
  * Thrown on failure.

--- a/packages/client/src/actions/comments.ts
+++ b/packages/client/src/actions/comments.ts
@@ -80,6 +80,9 @@ export const ListCommentsError = makeErrorGuard(
 /**
  * Lists comments for an event or series.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListCommentsError}
  * Thrown on failure.
  *
@@ -177,6 +180,9 @@ export const FetchCommentsByIdError = makeErrorGuard(
 /**
  * Fetches a comment thread by comment id.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchCommentsByIdError}
  * Thrown on failure.
  *
@@ -226,6 +232,9 @@ export const ListCommentsByUserAddressError = makeErrorGuard(
 
 /**
  * Lists comments written by a wallet address.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListCommentsByUserAddressError}
  * Thrown on failure.

--- a/packages/client/src/actions/events.ts
+++ b/packages/client/src/actions/events.ts
@@ -135,6 +135,9 @@ export const ListEventsError = makeErrorGuard(
 /**
  * Lists events.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListEventsError}
  * Thrown on failure.
  *
@@ -209,6 +212,9 @@ export const FetchEventError = makeErrorGuard(
 /**
  * Fetches an event.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchEventError}
  * Thrown on failure.
  *
@@ -274,6 +280,9 @@ export const FetchEventTagsError = makeErrorGuard(
 /**
  * Fetches an event's tags.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchEventTagsError}
  * Thrown on failure.
  *
@@ -315,6 +324,9 @@ export const FetchEventLiveVolumeError = makeErrorGuard(
 
 /**
  * Fetches live volume for an event.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchEventLiveVolumeError}
  * Thrown on failure.

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -123,7 +123,7 @@ export const FetchExecuteParamsError = makeErrorGuard(
  * Fetches the parameters needed to prepare a low-level transaction submission.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchExecuteParamsError}
  * Thrown on failure.
@@ -176,7 +176,7 @@ export const IsGaslessReadyError = makeErrorGuard(
  * Checks whether a wallet is ready for gasless transactions.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link IsGaslessReadyError}
  * Thrown on failure.
@@ -270,7 +270,7 @@ export const DeployDepositWalletError = makeErrorGuard(
  * Deploys a Deposit Wallet for the authenticated signer.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link DeployDepositWalletError}
  * Thrown on failure.
@@ -295,7 +295,7 @@ export async function deployDepositWallet(
  * Fetches a submitted transaction.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchGaslessTransactionError}
  * Thrown on failure.
@@ -362,7 +362,7 @@ export const PrepareGaslessTransactionError = makeErrorGuard(
  * Starts preparing a low-level transaction workflow from one or more calls.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link PrepareGaslessTransactionError}
  * Thrown on failure.

--- a/packages/client/src/actions/leaderboards.ts
+++ b/packages/client/src/actions/leaderboards.ts
@@ -79,6 +79,9 @@ export const ListBuilderLeaderboardError = makeErrorGuard(
 /**
  * Lists builder leaderboard rankings.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListBuilderLeaderboardError}
  * Thrown on failure.
  *
@@ -166,6 +169,9 @@ export const ListBuilderVolumeError = makeErrorGuard(
 /**
  * Lists daily builder volume entries.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListBuilderVolumeError}
  * Thrown on failure.
  *
@@ -209,6 +215,9 @@ export const ListTraderLeaderboardError = makeErrorGuard(
 
 /**
  * Lists trader leaderboard rankings.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListTraderLeaderboardError}
  * Thrown on failure.

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -170,6 +170,9 @@ export const ListMarketsError = makeErrorGuard(
 /**
  * Lists markets.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListMarketsError}
  * Thrown on failure.
  *
@@ -244,6 +247,9 @@ export const FetchMarketError = makeErrorGuard(
 /**
  * Fetches a market.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchMarketError}
  * Thrown on failure.
  *
@@ -302,6 +308,9 @@ export const FetchMarketTagsError = makeErrorGuard(
 /**
  * Fetches a market's tags.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchMarketTagsError}
  * Thrown on failure.
  *
@@ -343,6 +352,9 @@ export const ListMarketHoldersError = makeErrorGuard(
 
 /**
  * Lists the top holders for one or more markets.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListMarketHoldersError}
  * Thrown on failure.
@@ -389,6 +401,9 @@ export const ListOpenInterestError = makeErrorGuard(
 /**
  * Lists open interest for one or more markets.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListOpenInterestError}
  * Thrown on failure.
  *
@@ -432,6 +447,9 @@ export const ListMarketPositionsError = makeErrorGuard(
 
 /**
  * Lists positions for a market.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListMarketPositionsError}
  * Thrown on failure.

--- a/packages/client/src/actions/orders/cancel.ts
+++ b/packages/client/src/actions/orders/cancel.ts
@@ -59,6 +59,9 @@ export const CancelOrderError = makeErrorGuard(
 /**
  * Cancels a single open order for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link CancelOrderError}
  * Thrown on failure.
  *
@@ -102,6 +105,9 @@ export const CancelOrdersError = makeErrorGuard(
 /**
  * Cancels multiple open orders for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link CancelOrdersError}
  * Thrown on failure.
  *
@@ -139,6 +145,9 @@ export const CancelAllError = makeErrorGuard(
 
 /**
  * Cancels all open orders for the authenticated account.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link CancelAllError}
  * Thrown on failure.
@@ -178,6 +187,9 @@ export const CancelMarketOrdersError = makeErrorGuard(
 /**
  * Cancels all open orders for the authenticated account that match the market
  * or token filter.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link CancelMarketOrdersError}
  * Thrown on failure.

--- a/packages/client/src/actions/orders/estimate.ts
+++ b/packages/client/src/actions/orders/estimate.ts
@@ -107,6 +107,9 @@ export const EstimateMarketPriceError = makeErrorGuard(
  * should be treated as a partial-fill execution estimate rather than a full-fill
  * guarantee.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @example
  * ```ts
  * const price = await estimateMarketPrice(client, {

--- a/packages/client/src/actions/orders/post.ts
+++ b/packages/client/src/actions/orders/post.ts
@@ -58,6 +58,9 @@ export const PostOrdersError = makeErrorGuard(
 /**
  * Posts a signed order for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @example
  * ```ts
  * const order = await client.createMarketOrder({
@@ -91,6 +94,8 @@ export function postOrder(
  * Posts multiple signed orders for the authenticated account.
  *
  * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * Accepts between 1 and 15 orders, matching the current service limit.
  *
  * @example

--- a/packages/client/src/actions/orders/prepare.ts
+++ b/packages/client/src/actions/orders/prepare.ts
@@ -52,7 +52,7 @@ export const PrepareMarketOrderError = makeErrorGuard(
  * Starts the market-order workflow.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link PrepareMarketOrderError}
  * Thrown on failure.
@@ -108,7 +108,7 @@ export const PrepareLimitOrderError = makeErrorGuard(
  * Starts the limit-order workflow.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link PrepareLimitOrderError}
  * Thrown on failure.
@@ -155,7 +155,7 @@ export const PrepareMarketOrderPostingError = PrepareMarketOrderError;
  * Starts and posts a market-order workflow.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link PrepareMarketOrderPostingError}
  * Thrown on failure.
@@ -186,7 +186,7 @@ export const PrepareLimitOrderPostingError = PrepareLimitOrderError;
  * Starts and posts a limit-order workflow.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link PrepareLimitOrderPostingError}
  * Thrown on failure.

--- a/packages/client/src/actions/orders/trade.ts
+++ b/packages/client/src/actions/orders/trade.ts
@@ -51,6 +51,9 @@ export const CreateMarketOrderError = makeErrorGuard(
 /**
  * Creates a signed market order for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link CreateMarketOrderError}
  * Thrown on failure.
  */
@@ -82,6 +85,9 @@ export const PlaceMarketOrderError = makeErrorGuard(
 /**
  * Creates and posts a market order for the authenticated account.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link PlaceMarketOrderError}
  * Thrown on failure.
  */
@@ -111,6 +117,8 @@ export const CreateLimitOrderError = makeErrorGuard(
  * Creates a signed limit order for the authenticated account.
  *
  * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * GTD expirations must be at least 60 seconds in the future. Add your own
  * buffer for network latency and clock skew when deriving an expiration from
  * the current time.
@@ -146,6 +154,8 @@ export const PlaceLimitOrderError = makeErrorGuard(
  * Creates and posts a limit order for the authenticated account.
  *
  * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * GTD expirations must be at least 60 seconds in the future. Add your own
  * buffer for network latency and clock skew when deriving an expiration from
  * the current time.

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -132,6 +132,9 @@ export const ListPositionsError = makeErrorGuard(
 /**
  * Lists current positions for a wallet.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListPositionsError}
  * Thrown on failure.
  *
@@ -218,6 +221,9 @@ export const ListClosedPositionsError = makeErrorGuard(
 
 /**
  * Lists closed positions for a wallet.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link ListClosedPositionsError}
  * Thrown on failure.
@@ -306,6 +312,9 @@ export const FetchPortfolioValueError = makeErrorGuard(
 /**
  * Fetches the total value for a wallet's positions.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchPortfolioValueError}
  * Thrown on failure.
  *
@@ -350,6 +359,9 @@ export const FetchTradedMarketCountError = makeErrorGuard(
 /**
  * Fetches the total number of markets a wallet has traded.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchTradedMarketCountError}
  * Thrown on failure.
  *
@@ -393,6 +405,9 @@ export const DownloadAccountingSnapshotError = makeErrorGuard(
 
 /**
  * Downloads an accounting snapshot archive for a wallet.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link DownloadAccountingSnapshotError}
  * Thrown on failure.

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -153,7 +153,7 @@ export const PrepareRedeemPositionsError = makeErrorGuard(
  * Starts a split workflow for a market condition.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -214,6 +214,9 @@ export const SplitPositionError = makeErrorGuard(
 /**
  * Splits collateral into market positions.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link SplitPositionError}
  * Thrown on failure.
  */
@@ -230,7 +233,7 @@ export function splitPosition(
  * Starts a workflow to merge complementary positions in a market back into collateral.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -301,6 +304,9 @@ export const MergePositionsError = makeErrorGuard(
 /**
  * Merges complementary market positions back into collateral.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link MergePositionsError}
  * Thrown on failure.
  */
@@ -317,7 +323,7 @@ export function mergePositions(
  * Starts a redemption workflow for resolved positions.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -391,6 +397,9 @@ export const RedeemPositionsError = makeErrorGuard(
 
 /**
  * Redeems resolved market positions.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link RedeemPositionsError}
  * Thrown on failure.

--- a/packages/client/src/actions/profiles.ts
+++ b/packages/client/src/actions/profiles.ts
@@ -42,6 +42,9 @@ export const FetchPublicProfileError = makeErrorGuard(
 /**
  * Fetches a public profile by wallet address.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchPublicProfileError}
  * Thrown on failure.
  *

--- a/packages/client/src/actions/search.ts
+++ b/packages/client/src/actions/search.ts
@@ -77,6 +77,9 @@ export const SearchError = makeErrorGuard(
 /**
  * Runs a public full-text search.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link SearchError}
  * Thrown on failure.
  *

--- a/packages/client/src/actions/series.ts
+++ b/packages/client/src/actions/series.ts
@@ -68,6 +68,9 @@ export const ListSeriesError = makeErrorGuard(
 /**
  * Lists series.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListSeriesError}
  * Thrown on failure.
  *
@@ -160,6 +163,9 @@ export const FetchSeriesError = makeErrorGuard(
 
 /**
  * Fetches a series.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchSeriesError}
  * Thrown on failure.

--- a/packages/client/src/actions/sports.ts
+++ b/packages/client/src/actions/sports.ts
@@ -30,6 +30,9 @@ export const ListSportsError = makeErrorGuard(
 /**
  * Lists available sports metadata.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListSportsError}
  * Thrown on failure.
  *
@@ -64,6 +67,9 @@ export const FetchSportsMarketTypesError = makeErrorGuard(
 
 /**
  * Fetches the available market types grouped by sport.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchSportsMarketTypesError}
  * Thrown on failure.

--- a/packages/client/src/actions/subscriptions.ts
+++ b/packages/client/src/actions/subscriptions.ts
@@ -155,6 +155,9 @@ export type SubscribeError = TransportError;
 /**
  * Starts one or more realtime subscriptions on this client.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link SubscribeError}
  * Thrown when the realtime subscription cannot be established or fails.
  *

--- a/packages/client/src/actions/tags.ts
+++ b/packages/client/src/actions/tags.ts
@@ -103,6 +103,9 @@ export const ListTagsError = makeErrorGuard(
 /**
  * Lists tags.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListTagsError}
  * Thrown on failure.
  *
@@ -193,6 +196,9 @@ export const FetchTagError = makeErrorGuard(
 /**
  * Fetches a tag by id or slug.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchTagError}
  * Thrown on failure.
  *
@@ -260,6 +266,9 @@ export const FetchRelatedTagsError = makeErrorGuard(
 /**
  * Fetches related tag relationships by id or slug.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link FetchRelatedTagsError}
  * Thrown on failure.
  *
@@ -321,6 +330,9 @@ export const FetchRelatedTagResourcesError = makeErrorGuard(
 
 /**
  * Fetches resources linked from related tag relationships by id or slug.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link FetchRelatedTagResourcesError}
  * Thrown on failure.

--- a/packages/client/src/actions/teams.ts
+++ b/packages/client/src/actions/teams.ts
@@ -51,6 +51,9 @@ export const ListTeamsError = makeErrorGuard(
 /**
  * Lists teams.
  *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
  * @throws {@link ListTeamsError}
  * Thrown on failure.
  *

--- a/packages/client/src/actions/transfers.ts
+++ b/packages/client/src/actions/transfers.ts
@@ -55,7 +55,7 @@ export const PrepareErc20TransferError = makeErrorGuard(UserInputError);
  * Starts an ERC-20 transfer workflow.
  *
  * @remarks
- * This is a low-level action that most SDK consumers will not need.
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @example
  * ```ts
@@ -118,6 +118,9 @@ export const TransferErc20Error = makeErrorGuard(
 
 /**
  * Transfers ERC-20 tokens from the authenticated account.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link TransferErc20Error}
  * Thrown on failure.


### PR DESCRIPTION
## Summary
- Adds a generalized low-level function remark to every public action exported through the actions entry point.
- Normalizes existing low-level action/auth/market wording to point consumers at the client instance API.
- Leaves bound client decorator methods unchanged.

## Verification
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only JSDoc and changeset updates with no API or runtime behavior changes.
> 
> **Overview**
> Standardizes **JSDoc `@remarks`** on public helpers under `packages/client/src/actions/**` so they are explicitly labeled as **low-level** entry points and documentation steers integrators toward the **client instance API** instead of calling standalone `fetch*` / `list*` / `prepare*` / `cancel*` functions directly.
> 
> Where remarks already existed (auth, approvals, gasless, orders prepare, clob market helpers, balance allowance), wording is **normalized** from variants like “low-level action/auth/market” to the shared phrase. Functions that lacked remarks **gain** the same block. **Runtime behavior and client decorator methods are unchanged**; a **patch** changeset records the `@polymarket/client` documentation update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64cbd497f6e9a426fb65ece9e7ab656d4451d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->