### PR TITLE
fix(client): allow zero auth nonce

### DIFF
--- a/.changeset/zero-nonce-auth.md
+++ b/.changeset/zero-nonce-auth.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Allow `createSecureClient` authentication to accept an explicit `nonce: 0`, matching the documented default nonce behavior.

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -1,7 +1,11 @@
 import { ApiKeySchema } from '@polymarket/bindings';
 import type { ApiKeyCreds } from '@polymarket/bindings/clob';
 import { WalletType } from '@polymarket/bindings/gamma';
-import { type EvmAddress, expectEvmAddress } from '@polymarket/types';
+import {
+  type EvmAddress,
+  expectEvmAddress,
+  expectEvmSignature,
+} from '@polymarket/types';
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
@@ -156,6 +160,41 @@ describe('secure client gasless wallet setup', () => {
       credentials,
       environment,
       signer,
+      wallet: signerAddress,
+    });
+
+    expect(client.account).toEqual({
+      signer: signerAddress,
+      wallet: signerAddress,
+      walletType: WalletType.EOA,
+    });
+  });
+
+  it('accepts an explicit zero nonce for fresh authentication', async () => {
+    const signingSigner: Signer = {
+      ...signer,
+      signTypedData(payload) {
+        expect(payload.message.nonce).toBe(0);
+        return Promise.resolve(expectEvmSignature(`0x${'1'.repeat(130)}`));
+      },
+    };
+
+    server.use(
+      http.post(`${clobRoot}/auth/api-key`, ({ request }) => {
+        expect(request.headers.get('POLY_NONCE')).toBe('0');
+
+        return HttpResponse.json({
+          apiKey: credentials.key,
+          passphrase: credentials.passphrase,
+          secret: credentials.secret,
+        });
+      }),
+    );
+
+    const client = await createSecureClient({
+      environment,
+      nonce: 0,
+      signer: signingSigner,
       wallet: signerAddress,
     });
 

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -231,7 +231,7 @@ const BeginAuthenticationRequestSchema: z.ZodType<BeginAuthenticationRequest> =
     .object({
       wallet: EvmAddressSchema,
       credentials: BeginAuthenticationCredentialsSchema.optional(),
-      nonce: z.number().int().positive().optional(),
+      nonce: z.number().int().nonnegative().optional(),
     })
     .superRefine((value, context) => {
       if (value.credentials !== undefined && value.nonce !== undefined) {


### PR DESCRIPTION
## Summary
- Allow explicit nonce 0 during secure client authentication.
- Add client coverage that verifies nonce 0 is signed and sent as POLY_NONCE.

## Verification
- pnpm test:client -- packages/client/src/clients.test.ts
- pnpm lint
- pnpm typecheck

DEV-148

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow input-validation fix with a regression test; no changes to auth crypto or API contracts beyond accepting documented nonce 0.
> 
> **Overview**
> Fixes a validation mismatch in **`createSecureClient`** / `beginAuthentication`: the docs already treat the default auth **nonce** as **0**, but passing **`nonce: 0` explicitly** was rejected because the Zod schema required a **positive** integer.
> 
> The schema now allows **non-negative** integers (`0` included), so explicit `nonce: 0` follows the same fresh-auth path as omitting `nonce` (typed-data message and **`POLY_NONCE`** header). A new client test asserts signing and the auth request use nonce **0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2067f38e2ef7ee19a7f5ca3d3738fd6354d7441f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->