### PR TITLE
test(client): remove live approval revocation test

### DIFF
--- a/.changeset/remove-live-approval-revocation-test.md
+++ b/.changeset/remove-live-approval-revocation-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+No package changes.

--- a/packages/client/tests/integration/fixtures.ts
+++ b/packages/client/tests/integration/fixtures.ts
@@ -35,6 +35,7 @@ type IntegrationFixtures = {
   depositWalletAddress: EvmAddress;
   depositWalletPrivateKey: PrivateKey;
   depositWalletSigner: Signer;
+  newDepositWalletClient: SecureClient;
   publicClient: PublicClient;
   proxyWalletAddress: EvmAddress;
   proxyWalletSigner: Signer;
@@ -73,6 +74,19 @@ export const it: TestAPI<IntegrationFixtures> =
         apiKey: relayerAuthentication,
         signer: depositWalletSigner,
         wallet: depositWalletAddress,
+      });
+
+      await use(secureClient);
+    },
+
+    newDepositWalletClient: async ({ relayerAuthentication }, use) => {
+      // Intended for vnet-backed tests that give a fresh Deposit Wallet a
+      // synthetic collateral balance. Do not use against live funds without an
+      // explicit cleanup strategy.
+      const signer = createTestSigner(generatePrivateKey());
+      const secureClient = await createSecureClient({
+        apiKey: relayerAuthentication,
+        signer,
       });
 
       await use(secureClient);

--- a/packages/client/tests/integration/orders.test.ts
+++ b/packages/client/tests/integration/orders.test.ts
@@ -237,6 +237,36 @@ describe('Orders', { timeout: 60_000 }, () => {
       expect(order.postOnly).toBe(true);
       expect(order.builder).toBe(builderCode);
     });
+
+    // Enable once this suite runs against the staging Tenderly vnet with a fake
+    // collateral balance assigned to the fresh Deposit Wallet. The fresh wallet
+    // naturally has zero exchange allowance, so this avoids revoking live
+    // approval state on the shared funded Deposit Wallet.
+    it.skip('requests a collateral approval if necessary', async ({
+      annotate,
+      newDepositWalletClient,
+    }) => {
+      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+      annotate(`Market ID: ${market.id}`);
+      annotate(`Token ID: ${yesTokenId}`);
+      const minPrice = expectPresent(market.trading.minimumTickSize);
+      const minSize = expectPresent(market.trading.minimumOrderSize);
+
+      const response = await newDepositWalletClient.placeLimitOrder({
+        price: minPrice,
+        side: OrderSide.BUY,
+        size: minSize,
+        tokenId: yesTokenId,
+      });
+
+      expect(response.ok).toBe(true);
+      const acceptedResponse = expectAcceptedOrderResponse(response);
+
+      const cancelResult = await newDepositWalletClient.cancelOrder({
+        orderId: acceptedResponse.orderId,
+      });
+      expect(cancelResult.canceled).toContain(acceptedResponse.orderId);
+    });
   });
 
   describe('placeLimitOrder', () => {

--- a/packages/client/tests/integration/orders.test.ts
+++ b/packages/client/tests/integration/orders.test.ts
@@ -1,13 +1,11 @@
 import { BuilderCodeSchema, OrderSide, OrderType } from '@polymarket/bindings';
 import { OrderPostStatus } from '@polymarket/bindings/clob';
 import {
-  createSecureClient,
   InsufficientLiquidityError,
   type Market,
   type SecureClient,
   UserInputError,
 } from '@polymarket/client';
-import { fetchNegRisk } from '@polymarket/client/actions';
 import { expectPresent } from '@polymarket/types';
 import { afterAll } from 'vitest';
 import {
@@ -239,52 +237,6 @@ describe('Orders', { timeout: 60_000 }, () => {
       expect(order.postOnly).toBe(true);
       expect(order.builder).toBe(builderCode);
     });
-
-    it('requests a collateral approval if necessary', async ({
-      annotate,
-      depositWalletAddress,
-      depositWalletSigner,
-
-      relayerAuthentication,
-    }) => {
-      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
-      annotate(`Market ID: ${market.id}`);
-      annotate(`Token ID: ${yesTokenId}`);
-      const minPrice = expectPresent(market.trading.minimumTickSize);
-      const minSize = expectPresent(market.trading.minimumOrderSize);
-      const gaslessClient = await createSecureClient({
-        apiKey: relayerAuthentication,
-        signer: depositWalletSigner,
-        wallet: depositWalletAddress,
-      });
-      const exchangeAddress = await resolveExchangeAddressForToken(
-        gaslessClient,
-        yesTokenId,
-      );
-
-      await gaslessClient
-        .approveErc20({
-          amount: 0n,
-          spenderAddress: exchangeAddress,
-          tokenAddress: gaslessClient.environment.collateralToken,
-        })
-        .then((handle) => handle.wait());
-
-      const response = await gaslessClient.placeLimitOrder({
-        price: minPrice,
-        side: OrderSide.BUY,
-        size: minSize,
-        tokenId: yesTokenId,
-      });
-
-      expect(response.ok).toBe(true);
-      const acceptedResponse = expectAcceptedOrderResponse(response);
-
-      const cancelResult = await gaslessClient.cancelOrder({
-        orderId: acceptedResponse.orderId,
-      });
-      expect(cancelResult.canceled).toContain(acceptedResponse.orderId);
-    });
   });
 
   describe('placeLimitOrder', () => {
@@ -490,19 +442,6 @@ async function createSignedRestingLimitOrder(
     size,
     tokenId: yesTokenId,
   });
-}
-
-async function resolveExchangeAddressForToken(
-  client: SecureClient,
-  tokenId: string,
-) {
-  const negRisk = await fetchNegRisk(client, {
-    tokenId,
-  });
-
-  return negRisk
-    ? client.environment.negRiskExchange
-    : client.environment.standardExchange;
 }
 
 async function cancelMarketOrderWithRetry(


### PR DESCRIPTION
## Summary
- Remove the live orders integration test setup that forced insufficient collateral allowance by submitting approve(exchange, 0) against the shared funded Deposit Wallet.
- Add a newDepositWalletClient fixture for the future fresh Deposit Wallet approval path.
- Keep the collateral auto-approval coverage as a skipped placeholder until the suite runs against a staging Tenderly vnet with synthetic collateral for the fresh Deposit Wallet.

## Context
The relayer now intentionally rejects Deposit Wallet exchange approvals unless the amount is MaxUint256, so revoking approval on the shared live wallet fails before the SDK auto-approval behavior under test can run. A fresh Deposit Wallet naturally starts with zero exchange allowance and avoids mutating shared live approval state, but needs vnet-backed collateral before the test can be enabled safely.

## Verification
- pnpm lint
- pnpm typecheck
- pnpm vitest --project client-integration packages/client/tests/integration/orders.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Integration-test and fixture changes only; no production client or relayer behavior is modified.
> 
> **Overview**
> Stops the orders integration test from **revoking live collateral allowance** on the shared funded Deposit Wallet by removing the `approveErc20(..., 0)` setup that no longer works now that the relayer rejects non–`MaxUint256` exchange approvals.
> 
> Adds a **`newDepositWalletClient`** fixture (ephemeral signer / fresh Deposit Wallet) for future vnet-backed coverage, and **skips** the “requests a collateral approval if necessary” case until staging Tenderly can fund that wallet with synthetic collateral. The skipped test now targets `newDepositWalletClient` instead of manually building a client and revoking allowance; unused **`resolveExchangeAddressForToken`** / **`fetchNegRisk`** wiring is removed from `orders.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5faade652be37ad946fb00d0cbd1a865bb4850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->