### PR TITLE
docs: update runtime support metadata

### DIFF
--- a/.changeset/node-24-engines.md
+++ b/.changeset/node-24-engines.md
@@ -1,0 +1,7 @@
+---
+"@polymarket/client": patch
+"@polymarket/bindings": patch
+"@polymarket/types": patch
+---
+
+Declare Node.js 24 as the minimum supported runtime for published SDK packages.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,8 +23,8 @@ body:
     id: runtime
     attributes:
       label: Runtime
-      description: Include your Node.js version, browser/runtime if relevant, and package manager.
-      placeholder: "Node.js 22.11.0, pnpm 9.15.0"
+      description: Include your Node.js version, browser/runtime if relevant, and package manager/version.
+      placeholder: "Node.js 24.14.0, pnpm 10.33.0"
     validations:
       required: true
   - type: textarea

--- a/packages/bindings/package.json
+++ b/packages/bindings/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/bindings"
   },
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/client"
   },
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -8,6 +8,9 @@
     "directory": "packages/types"
   },
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- update the bug report runtime placeholder to supported Node.js and pnpm example versions
- declare Node.js >=24 in published SDK package metadata
- add a patch changeset for the package metadata update

## Verification
- pnpm lint
- pnpm typecheck

Closes DEV-156
Refs Polymarket/ts-sdk#70

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and template-only changes with no runtime or API logic; install tools may warn users still on Node &lt;24.
> 
> **Overview**
> Documents **Node.js 24+** as the minimum runtime for published SDK packages and aligns contributor-facing templates with that policy.
> 
> Adds `"engines": { "node": ">=24" }` to `@polymarket/client`, `@polymarket/bindings`, and `@polymarket/types` so npm/yarn/pnpm surface the requirement at install time. The GitHub bug report template’s runtime placeholder and copy now reference **Node.js 24.14.0** and **pnpm 10.33.0** instead of older examples. A patch **changeset** records the metadata bump for those three packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc633924b3df246f44082566e31087e538589a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->