### PR TITLE
Unblock changesets from integration tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
     needs:
       - verify
       - test
-      - integration-tests
+      # Temporarily do not block changesets while we solve the integration test runner issue.
+      # - integration-tests
 
     steps:
       - name: Checkout Repository
@@ -62,7 +63,7 @@ jobs:
     needs:
       - verify
       - test
-      # Temporarily do not block canary publishing on integration tests while checks are blocked by a BE bug.
+      # Temporarily do not block canary publishing while we solve the integration test runner issue.
       # - integration-tests
     if: "${{ !contains(github.event.head_commit.message, 'chore: bumps package versions') }}"
 


### PR DESCRIPTION
## Summary
- allow the changeset job to run without waiting on integration tests
- update the canary publishing comment to match the current integration runner issue

## Verification
- workflow-only change; not run locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shipping changesets and canaries without a green integration-test gate increases the chance of broken releases until the runner issue is fixed and the dependency is restored.
> 
> **Overview**
> The **release** workflow no longer waits on **integration tests** before running **Changesets** or **canary** publish jobs.
> 
> The `changesets` job’s `needs` list drops `integration-tests`, so version-bump/release PR automation can proceed after **verify** and **test** only. A short comment documents this as a temporary workaround for an integration test runner problem. The **canary** job was already not gated on integration tests; its comment is updated to cite the same runner issue instead of a backend bug.
> 
> Integration tests still run as their own job on `main`; they just no longer block release automation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcbc7c7156bbec84f7b97b055a991d462d6261ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->