### PR TITLE
Default secure client to Deposit Wallet flow

### DIFF
--- a/.changeset/brave-lobsters-deploy.md
+++ b/.changeset/brave-lobsters-deploy.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Default `createSecureClient` to the authenticated signer's current deterministic Deposit Wallet when no wallet is provided. The client now derives the current Deposit Wallet at runtime, deploys it when needed, and preserves explicit EOA and existing wallet behavior.

--- a/.changeset/calm-pugs-approve.md
+++ b/.changeset/calm-pugs-approve.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Make `setupTradingApprovals` idempotent by checking existing ERC-20 allowances and ERC-1155 operator approvals before submitting transactions. The method now waits internally and returns a deprecated compatibility handle for callers that still call `wait()`.

--- a/packages/client/src/abis.ts
+++ b/packages/client/src/abis.ts
@@ -9,11 +9,17 @@ const ZERO_BYTES32 =
 const ERC20_APPROVE_FUNCTION = AbiFunction.from(
   'function approve(address spender, uint256 amount)',
 );
+const ERC20_ALLOWANCE_FUNCTION = AbiFunction.from(
+  'function allowance(address owner, address spender) view returns (uint256)',
+);
 const ERC20_TRANSFER_FUNCTION = AbiFunction.from(
   'function transfer(address recipient, uint256 amount)',
 );
 const ERC1155_SET_APPROVAL_FOR_ALL_FUNCTION = AbiFunction.from(
   'function setApprovalForAll(address operator, bool approved)',
+);
+const ERC1155_IS_APPROVED_FOR_ALL_FUNCTION = AbiFunction.from(
+  'function isApprovedForAll(address account, address operator) view returns (bool)',
 );
 const CTF_SPLIT_POSITION_FUNCTION = AbiFunction.from(
   'function splitPosition(address collateralToken, bytes32 parentCollectionId, bytes32 conditionId, uint256[] partition, uint256 amount)',
@@ -62,6 +68,23 @@ export function erc20ApprovalCall(
   };
 }
 
+/** @internal */
+export function erc20AllowanceCall(
+  tokenAddress: EvmAddress,
+  owner: EvmAddress,
+  spender: EvmAddress,
+): TransactionCall {
+  return {
+    data: AbiFunction.encodeData(ERC20_ALLOWANCE_FUNCTION, [owner, spender]),
+    to: tokenAddress,
+  };
+}
+
+/** @internal */
+export function decodeErc20AllowanceResult(data: HexString): bigint {
+  return AbiFunction.decodeResult(ERC20_ALLOWANCE_FUNCTION, data);
+}
+
 /**
  * Creates a transaction call for `setApprovalForAll(address,bool)` on an ERC-1155 token.
  */
@@ -74,6 +97,26 @@ export function erc1155ApprovalForAllCall(
     data: encodeErc1155SetApprovalForAllCall(operator, approved),
     to: tokenAddress,
   };
+}
+
+/** @internal */
+export function erc1155IsApprovedForAllCall(
+  tokenAddress: EvmAddress,
+  owner: EvmAddress,
+  operator: EvmAddress,
+): TransactionCall {
+  return {
+    data: AbiFunction.encodeData(ERC1155_IS_APPROVED_FOR_ALL_FUNCTION, [
+      owner,
+      operator,
+    ]),
+    to: tokenAddress,
+  };
+}
+
+/** @internal */
+export function decodeErc1155IsApprovedForAllResult(data: HexString): boolean {
+  return AbiFunction.decodeResult(ERC1155_IS_APPROVED_FOR_ALL_FUNCTION, data);
 }
 
 export type Erc20TransferCallError = UserInputError;

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -1,37 +1,38 @@
 import { WalletType } from '@polymarket/bindings/gamma';
-import { expectTxHash } from '@polymarket/types';
-import { describe, expect, it } from 'vitest';
-import { erc1155ApprovalForAllCall } from '../abis';
+import {
+  expectEvmAddress,
+  expectTxHash,
+  type HexString,
+} from '@polymarket/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  erc20ApprovalCall,
+  erc1155ApprovalForAllCall,
+  MAX_UINT256,
+} from '../abis';
 import type { BaseSecureClient } from '../clients';
 import { production } from '../environments';
+import type { EthCallRequest } from '../rpc';
 import type { TransactionHandle } from '../types';
 import { prepareTradingApprovals } from './approvals';
 
