### PR TITLE
Update RFQ quoter WebSocket URL

### DIFF
--- a/.changeset/rfq-quoter-ws-url.md
+++ b/.changeset/rfq-quoter-ws-url.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Update the RFQ quoter WebSocket URL.

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -137,8 +137,7 @@ export const production: EnvironmentConfig = {
   gamma: 'https://gamma-api.polymarket.com',
   data: 'https://data-api.polymarket.com',
   rtdsWs: 'wss://ws-live-data.polymarket.com',
-  rfqQuoterWs:
-    'wss://combos-rfq-gateway-quoter.preprod.pmd.euw2.polymarket.sh/ws',
+  rfqQuoterWs: 'wss://combos-rfq-gateway-quoter-preprod.polymarket.sh/ws/rfq',
   sportsWs: 'wss://sports-api.polymarket.com/ws',
   relayerMaxPolls: 100,
   relayerPollFrequencyMs: 2000,


### PR DESCRIPTION
## Summary
- Update the RFQ quoter WebSocket URL to the current pre-production endpoint.
- Add a patch changeset for @polymarket/client.

## Verification
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single environment URL swap with no logic, auth, or data-handling changes; clients must reach the new gateway for RFQ quoter connectivity.
> 
> **Overview**
> Updates the **production** `rfqQuoterWs` endpoint in `@polymarket/client` from the legacy `*.preprod.pmd.euw2.polymarket.sh/ws` host to `combos-rfq-gateway-quoter-preprod.polymarket.sh/ws/rfq`.
> 
> A patch **changeset** records the client package bump for this configuration-only change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d50f299379d55c2a13e820d5192642046f40cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->