### PR TITLE
fix(client): issue with activities parsing and test failing

### DIFF
--- a/.changeset/sparse-activity-icons.md
+++ b/.changeset/sparse-activity-icons.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Allow activity market icons to be null when the Data API returns sparse historical rows without an icon URL.

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -62,8 +62,8 @@ export type TradeActivity = ActivityBase & {
   title: string;
   /** URL slug of the market traded by the wallet. */
   slug: string;
-  /** Icon URL for the market traded by the wallet. */
-  icon: string;
+  /** Icon URL for the market traded by the wallet, when available. */
+  icon: string | null;
   /** URL slug of the event containing the traded market. */
   eventSlug: string;
 };
@@ -79,8 +79,8 @@ export type SplitActivity = ActivityBase & {
   title: string;
   /** URL slug of the market whose complete set was created. */
   slug: string;
-  /** Icon URL for the market whose complete set was created. */
-  icon: string;
+  /** Icon URL for the market whose complete set was created, when available. */
+  icon: string | null;
   /** URL slug of the event containing the split market. */
   eventSlug: string;
 };
@@ -96,8 +96,8 @@ export type MergeActivity = ActivityBase & {
   title: string;
   /** URL slug of the market whose complete set was merged. */
   slug: string;
-  /** Icon URL for the market whose complete set was merged. */
-  icon: string;
+  /** Icon URL for the market whose complete set was merged, when available. */
+  icon: string | null;
   /** URL slug of the event containing the merged market. */
   eventSlug: string;
 };
@@ -113,8 +113,8 @@ export type RedeemActivity = ActivityBase & {
   title: string;
   /** URL slug of the market redeemed by the wallet. */
   slug: string;
-  /** Icon URL for the market redeemed by the wallet. */
-  icon: string;
+  /** Icon URL for the market redeemed by the wallet, when available. */
+  icon: string | null;
   /** URL slug of the event containing the redeemed market. */
   eventSlug: string;
 };
@@ -130,8 +130,8 @@ export type ConversionActivity = ActivityBase & {
   title: string;
   /** URL slug of the market involved in the conversion. */
   slug: string;
-  /** Icon URL for the market involved in the conversion. */
-  icon: string;
+  /** Icon URL for the market involved in the conversion, when available. */
+  icon: string | null;
   /** URL slug of the event containing the converted market. */
   eventSlug: string;
 };
@@ -280,7 +280,7 @@ function normalizeActivity(activity: RawActivity): Activity {
         outcomeIndex: expectPresent(activity.outcomeIndex, 'outcomeIndex'),
         title: expectPresent(activity.title, 'title'),
         slug: expectPresent(activity.slug, 'slug'),
-        icon: expectPresent(activity.icon, 'icon'),
+        icon: activity.icon ?? null,
         eventSlug: expectPresent(activity.eventSlug, 'eventSlug'),
       };
     case ActivityType.SPLIT:
@@ -294,7 +294,7 @@ function normalizeActivity(activity: RawActivity): Activity {
         amount: inferAmount(activity),
         title: expectPresent(activity.title, 'title'),
         slug: expectPresent(activity.slug, 'slug'),
-        icon: expectPresent(activity.icon, 'icon'),
+        icon: activity.icon ?? null,
         eventSlug: expectPresent(activity.eventSlug, 'eventSlug'),
       };
     case ActivityType.REWARD:

--- a/packages/client/tests/integration/ethers-v5.test.ts
+++ b/packages/client/tests/integration/ethers-v5.test.ts
@@ -7,8 +7,7 @@ import { ethers } from 'ethers-v5';
 import { polygon } from 'viem/chains';
 import { describe, expect, it, runMeteredTests } from './fixtures';
 import { expectAcceptedOrderResponse } from './helpers';
-
-const TEST_MARKET_SLUG = 'eth-flipped-in-2026';
+import { findHighVolumeLowPriceMarket } from './markets';
 
 const provider = new ethers.providers.JsonRpcProvider(
   polygon.rpcUrls.default.http[0],
@@ -39,9 +38,7 @@ describe('ethers-v5', () => {
       publicClient,
       relayerAuthentication,
     }) => {
-      const market = await publicClient.fetchMarket({
-        slug: TEST_MARKET_SLUG,
-      });
+      const market = await findHighVolumeLowPriceMarket(publicClient);
       const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
       const price = expectPresent(market.trading.minimumTickSize);
       const size = expectPresent(market.trading.minimumOrderSize);

--- a/packages/client/tests/integration/positions.test.ts
+++ b/packages/client/tests/integration/positions.test.ts
@@ -6,8 +6,8 @@ import {
 import { expectPresent } from '@polymarket/types';
 import { vi } from 'vitest';
 import { describe, expect, it, publicClient } from './fixtures';
+import { findHighVolumeLowPriceMarket } from './markets';
 
-const TEST_MARKET_SLUG = 'eth-flipped-in-2026';
 const TEST_COMBO_AMOUNT = 1_000_000n;
 const TEST_COMBO_CONDITION_ID =
   '0x034eabdeca272641d98717d8ca2f8e5f330000000000000000000000000000';
@@ -15,11 +15,9 @@ const TEST_COMBO_LEGS = [
   '920454018917169090762848014984037642864617754825717966757321143422977835520',
   '1012585296795354377868537359137497102116066671623168081060942028909450362880',
 ];
-const conditionId = await publicClient
-  .fetchMarket({
-    slug: TEST_MARKET_SLUG,
-  })
-  .then((market) => expectPresent(market.conditionId));
+const conditionId = expectPresent(
+  (await findHighVolumeLowPriceMarket(publicClient)).conditionId,
+);
 
 describe('Positions', () => {
   describe('and a CLOB market', () => {


### PR DESCRIPTION
## Summary
- add combo position listing and account binding
- add split, merge, and redeem support for market and combo positions
- handle balance-backed max merge and full-balance combo redeem flows
- tolerate sparse Data API activity icons and replace stale live integration market fixtures

## Verification
- pnpm --filter @polymarket/bindings build
- pnpm lint
- pnpm typecheck
- pnpm vitest packages/client/src/protocol.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow type and parsing relaxation for optional display metadata; integration test fixture changes only affect tests.
> 
> **Overview**
> Activity bindings now treat market **`icon`** as optional (`string | null`) on trade, split, merge, redeem, and conversion rows, matching sparse Data API history where icon URLs are missing. Normalization no longer throws when **`icon`** is absent; it maps missing values to **`null`** instead of **`expectPresent`**.
> 
> Live integration tests stop using the fixed **`eth-flipped-in-2026`** slug and resolve markets via **`findHighVolumeLowPriceMarket`** in the ethers-v5 order flow and positions setup. A changeset records patch bumps for **`@polymarket/bindings`** and **`@polymarket/client`** for this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50682d69a5dd9a859afd8809105c1bd98a7e7e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->