### PR TITLE
Fix wallet action gasless error unions

### DIFF
--- a/.changeset/dev-206-gasless-wallet-errors.md
+++ b/.changeset/dev-206-gasless-wallet-errors.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Align wallet action error unions with gasless transaction failure paths for non-EOA accounts.

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -120,12 +120,20 @@ export async function prepareErc20Approval(
 }
 
 export type ApproveErc20Error =
-  | PrepareErc20ApprovalError
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError
   | CancelledSigningError
   | SigningError;
 export const ApproveErc20Error = makeErrorGuard(
   CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
   SigningError,
+  TransportError,
+  UnexpectedResponseError,
   UserInputError,
 );
 
@@ -229,12 +237,20 @@ export async function prepareErc1155ApprovalForAll(
 }
 
 export type ApproveErc1155ForAllError =
-  | PrepareErc1155ApprovalForAllError
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError
   | CancelledSigningError
   | SigningError;
 export const ApproveErc1155ForAllError = makeErrorGuard(
   CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
   SigningError,
+  TransportError,
+  UnexpectedResponseError,
   UserInputError,
 );
 

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -120,8 +120,19 @@ export type PrepareRedeemPositionsRequest = z.input<
   typeof PrepareRedeemPositionsRequestSchema
 >;
 
-export type PrepareSplitPositionError = UserInputError;
-export const PrepareSplitPositionError = makeErrorGuard(UserInputError);
+export type PrepareSplitPositionError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const PrepareSplitPositionError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
 export type PrepareMergePositionsError =
   | RateLimitError
   | RequestRejectedError
@@ -202,12 +213,20 @@ export async function prepareSplitPosition(
 }
 
 export type SplitPositionError =
-  | PrepareSplitPositionError
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError
   | CancelledSigningError
   | SigningError;
 export const SplitPositionError = makeErrorGuard(
   CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
   SigningError,
+  TransportError,
+  UnexpectedResponseError,
   UserInputError,
 );
 
@@ -288,7 +307,11 @@ export async function prepareMergePositions(
 }
 
 export type MergePositionsError =
-  | PrepareMergePositionsError
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError
   | CancelledSigningError
   | SigningError;
 export const MergePositionsError = makeErrorGuard(
@@ -382,7 +405,11 @@ export async function prepareRedeemPositions(
 }
 
 export type RedeemPositionsError =
-  | PrepareRedeemPositionsError
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError
   | CancelledSigningError
   | SigningError;
 export const RedeemPositionsError = makeErrorGuard(

--- a/packages/client/src/actions/transfers.ts
+++ b/packages/client/src/actions/transfers.ts
@@ -7,7 +7,11 @@ import type { BaseSecureClient } from '../clients';
 import {
   CancelledSigningError,
   makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
   SigningError,
+  TransportError,
+  UnexpectedResponseError,
   UserInputError,
 } from '../errors';
 import { parseUserInput } from '../input';
@@ -107,12 +111,20 @@ export async function prepareErc20Transfer(
 }
 
 export type TransferErc20Error =
-  | PrepareErc20TransferError
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError
   | CancelledSigningError
   | SigningError;
 export const TransferErc20Error = makeErrorGuard(
   CancelledSigningError,
+  RateLimitError,
+  RequestRejectedError,
   SigningError,
+  TransportError,
+  UnexpectedResponseError,
   UserInputError,
 );
 


### PR DESCRIPTION
## Summary
- align approval, transfer, and position lifecycle action error unions with non-EOA gasless transaction paths
- keep exported error aliases and runtime guards in sync
- add a patch changeset for @polymarket/client

Fixes #92
Linear: DEV-206

## Verification
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and runtime error-guard alignment; no change to transaction or signing behavior.
> 
> **Overview**
> **Expands `@polymarket/client` wallet action error types** so they match what non-EOA (gasless) flows can actually throw, not only EOA prepare/signing failures.
> 
> For **approvals** (`ApproveErc20Error`, `ApproveErc1155ForAllError`), **transfers** (`TransferErc20Error`), and **position lifecycle** (`SplitPositionError`, `MergePositionsError`, `RedeemPositionsError`, plus `PrepareSplitPositionError`), the exported unions and `makeErrorGuard` lists now include `RateLimitError`, `RequestRejectedError`, `TransportError`, and `UnexpectedResponseError` alongside existing signing and `UserInputError` cases. Prepare-only aliases that incorrectly implied only input validation errors were replaced or broadened where gasless preparation is involved.
> 
> A **patch changeset** records the `@polymarket/client` release note for this alignment (fixes #92 / DEV-206).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04bbc462a1b24a8416e3ab456217dbd19ac511ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->