### PR TITLE
fix(client): accept copied event market URLs

### DIFF
--- a/.changeset/dev-168-market-event-url.md
+++ b/.changeset/dev-168-market-event-url.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Accept copied market URLs in the current `/event/{eventSlug}/{marketSlug}` shape when fetching markets by URL.

--- a/.changeset/dev-168-market-event-url.md
+++ b/.changeset/dev-168-market-event-url.md
@@ -2,4 +2,4 @@
 "@polymarket/client": patch
 ---
 
-Accept copied market URLs in the current `/event/{eventSlug}/{marketSlug}` shape when fetching markets by URL.
+Accept copied `/event/{slug}` market URLs when fetching markets by URL.

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -266,7 +266,7 @@ export const FetchMarketError = makeErrorGuard(
  * });
  *
  * const marketByUrl = await fetchMarket(client, {
- *   url: 'https://polymarket.com/market/some-market-slug',
+ *   url: 'https://polymarket.com/event/some-event-slug/some-market-slug',
  * });
  *
  * // market === Market

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -266,7 +266,7 @@ export const FetchMarketError = makeErrorGuard(
  * });
  *
  * const marketByUrl = await fetchMarket(client, {
- *   url: 'https://polymarket.com/event/some-event-slug/some-market-slug',
+ *   url: 'https://polymarket.com/event/some-market-slug',
  * });
  *
  * // market === Market

--- a/packages/client/src/decorators/discovery.ts
+++ b/packages/client/src/decorators/discovery.ts
@@ -189,7 +189,7 @@ export type DiscoveryActions = {
    * });
    *
    * const marketByUrl = await client.fetchMarket({
-   *   url: 'https://polymarket.com/market/some-market-slug',
+   *   url: 'https://polymarket.com/event/some-event-slug/some-market-slug',
    * });
    * ```
    */

--- a/packages/client/src/decorators/discovery.ts
+++ b/packages/client/src/decorators/discovery.ts
@@ -189,7 +189,7 @@ export type DiscoveryActions = {
    * });
    *
    * const marketByUrl = await client.fetchMarket({
-   *   url: 'https://polymarket.com/event/some-event-slug/some-market-slug',
+   *   url: 'https://polymarket.com/event/some-market-slug',
    * });
    * ```
    */

--- a/packages/client/src/polymarket-url.ts
+++ b/packages/client/src/polymarket-url.ts
@@ -30,10 +30,9 @@ export function parsePolymarketSlugUrl(
     resource === 'market' &&
     actualResource === 'event' &&
     slug !== undefined &&
-    marketSlug !== undefined &&
-    extraSegments.length === 1
+    extraSegments.length <= 1
   ) {
-    return marketSlug;
+    return marketSlug ?? slug;
   }
 
   if (

--- a/packages/client/src/polymarket-url.ts
+++ b/packages/client/src/polymarket-url.ts
@@ -24,6 +24,17 @@ export function parsePolymarketSlugUrl(
   const [actualResource, slug, ...extraSegments] = url.pathname
     .split('/')
     .filter(Boolean);
+  const marketSlug = extraSegments[0];
+
+  if (
+    resource === 'market' &&
+    actualResource === 'event' &&
+    slug !== undefined &&
+    marketSlug !== undefined &&
+    extraSegments.length === 1
+  ) {
+    return marketSlug;
+  }
 
   if (
     actualResource !== resource ||

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -58,7 +58,7 @@ describe('Markets', () => {
 
     it('fetches a market by URL', async ({ publicClient }) => {
       const marketByUrl = await publicClient.fetchMarket({
-        url: `https://polymarket.com/event/some-event-slug/${expectPresent(market.slug)}`,
+        url: `https://polymarket.com/event/${expectPresent(market.slug)}`,
       });
 
       expect(marketByUrl.id).toBe(market.id);
@@ -79,7 +79,7 @@ describe('Markets', () => {
 
       await expect(
         publicClient.fetchMarket({
-          url: 'https://polymarket.com/event/presidential-election-2028',
+          url: 'https://polymarket.com/tag/politics',
         }),
       ).rejects.toThrow(UserInputError);
     });

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -58,7 +58,7 @@ describe('Markets', () => {
 
     it('fetches a market by URL', async ({ publicClient }) => {
       const marketByUrl = await publicClient.fetchMarket({
-        url: `https://polymarket.com/market/${expectPresent(market.slug)}`,
+        url: `https://polymarket.com/event/some-event-slug/${expectPresent(market.slug)}`,
       });
 
       expect(marketByUrl.id).toBe(market.id);


### PR DESCRIPTION
## Summary
- accept copied market URLs shaped like `/event/{slug}` in `fetchMarket(url: ...)`
- also supports selected-market URLs shaped like `/event/{eventSlug}/{marketSlug}` by using the final slug
- update market URL examples and the existing market URL integration test

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:client:integration packages/client/tests/integration/markets.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized URL parsing for market lookup only; no auth or API contract changes beyond accepting additional user input shapes.
> 
> **Overview**
> **`fetchMarket({ url })`** now accepts Polymarket links copied from the site that use the **`/event/...`** path, not only **`/market/{slug}`**.
> 
> `parsePolymarketSlugUrl` gains a **market-specific** branch: when resolving a market, **`/event/{slug}`** uses that segment as the market slug, and **`/event/{eventSlug}/{marketSlug}`** prefers the second segment when present (at most one extra path segment). Other shapes still fail with **`UserInputError`**. Docs/examples and the integration test were updated to use event-style URLs; the negative test now rejects a **tag** URL instead of a plain event URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a75a6fd0a15b11a7a079dd70fac3f63eb1ca2789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->