-const TRANSACTION_HANDLE: TransactionHandle = {
-  transactionHash: null,
-  transactionId: null,
-  async wait() {
-    return {
-      transactionHash: expectTxHash(
-        '0x1111111111111111111111111111111111111111111111111111111111111111',
-      ),
-      transactionId: null,
-    };
-  },
-};
+const FALSE_RESULT = `0x${'0'.repeat(64)}` as HexString;
+const TRUE_RESULT = `0x${'0'.repeat(63)}1` as HexString;
+const MAX_UINT256_RESULT = `0x${'f'.repeat(64)}` as HexString;
+const wallet = expectEvmAddress('0x0000000000000000000000000000000000000001');
 
 describe('prepareTradingApprovals', () => {
   it('includes auto-redeem approval in account setup', async () => {
-    const client = {
-      account: { walletType: WalletType.EOA },
-      environment: production,
-    } as BaseSecureClient;
+    const { client } = createClient([
+      ...Array<HexString>(5).fill(FALSE_RESULT),
+      ...Array<HexString>(6).fill(FALSE_RESULT),
+    ]);
     const workflow = await prepareTradingApprovals(client);
     let result = await workflow.next();
 
     for (let index = 0; index < 10; index += 1) {
       expect(result.done).toBe(false);
-      result = await workflow.next(TRANSACTION_HANDLE);
+      result = await workflow.next(createTransactionHandle());
     }
 
     expect(result).toEqual({
@@ -49,4 +50,103 @@ describe('prepareTradingApprovals', () => {
       },
     });
   });
+
+  it('completes without transactions when approvals are already set', async () => {
+    const { client, ethCallBatch } = createClient([
+      ...Array<HexString>(5).fill(MAX_UINT256_RESULT),
+      ...Array<HexString>(6).fill(TRUE_RESULT),
+    ]);
+
+    const workflow = await prepareTradingApprovals(client);
+
+    const result = await workflow.next();
+
+    expect(result).toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(ethCallBatch).toHaveBeenCalledTimes(1);
+    expect(ethCallBatch.mock.calls[0]?.[0]).toHaveLength(11);
+  });
+
+  it('submits only missing approvals', async () => {
+    const { client } = createClient([
+      FALSE_RESULT,
+      ...Array<HexString>(4).fill(MAX_UINT256_RESULT),
+      FALSE_RESULT,
+      ...Array<HexString>(5).fill(TRUE_RESULT),
+    ]);
+    const firstHandle = createTransactionHandle();
+    const secondHandle = createTransactionHandle();
+    const workflow = await prepareTradingApprovals(client);
+
+    let result = await workflow.next();
+
+    expect(result).toEqual({
+      done: false,
+      value: {
+        kind: 'sendErc20ApprovalTransaction',
+        request: {
+          chainId: production.chainId,
+          ...erc20ApprovalCall(
+            production.collateralToken,
+            production.standardExchange,
+            MAX_UINT256,
+          ),
+        },
+      },
+    });
+
+    result = await workflow.next(firstHandle);
+
+    expect(result).toEqual({
+      done: false,
+      value: {
+        kind: 'sendErc1155ApprovalForAllTransaction',
+        request: {
+          chainId: production.chainId,
+          ...erc1155ApprovalForAllCall(
+            production.conditionalTokens,
+            production.standardExchange,
+            true,
+          ),
+        },
+      },
+    });
+
+    result = await workflow.next(secondHandle);
+
+    expect(result).toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(firstHandle.wait).toHaveBeenCalledTimes(1);
+    expect(secondHandle.wait).toHaveBeenCalledTimes(1);
+  });
 });
+
+function createClient(results: HexString[]) {
+  const ethCallBatch = vi.fn(
+    async (_calls: readonly EthCallRequest[]): Promise<HexString[]> => results,
+  );
+  const client = {
+    account: { wallet, walletType: WalletType.EOA },
+    environment: production,
+    rpc: { ethCallBatch },
+  } as unknown as BaseSecureClient;
+
+  return { client, ethCallBatch };
+}
+
+function createTransactionHandle(): TransactionHandle {
+  return {
+    transactionHash: null,
+    transactionId: null,
+    wait: vi.fn(async () => ({
+      transactionHash: expectTxHash(
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+      ),
+      transactionId: null,
+    })),
+  };
+}

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -1,17 +1,27 @@
 import { type EvmAddress, EvmAddressSchema } from '@polymarket/bindings';
 import { WalletType } from '@polymarket/bindings/gamma';
-import type { EvmSignature } from '@polymarket/types';
+import type { EvmSignature, HexString } from '@polymarket/types';
 import { z } from 'zod';
 import {
+  decodeErc20AllowanceResult,
+  decodeErc1155IsApprovedForAllResult,
+  erc20AllowanceCall,
   erc20ApprovalCall,
   erc1155ApprovalForAllCall,
+  erc1155IsApprovedForAllCall,
   MAX_UINT256,
 } from '../abis';
 import type { BaseSecureClient } from '../clients';
 import {
   CancelledSigningError,
   makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
   SigningError,
+  TimeoutError,
+  TransactionFailedError,
+  TransportError,
+  UnexpectedResponseError,
   UserInputError,
 } from '../errors';
 import { parseUserInput } from '../input';
@@ -30,6 +40,7 @@ import {
   GaslessTransactionMetadataSchema,
   type GaslessWorkflowRequest,
   prepareGaslessTransaction,
+  type WaitForGaslessTransactionError,
 } from './gasless';
 
 export type Erc20ApprovalWorkflowRequest =
@@ -252,12 +263,37 @@ export type TradingApprovalsWorkflowRequest =
 
 export type TradingApprovalsWorkflow = AsyncGenerator<
   TradingApprovalsWorkflowRequest,
-  TransactionHandle,
+  void,
   EvmAddress | EvmSignature | TransactionHandle
 >;
 
-export type PrepareTradingApprovalsError = UserInputError;
-export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
+export type PrepareTradingApprovalsError =
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const PrepareTradingApprovalsError = makeErrorGuard(
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+type Erc20TradingApproval = {
+  amount: bigint;
+  spenderAddress: EvmAddress;
+  tokenAddress: EvmAddress;
+};
+
+type Erc1155TradingApproval = {
+  operatorAddress: EvmAddress;
+  tokenAddress: EvmAddress;
+};
+
+type TradingApprovalRequirements = {
+  erc20: Erc20TradingApproval[];
+  erc1155: Erc1155TradingApproval[];
+};
 
 /**
  * Starts a trading-setup approval workflow.
@@ -265,11 +301,12 @@ export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
- * Prepares all approvals required for trading, including collateral and
+ * Prepares missing approvals required for trading, including collateral and
  * position token approvals for both standard and neg-risk market flows.
  * The collateral adapter approvals cover split, merge, and redemption workflows.
  * Auto-redeem approval is included so accounts are ready for supported position
- * lifecycle workflows.
+ * lifecycle workflows. If all approvals are already in place, the workflow
+ * completes without yielding any transaction requests.
  *
  * @example
  * ```ts
@@ -282,66 +319,27 @@ export const PrepareTradingApprovalsError = makeErrorGuard(UserInputError);
 export async function prepareTradingApprovals(
   client: BaseSecureClient,
 ): Promise<TradingApprovalsWorkflow> {
-  const erc20ApprovalCalls = [
+  const missingApprovals = await resolveMissingTradingApprovals(client);
+  const erc20ApprovalCalls = missingApprovals.erc20.map((approval) =>
     erc20ApprovalCall(
-      client.environment.collateralToken,
-      client.environment.standardExchange,
-      MAX_UINT256,
+      approval.tokenAddress,
+      approval.spenderAddress,
+      approval.amount,
     ),
-    erc20ApprovalCall(
-      client.environment.collateralToken,
-      client.environment.negRiskExchange,
-      MAX_UINT256,
-    ),
-    erc20ApprovalCall(
-      client.environment.collateralToken,
-      client.environment.negRiskAdapter,
-      MAX_UINT256,
-    ),
-    erc20ApprovalCall(
-      client.environment.collateralToken,
-      client.environment.collateralAdapter,
-      MAX_UINT256,
-    ),
-    erc20ApprovalCall(
-      client.environment.collateralToken,
-      client.environment.negRiskCollateralAdapter,
-      MAX_UINT256,
-    ),
-  ] as const;
-  const erc1155ApprovalCalls = [
+  );
+  const erc1155ApprovalCalls = missingApprovals.erc1155.map((approval) =>
     erc1155ApprovalForAllCall(
-      client.environment.conditionalTokens,
-      client.environment.standardExchange,
+      approval.tokenAddress,
+      approval.operatorAddress,
       true,
     ),
-    erc1155ApprovalForAllCall(
-      client.environment.conditionalTokens,
-      client.environment.negRiskExchange,
-      true,
-    ),
-    erc1155ApprovalForAllCall(
-      client.environment.conditionalTokens,
-      client.environment.negRiskAdapter,
-      true,
-    ),
-    erc1155ApprovalForAllCall(
-      client.environment.conditionalTokens,
-      client.environment.collateralAdapter,
-      true,
-    ),
-    erc1155ApprovalForAllCall(
-      client.environment.conditionalTokens,
-      client.environment.negRiskCollateralAdapter,
-      true,
-    ),
-    erc1155ApprovalForAllCall(
-      client.environment.conditionalTokens,
-      client.environment.autoRedeemOperator,
-      true,
-    ),
-  ] as const;
+  );
+
   return async function* (): TradingApprovalsWorkflow {
+    if (erc20ApprovalCalls.length === 0 && erc1155ApprovalCalls.length === 0) {
+      return;
+    }
+
     if (client.account.walletType === WalletType.EOA) {
       for (const call of erc20ApprovalCalls) {
         const handle = expectTransactionHandle(
@@ -353,37 +351,52 @@ export async function prepareTradingApprovals(
         await handle.wait();
       }
 
-      for (const [index, call] of erc1155ApprovalCalls.entries()) {
+      for (const call of erc1155ApprovalCalls) {
         const handle = expectTransactionHandle(
           yield sendErc1155ApprovalForAllTransaction(
             signerTransactionRequest(client.environment.chainId, call),
           ),
         );
 
-        if (index === erc1155ApprovalCalls.length - 1) {
-          return handle;
-        }
-
         await handle.wait();
       }
+
+      return;
     }
 
-    return yield* await prepareGaslessTransaction(client, {
+    const handle = yield* await prepareGaslessTransaction(client, {
       calls: [...erc20ApprovalCalls, ...erc1155ApprovalCalls],
       metadata: 'Trading setup approvals',
     });
+
+    await handle.wait();
   }.call(null);
 }
 
 export type SetupTradingApprovalsError =
   | PrepareTradingApprovalsError
   | CancelledSigningError
-  | SigningError;
+  | SigningError
+  | WaitForGaslessTransactionError;
 export const SetupTradingApprovalsError = makeErrorGuard(
   CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
   SigningError,
+  TimeoutError,
+  TransactionFailedError,
+  TransportError,
+  UnexpectedResponseError,
   UserInputError,
 );
+
+export type DeprecatedTransactionHandle = Omit<TransactionHandle, 'wait'> & {
+  /**
+   * @deprecated `setupTradingApprovals` now waits internally. You do not need
+   * to call this method, and it will be removed in a later version.
+   */
+  wait(): Promise<void>;
+};
 
 /**
  * Sets up the approvals required for trading.
@@ -396,8 +409,120 @@ export const SetupTradingApprovalsError = makeErrorGuard(
  */
 export function setupTradingApprovals(
   client: BaseSecureClient,
-): Promise<TransactionHandle> {
-  return prepareTradingApprovals(client).then(completeWith(client.signer));
+): Promise<DeprecatedTransactionHandle> {
+  return prepareTradingApprovals(client)
+    .then(completeWith(client.signer))
+    .then(createDeprecatedTransactionHandle);
+}
+
+function createDeprecatedTransactionHandle(): DeprecatedTransactionHandle {
+  return {
+    transactionHash: null,
+    transactionId: null,
+    wait: async () => {},
+  };
+}
+
+async function resolveMissingTradingApprovals(
+  client: BaseSecureClient,
+): Promise<TradingApprovalRequirements> {
+  const requiredApprovals = getRequiredTradingApprovals(client);
+  const checkCalls = [
+    ...requiredApprovals.erc20.map((approval) =>
+      erc20AllowanceCall(
+        approval.tokenAddress,
+        client.account.wallet,
+        approval.spenderAddress,
+      ),
+    ),
+    ...requiredApprovals.erc1155.map((approval) =>
+      erc1155IsApprovedForAllCall(
+        approval.tokenAddress,
+        client.account.wallet,
+        approval.operatorAddress,
+      ),
+    ),
+  ];
+  const results = await client.rpc.ethCallBatch(checkCalls);
+  const erc20Results = results.slice(0, requiredApprovals.erc20.length);
+  const erc1155Results = results.slice(requiredApprovals.erc20.length);
+
+  return {
+    erc20: requiredApprovals.erc20.filter((approval, index) => {
+      const allowance = decodeErc20AllowanceResult(
+        erc20Results[index] as HexString,
+      );
+
+      return allowance < approval.amount;
+    }),
+    erc1155: requiredApprovals.erc1155.filter((_, index) => {
+      const approved = decodeErc1155IsApprovedForAllResult(
+        erc1155Results[index] as HexString,
+      );
+
+      return !approved;
+    }),
+  };
+}
+
+function getRequiredTradingApprovals(
+  client: BaseSecureClient,
+): TradingApprovalRequirements {
+  return {
+    erc20: [
+      {
+        amount: MAX_UINT256,
+        spenderAddress: client.environment.standardExchange,
+        tokenAddress: client.environment.collateralToken,
+      },
+      {
+        amount: MAX_UINT256,
+        spenderAddress: client.environment.negRiskExchange,
+        tokenAddress: client.environment.collateralToken,
+      },
+      {
+        amount: MAX_UINT256,
+        spenderAddress: client.environment.negRiskAdapter,
+        tokenAddress: client.environment.collateralToken,
+      },
+      {
+        amount: MAX_UINT256,
+        spenderAddress: client.environment.collateralAdapter,
+        tokenAddress: client.environment.collateralToken,
+      },
+      {
+        amount: MAX_UINT256,
+        spenderAddress: client.environment.negRiskCollateralAdapter,
+        tokenAddress: client.environment.collateralToken,
+      },
+    ],
+    erc1155: [
+      {
+        operatorAddress: client.environment.standardExchange,
+        tokenAddress: client.environment.conditionalTokens,
+      },
+      {
+        operatorAddress: client.environment.negRiskExchange,
+        tokenAddress: client.environment.conditionalTokens,
+      },
+      {
+        operatorAddress: client.environment.negRiskAdapter,
+        tokenAddress: client.environment.conditionalTokens,
+      },
+      {
+        operatorAddress: client.environment.collateralAdapter,
+        tokenAddress: client.environment.conditionalTokens,
+      },
+      {
+        operatorAddress: client.environment.negRiskCollateralAdapter,
+        tokenAddress: client.environment.conditionalTokens,
+      },
+      {
+        operatorAddress: client.environment.autoRedeemOperator,
+        tokenAddress: client.environment.conditionalTokens,
+      },
+    ],
+  };
 }
 
 function sendErc20ApprovalTransaction(

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -151,20 +151,22 @@ export type FetchGaslessTransactionRequest = z.input<
   typeof FetchGaslessTransactionRequestSchema
 >;
 
-const IsGaslessReadyRequestSchema = z.object({
+const IsWalletDeployedRequestSchema = z.object({
   wallet: EvmAddressSchema,
   type: z.enum(WalletType),
 });
 
-export type IsGaslessReadyRequest = z.input<typeof IsGaslessReadyRequestSchema>;
+export type IsWalletDeployedRequest = z.input<
+  typeof IsWalletDeployedRequestSchema
+>;
 
-export type IsGaslessReadyError =
+export type IsWalletDeployedError =
   | RateLimitError
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
-export const IsGaslessReadyError = makeErrorGuard(
+export const IsWalletDeployedError = makeErrorGuard(
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -173,26 +175,29 @@ export const IsGaslessReadyError = makeErrorGuard(
 );
 
 /**
- * Checks whether a wallet is ready for gasless transactions.
+ * Checks whether a wallet is deployed for relayer-backed transactions.
+ *
+ * It only checks deployment status; it does not check trading approvals or complete
+ * order-readiness.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
- * @throws {@link IsGaslessReadyError}
+ * @throws {@link IsWalletDeployedError}
  * Thrown on failure.
  *
  * @example
  * ```ts
- * const ready = await isGaslessReady(client, {
+ * const deployed = await isWalletDeployed(client, {
  *   wallet: '0x1234...',
  * });
  * ```
  */
-export async function isGaslessReady(
+export async function isWalletDeployed(
   client: BaseClient,
-  request?: IsGaslessReadyRequest,
+  request?: IsWalletDeployedRequest,
 ): Promise<boolean> {
-  const params = await resolveGaslessReadinessTarget(client, request);
+  const params = await resolveWalletDeploymentTarget(client, request);
 
   if (params.type === WalletType.EOA) {
     return false;
@@ -217,12 +222,12 @@ export async function isGaslessReady(
   );
 }
 
-async function resolveGaslessReadinessTarget(
+async function resolveWalletDeploymentTarget(
   client: BaseClient,
-  request: IsGaslessReadyRequest | undefined,
-): Promise<z.output<typeof IsGaslessReadyRequestSchema>> {
+  request: IsWalletDeployedRequest | undefined,
+): Promise<z.output<typeof IsWalletDeployedRequestSchema>> {
   if (request !== undefined) {
-    return parseUserInput(request, IsGaslessReadyRequestSchema);
+    return parseUserInput(request, IsWalletDeployedRequestSchema);
   }
 
   if (!client.isSecureClient()) {

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -5,7 +5,7 @@ import { type EvmAddress, expectEvmAddress } from '@polymarket/types';
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { BaseSecureClient } from './clients';
+import { BaseSecureClient, createSecureClient } from './clients';
 import { walletActions } from './decorators/wallet';
 import { production } from './environments';
 import type { ApiKeyAuthorization, Signer } from './types';
@@ -17,6 +17,7 @@ import {
 
 const rpcRoot = 'http://localhost:4014';
 const relayerRoot = 'http://localhost:4015';
+const clobRoot = 'http://localhost:4016';
 const server = setupServer();
 const signerAddress = expectEvmAddress(
   '0x0000000000000000000000000000000000000001',
@@ -24,6 +25,7 @@ const signerAddress = expectEvmAddress(
 
 const environment = {
   ...production,
+  clob: clobRoot,
   relayer: relayerRoot,
   rpc: rpcRoot,
 };
@@ -122,6 +124,29 @@ describe('secure client gasless wallet setup', () => {
     await expect(walletActions(client).isGaslessReady()).resolves.toBe(true);
   });
 
+  it('defaults createSecureClient without a wallet to the deterministic deposit wallet', async () => {
+    const expectedWallet = deriveBeaconDepositWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
+    mockApiKeys();
+    mockBeaconFactory();
+    mockDeployedWallet(expectedWallet);
+
+    const client = await createSecureClient({
+      apiKey,
+      credentials,
+      environment,
+      signer,
+    });
+
+    expect(client.account).toEqual({
+      signer: signerAddress,
+      wallet: expectedWallet,
+      walletType: WalletType.DEPOSIT_WALLET,
+    });
+  });
+
   it('does not silently fall back when factory detection fails generically', async () => {
     mockFactoryRpcError();
     const client = createEoaClient();
@@ -175,6 +200,14 @@ function mockFactoryRpcError() {
         id: 1,
         error: { code: -32_603, message: 'upstream unavailable' },
       }),
+    ),
+  );
+}
+
+function mockApiKeys() {
+  server.use(
+    http.get(`${clobRoot}/auth/api-keys`, () =>
+      HttpResponse.json({ apiKeys: [credentials.key] }),
     ),
   );
 }

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -5,14 +5,14 @@ import { type EvmAddress, expectEvmAddress } from '@polymarket/types';
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
-import { BaseSecureClient, createSecureClient } from './clients';
-import { walletActions } from './decorators/wallet';
+import { createSecureClient } from './clients';
 import { production } from './environments';
 import type { ApiKeyAuthorization, Signer } from './types';
 import {
   deriveBeaconDepositWalletAddress,
+  deriveProxyWalletAddress,
+  deriveSafeWalletAddress,
   deriveUupsDepositWalletAddress,
-  resolveAccountIdentity,
 } from './wallet';
 
 const rpcRoot = 'http://localhost:4014';
@@ -76,52 +76,29 @@ describe('secure client gasless wallet setup', () => {
     server.close();
   });
 
-  it('uses the beacon deposit wallet when the factory exposes BEACON', async () => {
+  it('deploys the default deposit wallet when it is not yet deployed', async () => {
     const expectedWallet = deriveBeaconDepositWalletAddress(
       signerAddress,
       environment.walletDerivation,
     );
+    mockApiKeys();
     mockBeaconFactory();
-    mockDeployedWallet(expectedWallet);
-    const client = createEoaClient();
+    mockUndeployedWallet(expectedWallet);
+    const submit = mockDeployDepositWallet();
 
-    const gaslessClient = await client.setupGaslessWallet();
+    const client = await createSecureClient({
+      apiKey,
+      credentials,
+      environment,
+      signer,
+    });
 
-    expect(gaslessClient.account).toEqual({
+    expect(submit.called).toBe(true);
+    expect(client.account).toEqual({
       signer: signerAddress,
       wallet: expectedWallet,
       walletType: WalletType.DEPOSIT_WALLET,
     });
-  });
-
-  it('uses the UUPS deposit wallet when the factory BEACON call reverts', async () => {
-    const expectedWallet = deriveUupsDepositWalletAddress(
-      signerAddress,
-      environment.walletDerivation,
-    );
-    mockLegacyFactory();
-    mockDeployedWallet(expectedWallet);
-    const client = createEoaClient();
-
-    const gaslessClient = await client.setupGaslessWallet();
-
-    expect(gaslessClient.account).toEqual({
-      signer: signerAddress,
-      wallet: expectedWallet,
-      walletType: WalletType.DEPOSIT_WALLET,
-    });
-  });
-
-  it('checks the current deterministic deposit wallet for EOA gasless readiness', async () => {
-    const expectedWallet = deriveBeaconDepositWalletAddress(
-      signerAddress,
-      environment.walletDerivation,
-    );
-    mockBeaconFactory();
-    mockDeployedWallet(expectedWallet);
-    const client = createEoaClient();
-
-    await expect(walletActions(client).isGaslessReady()).resolves.toBe(true);
   });
 
   it('defaults createSecureClient without a wallet to the deterministic deposit wallet', async () => {
@@ -147,26 +124,159 @@ describe('secure client gasless wallet setup', () => {
     });
   });
 
-  it('does not silently fall back when factory detection fails generically', async () => {
-    mockFactoryRpcError();
-    const client = createEoaClient();
+  it('verifies an explicit deposit wallet before returning the secure client', async () => {
+    const expectedWallet = deriveBeaconDepositWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
+    mockApiKeys();
+    const deployedWallet = mockDeployedWallet(expectedWallet);
 
-    await expect(client.setupGaslessWallet()).rejects.toMatchObject({
+    const client = await createSecureClient({
+      apiKey,
+      credentials,
+      environment,
+      signer,
+      wallet: expectedWallet,
+    });
+
+    expect(deployedWallet.called).toBe(true);
+    expect(client.account).toEqual({
+      signer: signerAddress,
+      wallet: expectedWallet,
+      walletType: WalletType.DEPOSIT_WALLET,
+    });
+  });
+
+  it('keeps an explicit EOA wallet bound to the EOA', async () => {
+    mockApiKeys();
+
+    const client = await createSecureClient({
+      apiKey,
+      credentials,
+      environment,
+      signer,
+      wallet: signerAddress,
+    });
+
+    expect(client.account).toEqual({
+      signer: signerAddress,
+      wallet: signerAddress,
+      walletType: WalletType.EOA,
+    });
+  });
+
+  it('keeps an explicit deployed Safe wallet bound to the Safe', async () => {
+    const safeWallet = deriveSafeWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
+    mockApiKeys();
+    mockAccountWalletDeployed(safeWallet, true);
+
+    const client = await createSecureClient({
+      apiKey,
+      credentials,
+      environment,
+      signer,
+      wallet: safeWallet,
+    });
+
+    expect(client.account).toEqual({
+      signer: signerAddress,
+      wallet: safeWallet,
+      walletType: WalletType.GNOSIS_SAFE,
+    });
+  });
+
+  it('keeps an explicit deployed proxy wallet bound to the proxy', async () => {
+    const proxyWallet = deriveProxyWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
+    mockApiKeys();
+    mockAccountWalletDeployed(proxyWallet, true);
+
+    const client = await createSecureClient({
+      apiKey,
+      credentials,
+      environment,
+      signer,
+      wallet: proxyWallet,
+    });
+
+    expect(client.account).toEqual({
+      signer: signerAddress,
+      wallet: proxyWallet,
+      walletType: WalletType.POLY_PROXY,
+    });
+  });
+
+  it('rejects an explicit Safe wallet with no deployed code', async () => {
+    const safeWallet = deriveSafeWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
+    mockApiKeys();
+    mockAccountWalletDeployed(safeWallet, false);
+
+    await expect(
+      createSecureClient({
+        apiKey,
+        credentials,
+        environment,
+        signer,
+        wallet: safeWallet,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining('is not deployed'),
+      name: 'UserInputError',
+    });
+  });
+
+  it('rejects an explicit undeployed deposit wallet that is not the current one', async () => {
+    const currentWallet = deriveBeaconDepositWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
+    const legacyWallet = deriveUupsDepositWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
+    mockApiKeys();
+    mockBeaconFactory();
+    mockUndeployedWallet(legacyWallet);
+
+    await expect(
+      createSecureClient({
+        apiKey,
+        credentials,
+        environment,
+        signer,
+        wallet: legacyWallet,
+      }),
+    ).rejects.toMatchObject({
+      message: `Wallet ${legacyWallet} does not match the expected Deposit Wallet ${currentWallet} for this signer, nor a deployed wallet address.`,
+      name: 'UserInputError',
+    });
+  });
+
+  it('does not silently fall back when default deposit wallet detection fails generically', async () => {
+    mockFactoryRpcError();
+
+    await expect(
+      createSecureClient({
+        apiKey,
+        credentials,
+        environment,
+        signer,
+      }),
+    ).rejects.toMatchObject({
       message: 'JSON-RPC eth_call failed: upstream unavailable',
       name: 'RequestRejectedError',
     });
   });
 });
-
-function createEoaClient() {
-  return new BaseSecureClient({
-    account: resolveAccountIdentity(environment, signerAddress, signerAddress),
-    apiKey,
-    credentials,
-    environment,
-    signer,
-  });
-}
 
 function mockBeaconFactory() {
   server.use(
@@ -175,18 +285,6 @@ function mockBeaconFactory() {
         jsonrpc: '2.0',
         id: 1,
         result: `0x000000000000000000000000${environment.walletDerivation.depositWalletBeacon.slice(2)}`,
-      }),
-    ),
-  );
-}
-
-function mockLegacyFactory() {
-  server.use(
-    http.post(rpcRoot, () =>
-      HttpResponse.json({
-        jsonrpc: '2.0',
-        id: 1,
-        error: { code: 3, message: 'execution reverted' },
       }),
     ),
   );
@@ -212,9 +310,64 @@ function mockApiKeys() {
   );
 }
 
-function mockDeployedWallet(expectedWallet: EvmAddress) {
+function mockAccountWalletDeployed(wallet: EvmAddress, deployed: boolean) {
   server.use(
     http.get(`${relayerRoot}/deployed`, ({ request }) => {
+      const url = new URL(request.url);
+
+      expect(url.searchParams.get('address')).toBe(wallet);
+
+      return HttpResponse.json({ deployed });
+    }),
+  );
+}
+
+function mockUndeployedWallet(expectedWallet: EvmAddress) {
+  server.use(
+    http.get(`${relayerRoot}/deployed`, ({ request }) => {
+      const url = new URL(request.url);
+
+      expect(url.searchParams.get('address')).toBe(expectedWallet);
+      expect(url.searchParams.get('type')).toBe('WALLET');
+
+      return HttpResponse.json({ deployed: false });
+    }),
+  );
+}
+
+function mockDeployDepositWallet() {
+  const state = { called: false };
+  const transactionId = '00000000-0000-0000-0000-000000000001';
+  const transactionHash = `0x${'1'.repeat(64)}`;
+
+  server.use(
+    http.post(`${relayerRoot}/submit`, () => {
+      state.called = true;
+
+      return HttpResponse.json({
+        state: 'STATE_MINED',
+        transactionHash,
+        transactionID: transactionId,
+      });
+    }),
+    http.get(`${relayerRoot}/v1/account/transactions/${transactionId}`, () =>
+      HttpResponse.json({
+        state: 'STATE_MINED',
+        transaction_hash: transactionHash,
+        transaction_id: transactionId,
+      }),
+    ),
+  );
+
+  return state;
+}
+
+function mockDeployedWallet(expectedWallet: EvmAddress) {
+  const state = { called: false };
+
+  server.use(
+    http.get(`${relayerRoot}/deployed`, ({ request }) => {
+      state.called = true;
       const url = new URL(request.url);
 
       expect(url.searchParams.get('address')).toBe(expectedWallet);
@@ -223,4 +376,6 @@ function mockDeployedWallet(expectedWallet: EvmAddress) {
       return HttpResponse.json({ deployed: true });
     }),
   );
+
+  return state;
 }

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -229,7 +229,7 @@ describe('secure client gasless wallet setup', () => {
         wallet: safeWallet,
       }),
     ).rejects.toMatchObject({
-      message: expect.stringContaining('is not deployed'),
+      message: expect.stringContaining('does not exist'),
       name: 'UserInputError',
     });
   });

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -17,8 +17,8 @@ import {
 import {
   type DeployDepositWalletError,
   deployDepositWallet,
-  type IsGaslessReadyError,
-  isGaslessReady,
+  type IsWalletDeployedError,
+  isWalletDeployed,
   type WaitForGaslessTransactionError,
 } from './actions/gasless';
 import { createApiKeyAuthTypedDataPayload } from './authentication';
@@ -551,71 +551,14 @@ class BaseSecureClient<
   }
 
   /**
-   * Sets up a gasless wallet and returns a secure client bound to it.
-   *
-   * @remarks
-   * If this client is already bound to a gasless wallet, this returns a secure
-   * client for the current wallet. For EOA clients, this deploys or reuses the
-   * authenticated signer's deterministic Deposit Wallet.
-   *
-   * @throws {@link SetupGaslessWalletError}
-   * Thrown on failure.
+   * @deprecated `createSecureClient` now sets up the account wallet for its
+   * trading flow, so this is a no-op retained only for backward compatibility
+   * and returns the current secure client.
    */
-  async setupGaslessWallet(): Promise<
-    SecureClient<TPublicActions, TSecureActions>
-  > {
-    const signerAddress = expectEvmAddress(await this.signer.getAddress());
-
-    invariant(
-      isSameEvmAddress(signerAddress, this.account.signer),
-      'The current signer address does not match the authenticated signer for this client.',
+  setupGaslessWallet(): Promise<SecureClient<TPublicActions, TSecureActions>> {
+    return Promise.resolve(
+      this as unknown as SecureClient<TPublicActions, TSecureActions>,
     );
-
-    if (this.account.walletType !== WalletType.EOA) {
-      return this.#createSecureClientForWallet(
-        this.account.wallet,
-        signerAddress,
-      );
-    }
-
-    const depositWallet = await deriveCurrentDepositWalletAddress(
-      this.rpc,
-      signerAddress,
-      this.environment.walletDerivation,
-    );
-
-    if (
-      await isGaslessReady(this, {
-        wallet: depositWallet,
-        type: WalletType.DEPOSIT_WALLET,
-      })
-    ) {
-      return this.#createSecureClientForWallet(depositWallet, signerAddress);
-    }
-
-    const handle = await deployDepositWallet(this);
-    await handle.wait();
-
-    return this.#createSecureClientForWallet(depositWallet, signerAddress);
-  }
-
-  #createSecureClientForWallet(
-    wallet: AccountIdentity['wallet'],
-    signerAddress: AccountIdentity['signer'],
-  ): SecureClient<TPublicActions, TSecureActions> {
-    const client = new BaseSecureClient<TPublicActions, TSecureActions>({
-      account: resolveAccountIdentity(this.environment, signerAddress, wallet),
-      apiKey: this.context.apiKey,
-      credentials: this.credentials,
-      environment: this.environment,
-      signer: this.context.signer,
-    });
-
-    for (const decorator of this.decorators) {
-      client.extend(decorator);
-    }
-
-    return client as SecureClient<TPublicActions, TSecureActions>;
   }
 
   /** @internal */
@@ -872,6 +815,8 @@ export function createPublicClient(
 
 export type CreateSecureClientError =
   | CancelledSigningError
+  | DeployDepositWalletError
+  | IsWalletDeployedError
   | RateLimitError
   | RequestRejectedError
   | SigningError
@@ -879,7 +824,8 @@ export type CreateSecureClientError =
   | TransactionFailedError
   | TransportError
   | UnexpectedResponseError
-  | UserInputError;
+  | UserInputError
+  | WaitForGaslessTransactionError;
 export const CreateSecureClientError = makeErrorGuard(
   CancelledSigningError,
   RateLimitError,
@@ -892,22 +838,8 @@ export const CreateSecureClientError = makeErrorGuard(
   UserInputError,
 );
 
-export type SetupGaslessWalletError =
-  | DeployDepositWalletError
-  | IsGaslessReadyError
-  | SigningError
-  | WaitForGaslessTransactionError
-  | UserInputError;
-export const SetupGaslessWalletError = makeErrorGuard(
-  RateLimitError,
-  RequestRejectedError,
-  SigningError,
-  TimeoutError,
-  TransactionFailedError,
-  TransportError,
-  UnexpectedResponseError,
-  UserInputError,
-);
+export type SetupGaslessWalletError = UserInputError;
+export const SetupGaslessWalletError = makeErrorGuard(UserInputError);
 
 /**
  * Creates a new authenticated `SecureClient` instance.
@@ -929,7 +861,7 @@ export async function createSecureClient(
     environment: options.environment,
     apiKey: options.apiKey,
   });
-  const wallet = options.wallet ?? (await options.signer.getAddress());
+  const wallet = await resolveRequestedWallet(client, options);
 
   const secureClient = await client
     .beginAuthentication(
@@ -942,9 +874,71 @@ export async function createSecureClient(
     )
     .then(authenticateWith(options.signer));
 
-  if (options.wallet !== undefined) {
+  if (secureClient.account.walletType === WalletType.EOA) {
     return secureClient;
   }
 
-  return secureClient.setupGaslessWallet();
+  const deployed = await isWalletDeployed(secureClient, {
+    wallet: secureClient.account.wallet,
+    type: secureClient.account.walletType,
+  });
+
+  if (deployed) {
+    return secureClient;
+  }
+
+  if (secureClient.account.walletType === WalletType.DEPOSIT_WALLET) {
+    await deployDefaultDepositWallet(secureClient);
+    return secureClient;
+  }
+
+  throw new UserInputError(
+    `Wallet ${secureClient.account.wallet} does not exist. Provide an existing wallet address, or omit wallet to use the default Deposit Wallet flow.`,
+  );
+}
+
+/**
+ * Resolves the wallet address to authenticate as. Defaults to the signer's
+ * current deterministic Deposit Wallet when no wallet is provided.
+ */
+async function resolveRequestedWallet(
+  client: BasePublicClient,
+  options: SecureClientOptions,
+): Promise<string> {
+  if (options.wallet !== undefined) {
+    return options.wallet;
+  }
+
+  const signerAddress = expectEvmAddress(await options.signer.getAddress());
+
+  return deriveCurrentDepositWalletAddress(
+    client.rpc,
+    signerAddress,
+    client.environment.walletDerivation,
+  );
+}
+
+/**
+ * Deploys the signer's current deterministic Deposit Wallet for the secure
+ * client. Only the current Deposit Wallet can be deployed: a provided Deposit
+ * Wallet that does not match the current deterministic address would deploy a
+ * different wallet than the client is bound to, so it is rejected.
+ */
+async function deployDefaultDepositWallet(
+  secureClient: SecureClient<PublicActions, SecureActions>,
+): Promise<void> {
+  const currentDepositWallet = await deriveCurrentDepositWalletAddress(
+    secureClient.rpc,
+    secureClient.account.signer,
+    secureClient.environment.walletDerivation,
+  );
+
+  if (!isSameEvmAddress(secureClient.account.wallet, currentDepositWallet)) {
+    throw new UserInputError(
+      `Wallet ${secureClient.account.wallet} does not match the expected Deposit Wallet ${currentDepositWallet} for this signer, nor a deployed wallet address.`,
+    );
+  }
+
+  const handle = await deployDepositWallet(secureClient);
+  await handle.wait();
 }

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -823,13 +823,10 @@ export type SecureClientOptions = PublicClientOptions & {
   /**
    * Wallet address to use as the account wallet.
    *
-   * If omitted, the client uses the signer address as the account wallet and
-   * operates as an EOA account. EOA clients do not use gasless relayer flows:
-   * approvals, transfers, and other wallet operations are submitted directly by
-   * the signer and require the signer wallet to hold gas. Pass a supported Poly
-   * Deposit Wallet, Poly Safe, or Poly Proxy wallet address to use that wallet
-   * as the account/funder and enable gasless wallet operations when an API key
-   * strategy supports them.
+   * If omitted, the client uses the signer's deterministic Deposit Wallet as
+   * the account wallet. Pass the signer address itself to explicitly trade as
+   * an EOA account, or pass a supported Poly Deposit Wallet, Poly Safe, or Poly
+   * Proxy wallet address to use that wallet as the account/funder.
    */
   wallet?: string;
 
@@ -878,6 +875,8 @@ export type CreateSecureClientError =
   | RateLimitError
   | RequestRejectedError
   | SigningError
+  | TimeoutError
+  | TransactionFailedError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
@@ -886,6 +885,8 @@ export const CreateSecureClientError = makeErrorGuard(
   RateLimitError,
   RequestRejectedError,
   SigningError,
+  TimeoutError,
+  TransactionFailedError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
@@ -930,7 +931,7 @@ export async function createSecureClient(
   });
   const wallet = options.wallet ?? (await options.signer.getAddress());
 
-  return client
+  const secureClient = await client
     .beginAuthentication(
       {
         wallet,
@@ -940,4 +941,10 @@ export async function createSecureClient(
       options.signer,
     )
     .then(authenticateWith(options.signer));
+
+  if (options.wallet !== undefined) {
+    return secureClient;
+  }
+
+  return secureClient.setupGaslessWallet();
 }

--- a/packages/client/src/decorators/wallet.ts
+++ b/packages/client/src/decorators/wallet.ts
@@ -1,6 +1,7 @@
 import {
   approveErc20,
   approveErc1155ForAll,
+  type DeprecatedTransactionHandle,
   mergePositions,
   type PrepareErc20ApprovalRequest,
   type PrepareErc20TransferRequest,
@@ -31,14 +32,10 @@ export type SecureWalletActions = {
    *
    * @example
    * ```ts
-   * const handle = await client.setupTradingApprovals();
-   *
-   * const outcome = await handle.wait();
-   *
-   * // outcome.transactionHash: TxHash
+   * await client.setupTradingApprovals();
    * ```
    */
-  setupTradingApprovals(): Promise<TransactionHandle>;
+  setupTradingApprovals(): Promise<DeprecatedTransactionHandle>;
   /**
    * Approves ERC-20 token spending for the authenticated account.
    *

--- a/packages/client/src/decorators/wallet.ts
+++ b/packages/client/src/decorators/wallet.ts
@@ -1,7 +1,6 @@
 import {
   approveErc20,
   approveErc1155ForAll,
-  isGaslessReady,
   mergePositions,
   type PrepareErc20ApprovalRequest,
   type PrepareErc20TransferRequest,
@@ -19,15 +18,9 @@ import type { TransactionHandle } from '../types';
 
 export type SecureWalletActions = {
   /**
-   * Checks whether the authenticated account wallet is ready for gasless transactions.
-   *
-   * @throws {@link IsGaslessReadyError}
-   * Thrown on failure.
-   *
-   * @example
-   * ```ts
-   * const ready = await client.isGaslessReady();
-   * ```
+   * @deprecated You no longer need to call this. `createSecureClient` ensures
+   * the account wallet is set up for its trading flow, so this always resolves
+   * to `true` and is retained only for backward compatibility.
    */
   isGaslessReady(): Promise<boolean>;
   /**
@@ -184,7 +177,7 @@ export type SecureWalletActions = {
 
 export function walletActions(client: BaseSecureClient): SecureWalletActions {
   return {
-    isGaslessReady: isGaslessReady.bind(null, client),
+    isGaslessReady: () => Promise.resolve(true),
     setupTradingApprovals: setupTradingApprovals.bind(null, client),
     approveErc20: approveErc20.bind(null, client),
     approveErc1155ForAll: approveErc1155ForAll.bind(null, client),
@@ -201,7 +194,6 @@ export function walletActions(client: BaseSecureClient): SecureWalletActions {
 export {
   ApproveErc20Error,
   ApproveErc1155ForAllError,
-  IsGaslessReadyError,
   MergePositionsError,
   RedeemPositionsError,
   SetupTradingApprovalsError,

--- a/packages/client/src/rpc.test.ts
+++ b/packages/client/src/rpc.test.ts
@@ -44,6 +44,41 @@ describe('JsonRpcClient', () => {
     );
   });
 
+  it('performs batched eth_call requests', async () => {
+    const to = expectEvmAddress('0x0000000000000000000000000000000000000001');
+    server.use(
+      http.post(root, async ({ request }) => {
+        await expect(request.json()).resolves.toEqual([
+          {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'eth_call',
+            params: [{ to, data: '0x12345678' }, 'latest'],
+          },
+          {
+            jsonrpc: '2.0',
+            id: 2,
+            method: 'eth_call',
+            params: [{ to, data: '0xabcdef12' }, 'latest'],
+          },
+        ]);
+
+        return HttpResponse.json([
+          { jsonrpc: '2.0', id: 2, result: '0xbbbb' },
+          { jsonrpc: '2.0', id: 1, result: '0xaaaa' },
+        ]);
+      }),
+    );
+    const client = new JsonRpcClient({ url: root });
+
+    await expect(
+      client.ethCallBatch([
+        { to, data: '0x12345678' },
+        { to, data: '0xabcdef12' },
+      ]),
+    ).resolves.toEqual(['0xaaaa', '0xbbbb']);
+  });
+
   it('wraps JSON-RPC errors as rejected requests', async () => {
     const to = expectEvmAddress('0x0000000000000000000000000000000000000001');
     server.use(

--- a/packages/client/src/rpc.ts
+++ b/packages/client/src/rpc.ts
@@ -73,6 +73,58 @@ export class JsonRpcClient {
     return response.result;
   }
 
+  async ethCallBatch(
+    requests: readonly EthCallRequest[],
+  ): Promise<HexString[]> {
+    if (requests.length === 0) {
+      return [];
+    }
+
+    const responses = await this.#postBatch<HexString>(
+      requests.map((request, index) => ({
+        jsonrpc: '2.0',
+        id: index + 1,
+        method: 'eth_call',
+        params: [{ to: request.to, data: request.data }, 'latest'],
+      })),
+    );
+
+    const responsesById = new Map<number, JsonRpcResponse<HexString>>();
+
+    for (const response of responses) {
+      if ('error' in response && response.id === null) {
+        throw new RequestRejectedError(
+          `JSON-RPC eth_call failed: ${response.error.message}`,
+          { cause: response.error, status: 200 },
+        );
+      }
+
+      if (response.id !== null) {
+        responsesById.set(response.id, response);
+      }
+    }
+
+    return requests.map((_, index) => {
+      const id = index + 1;
+      const response = responsesById.get(id);
+
+      if (response === undefined) {
+        throw new UnexpectedResponseError(
+          'Expected JSON-RPC batch response for every request',
+        );
+      }
+
+      if ('error' in response) {
+        throw new RequestRejectedError(
+          `JSON-RPC eth_call failed: ${response.error.message}`,
+          { cause: response.error, status: 200 },
+        );
+      }
+
+      return expectRpcHexResult(response.result);
+    });
+  }
+
   async #post<TResult>(json: unknown): Promise<JsonRpcResponse<TResult>> {
     let response: Response;
 
@@ -104,6 +156,48 @@ export class JsonRpcClient {
     }
 
     if (!isJsonRpcResponse<TResult>(body)) {
+      throw new UnexpectedResponseError('Unexpected JSON-RPC response shape');
+    }
+
+    return body;
+  }
+
+  async #postBatch<TResult>(
+    json: unknown,
+  ): Promise<JsonRpcResponse<TResult>[]> {
+    let response: Response;
+
+    try {
+      response = await ky.post(this.#url, {
+        json,
+        throwHttpErrors: false,
+      });
+    } catch (error) {
+      throw TransportError.fromError(error);
+    }
+
+    if (!response.ok) {
+      throw new RequestRejectedError(
+        `JSON-RPC request to ${this.#url} failed with status ${response.status}`,
+        { status: response.status },
+      );
+    }
+
+    let body: unknown;
+
+    try {
+      body = await response.json();
+    } catch (error) {
+      throw new UnexpectedResponseError(
+        'Expected JSON-RPC response body to be JSON',
+        { cause: error },
+      );
+    }
+
+    if (
+      !Array.isArray(body) ||
+      !body.every((value) => isJsonRpcResponse<TResult>(value))
+    ) {
       throw new UnexpectedResponseError('Unexpected JSON-RPC response shape');
     }
 
@@ -167,6 +261,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isRpcHexString(value: string): value is HexString {
   return /^0x[a-fA-F0-9]*$/.test(value);
+}
+
+function expectRpcHexResult(value: unknown): HexString {
+  if (typeof value !== 'string' || !isRpcHexString(value)) {
+    throw new UnexpectedResponseError(
+      'Expected JSON-RPC eth_call result to be a hex string',
+    );
+  }
+
+  return value;
 }
 
 function stringifyJsonRpcErrorData(data: unknown): string {

--- a/packages/client/tests/integration/approvals.test.ts
+++ b/packages/client/tests/integration/approvals.test.ts
@@ -88,9 +88,11 @@ describe('Approvals', () => {
 
       expect(secureClient.account.walletType).toBe(WalletType.DEPOSIT_WALLET);
 
-      const handle = await secureClient.setupTradingApprovals();
-
-      await expect(handle.wait()).resolves.toBeTruthy();
+      await expect(secureClient.setupTradingApprovals()).resolves.toMatchObject(
+        {
+          wait: expect.any(Function),
+        },
+      );
     });
   });
 });

--- a/packages/client/tests/integration/approvals.test.ts
+++ b/packages/client/tests/integration/approvals.test.ts
@@ -33,8 +33,10 @@ describe('Approvals', () => {
     it('supports EOA approvals as traditional transactions', async ({
       randomEoaSigner,
     }) => {
+      const signerAddress = await randomEoaSigner.getAddress();
       const secureClient = await createSecureClient({
         signer: randomEoaSigner,
+        wallet: signerAddress,
       });
 
       expect(secureClient.account.walletType).toBe(WalletType.EOA);

--- a/packages/client/tests/integration/clients.test.ts
+++ b/packages/client/tests/integration/clients.test.ts
@@ -1,5 +1,5 @@
 import { createSecureClient, WalletType } from '@polymarket/client';
-import { fetchApiKeys } from '@polymarket/client/actions';
+import { fetchApiKeys, isWalletDeployed } from '@polymarket/client/actions';
 import { InvariantError, ZERO_ADDRESS } from '@polymarket/types';
 import { describe, expect, it, runMeteredTests } from './fixtures';
 
@@ -68,7 +68,8 @@ describe('clients', () => {
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
 
-    it('authenticates as EOA when wallet is omitted', async ({
+    it('defaults omitted wallet to the current Deposit Wallet', async ({
+      depositWalletAddress,
       depositWalletSigner,
     }) => {
       const signerAddress = await depositWalletSigner.getAddress();
@@ -77,10 +78,27 @@ describe('clients', () => {
       });
 
       expect(secureClient.account.signer).toBe(signerAddress);
-      expect(secureClient.account.wallet).toBe(signerAddress);
-      expect(secureClient.account.walletType).toBe(WalletType.EOA);
+      expect(secureClient.account.wallet).toBe(depositWalletAddress);
+      expect(secureClient.account.walletType).toBe(WalletType.DEPOSIT_WALLET);
       await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
     });
+
+    it.runIf(runMeteredTests)(
+      'deploys the default Deposit Wallet when omitted wallet is not deployed',
+      async ({ builderAuthentication, randomEoaSigner }) => {
+        const signerAddress = await randomEoaSigner.getAddress();
+        const secureClient = await createSecureClient({
+          apiKey: builderAuthentication,
+          signer: randomEoaSigner,
+        });
+
+        expect(secureClient.account.signer).toBe(signerAddress);
+        expect(secureClient.account.wallet).not.toBe(signerAddress);
+        expect(secureClient.account.walletType).toBe(WalletType.DEPOSIT_WALLET);
+        await expect(isWalletDeployed(secureClient)).resolves.toBe(true);
+      },
+      20_000,
+    );
 
     it('rejects with InvariantError when wallet does not match signer or any supported derived wallet', async ({
       depositWalletSigner,
@@ -144,68 +162,6 @@ describe('clients', () => {
       expect(remainingApiKeys).toContain(resumedClient.credentials.key);
       expect(remainingApiKeys).not.toContain(revokedKey);
     });
-  });
-
-  describe('SecureClient.setupGaslessWallet', () => {
-    it('returns a secure client for an already-bound Deposit Wallet', async ({
-      depositWalletAddress,
-      depositWalletSigner,
-      relayerAuthentication,
-    }) => {
-      const signerAddress = await depositWalletSigner.getAddress();
-      const secureClient = await createSecureClient({
-        apiKey: relayerAuthentication,
-        signer: depositWalletSigner,
-        wallet: depositWalletAddress,
-      });
-
-      const depositWalletClient = await secureClient.setupGaslessWallet();
-
-      expect(depositWalletClient.account.signer).toBe(signerAddress);
-      expect(depositWalletClient.account.wallet).toBe(depositWalletAddress);
-      expect(depositWalletClient.account.walletType).toBe(
-        WalletType.DEPOSIT_WALLET,
-      );
-    });
-
-    it('returns a secure client for an already-bound Proxy wallet', async ({
-      proxyWalletAddress,
-      proxyWalletSigner,
-      relayerAuthentication,
-    }) => {
-      const signerAddress = await proxyWalletSigner.getAddress();
-      const secureClient = await createSecureClient({
-        apiKey: relayerAuthentication,
-        signer: proxyWalletSigner,
-        wallet: proxyWalletAddress,
-      });
-
-      const gaslessClient = await secureClient.setupGaslessWallet();
-
-      expect(gaslessClient.account.signer).toBe(signerAddress);
-      expect(gaslessClient.account.wallet).toBe(proxyWalletAddress);
-      expect(gaslessClient.account.walletType).toBe(WalletType.POLY_PROXY);
-    });
-
-    it.runIf(runMeteredTests)(
-      'deploys the Deposit Wallet and returns a secure client bound to it',
-      async ({ builderAuthentication, randomEoaSigner }) => {
-        const secureClient = await createSecureClient({
-          apiKey: builderAuthentication,
-          signer: randomEoaSigner,
-        });
-
-        await expect(secureClient.isGaslessReady()).resolves.toBe(false);
-
-        const depositWalletClient = await secureClient.setupGaslessWallet();
-
-        expect(depositWalletClient.account.walletType).toBe(
-          WalletType.DEPOSIT_WALLET,
-        );
-        await expect(depositWalletClient.isGaslessReady()).resolves.toBe(true);
-      },
-      20_000,
-    );
   });
 
   describe('SecureClient.endAuthentication', () => {

--- a/packages/client/tests/integration/gasless.test.ts
+++ b/packages/client/tests/integration/gasless.test.ts
@@ -45,60 +45,6 @@ describe('Gasless', () => {
     server.close();
   });
 
-  describe('isGaslessReady', () => {
-    it('returns true for a deployed Deposit Wallet', async ({
-      depositWalletAddress,
-      depositWalletSigner,
-    }) => {
-      const secureClient = await createSecureClient({
-        signer: depositWalletSigner,
-        wallet: depositWalletAddress,
-      });
-
-      expect(secureClient.account.walletType).toBe(WalletType.DEPOSIT_WALLET);
-
-      await expect(secureClient.isGaslessReady()).resolves.toBe(true);
-    });
-
-    it('returns true for a deployed Proxy wallet', async ({
-      proxyWalletAddress,
-      proxyWalletSigner,
-    }) => {
-      const secureClient = await createSecureClient({
-        signer: proxyWalletSigner,
-        wallet: proxyWalletAddress,
-      });
-
-      expect(secureClient.account.walletType).toBe(WalletType.POLY_PROXY);
-
-      await expect(secureClient.isGaslessReady()).resolves.toBe(true);
-    });
-
-    it('returns true for a deployed Safe wallet', async ({
-      safeWalletAddress,
-      safeWalletSigner,
-    }) => {
-      const secureClient = await createSecureClient({
-        signer: safeWalletSigner,
-        wallet: safeWalletAddress,
-      });
-
-      expect(secureClient.account.walletType).toBe(WalletType.GNOSIS_SAFE);
-
-      await expect(secureClient.isGaslessReady()).resolves.toBe(true);
-    });
-
-    it('returns false for an EOA wallet type', async ({ randomEoaSigner }) => {
-      const secureClient = await createSecureClient({
-        signer: randomEoaSigner,
-      });
-
-      expect(secureClient.account.walletType).toBe(WalletType.EOA);
-
-      await expect(secureClient.isGaslessReady()).resolves.toBe(false);
-    });
-  });
-
   describe('prepareGaslessTransaction submit payloads', () => {
     it('submits a Deposit Wallet WALLET payload', async ({
       depositWalletAddress,

--- a/packages/client/tests/integration/privy.test.ts
+++ b/packages/client/tests/integration/privy.test.ts
@@ -132,9 +132,7 @@ async function createPrivyTestAccount({
     ).balance !== '0';
 
   if (hasCollateralBalance && runMeteredTests) {
-    const handle = await depositWalletClient.setupTradingApprovals();
-
-    await handle.wait();
+    await depositWalletClient.setupTradingApprovals();
   }
 
   return {


### PR DESCRIPTION
## Summary
- default createSecureClient to the current deterministic Deposit Wallet when wallet is omitted
- keep explicit EOA and deployed wallet behavior intact, while rejecting undeployed non-current Deposit Wallets and undeployed Safe/proxy wallets clearly
- make deprecated gasless setup/readiness methods no-op compatibility shims and rename the internal deployment check to isWalletDeployed

## Verification
- pnpm test:client -- clients.test.ts
- pnpm lint
- pnpm typecheck

Linear: DEV-157

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet binding defaults and on-chain approval/setup behavior at client creation; mistakes could affect which address trades or which txs are sent, though explicit wallet paths and stricter validation reduce silent misconfiguration.
> 
> **Overview**
> **`createSecureClient`** now defaults omitted `wallet` to the signer’s **current deterministic Deposit Wallet** (derived at runtime), checks relayer deployment, and **deploys** that wallet when needed. Explicit **EOA**, deployed **Safe/proxy**, and deployed deposit wallets stay supported; **undeployed** non-current deposit wallets and undeployed Safe/proxy addresses fail with clear **`UserInputError`**s instead of silent fallback.
> 
> **`setupGaslessWallet`** and **`isGaslessReady`** are deprecated **compatibility shims** (no-op / always `true`); deployment-only checks move to **`isWalletDeployed`**.
> 
> **`setupTradingApprovals`** is **idempotent**: batched **`ethCallBatch`** reads ERC-20 allowances and ERC-1155 operator status, submits only missing approvals, **waits internally**, and returns a stub handle whose **`wait()`** is deprecated.
> 
> **`JsonRpcClient.ethCallBatch`** supports the approval preflight. Tests and integration flows are updated for the new defaults and APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26160c9e078a35a0e9de87e22bfd9b45efcdb4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->