### PR TITLE
feat(bindings): distinguish condition ID brands

### DIFF
--- a/.changeset/condition-id-brands.md
+++ b/.changeset/condition-id-brands.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Add a distinct combo condition ID type and normalize supported combo condition wire forms.

--- a/.changeset/condition-id-brands.md
+++ b/.changeset/condition-id-brands.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Add a distinct combo condition ID type and normalize supported combo condition wire forms.
+Add distinct CTF and combo condition ID brands, keeping the previous condition ID exports as deprecated CTF aliases.

--- a/packages/bindings/src/clob/account.ts
+++ b/packages/bindings/src/clob/account.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import {
   BaseUnitsSchema,
-  ConditionIdSchema,
+  CtfConditionIdSchema,
   DecimalishSchema,
   DecimalStringSchema,
   EpochLikeToIsoDateTimeStringSchema,
@@ -227,7 +227,7 @@ export const UserEarningSchema = z
   .object({
     asset_address: z.string(),
     asset_rate: DecimalishSchema,
-    condition_id: ConditionIdSchema,
+    condition_id: CtfConditionIdSchema,
     date: EpochMillisecondsToIsoDateTimeStringSchema,
     earnings: DecimalishSchema,
     maker_address: z.string(),
@@ -271,7 +271,10 @@ export type TotalUserEarningsResponse = z.infer<
   typeof TotalUserEarningsResponseSchema
 >;
 
-export const RewardsPercentagesSchema = z.record(ConditionIdSchema, z.number());
+export const RewardsPercentagesSchema = z.record(
+  CtfConditionIdSchema,
+  z.number(),
+);
 
 export type RewardsPercentages = z.infer<typeof RewardsPercentagesSchema>;
 
@@ -318,7 +321,7 @@ export const EarningSchema = z
 
 export const UserRewardsEarningSchema = z
   .object({
-    condition_id: ConditionIdSchema,
+    condition_id: CtfConditionIdSchema,
     earning_percentage: z.number(),
     earnings: z.array(EarningSchema),
     event_slug: z.string(),

--- a/packages/bindings/src/clob/market-data.ts
+++ b/packages/bindings/src/clob/market-data.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-  ConditionIdSchema,
+  CtfConditionIdSchema,
   DecimalStringSchema,
   OrderSideSchema,
   TokenIdSchema,
@@ -95,7 +95,7 @@ export type PriceHistory = z.infer<typeof PriceHistorySchema>;
 
 export const ConditionByTokenSchema = z
   .object({
-    condition_id: ConditionIdSchema,
+    condition_id: CtfConditionIdSchema,
   })
   .transform(({ condition_id }) => condition_id);
 

--- a/packages/bindings/src/clob/order-book.ts
+++ b/packages/bindings/src/clob/order-book.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import {
-  type ConditionId,
-  ConditionIdSchema,
+  type CtfConditionId,
+  CtfConditionIdSchema,
   type DecimalString,
   DecimalStringSchema,
   type EpochMilliseconds,
@@ -19,7 +19,7 @@ export type OrderBookLevel = {
 export type OrderBookHash = string & { readonly __tag: 'OrderBookHash' };
 
 export type OrderBook = {
-  market: ConditionId;
+  market: CtfConditionId;
   tokenId: TokenId;
   timestamp?: EpochMilliseconds | null;
 
@@ -48,7 +48,7 @@ export const OrderBookHashSchema = z
 
 export const OrderBookSchema = z
   .object({
-    market: ConditionIdSchema,
+    market: CtfConditionIdSchema,
     asset_id: TokenIdSchema,
     timestamp: EpochMillisecondsStringSchema.nullish(),
     bids: z.array(OrderBookLevelSchema),

--- a/packages/bindings/src/clob/rewards.ts
+++ b/packages/bindings/src/clob/rewards.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-  ConditionIdSchema,
+  CtfConditionIdSchema,
   DecimalishSchema,
   EpochMillisecondsToIsoDateTimeStringSchema,
   TokenIdSchema,
@@ -36,7 +36,7 @@ export type CurrentRewardConfig = z.infer<typeof CurrentRewardConfigSchema>;
 
 export const CurrentRewardSchema = z
   .object({
-    condition_id: ConditionIdSchema,
+    condition_id: CtfConditionIdSchema,
     rewards_max_spread: z.number().optional(),
     rewards_min_size: DecimalishSchema.optional(),
     rewards_config: z.array(CurrentRewardConfigSchema).optional(),
@@ -126,7 +126,7 @@ export type RewardConfig = z.infer<typeof RewardConfigSchema>;
 
 export const MarketRewardSchema = z
   .object({
-    condition_id: ConditionIdSchema,
+    condition_id: CtfConditionIdSchema,
     question: z.string(),
     market_slug: z.string().optional(),
     event_slug: z.string().optional(),

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import {
-  type ConditionId,
-  ConditionIdSchema,
+  type CtfConditionId,
+  CtfConditionIdSchema,
   DecimalishSchema,
   type DecimalString,
   type EpochMilliseconds,
@@ -43,7 +43,7 @@ export type TradeActivity = ActivityBase & {
   /** A directional outcome-token trade. */
   type: 'TRADE';
   /** Condition id of the market traded by the wallet. */
-  conditionId: ConditionId;
+  conditionId: CtfConditionId;
   /** Outcome token id bought or sold by the wallet. */
   tokenId: TokenId;
   /** Direction of the wallet's trade in the outcome token. */
@@ -72,7 +72,7 @@ export type SplitActivity = ActivityBase & {
   /** Splitting collateral into a complete market set. */
   type: 'SPLIT';
   /** Condition id of the market whose complete set was created. */
-  conditionId: ConditionId;
+  conditionId: CtfConditionId;
   /** The collateral amount split into the complete set in USD. */
   amount: DecimalString;
   /** Human-readable title of the market whose complete set was created. */
@@ -89,7 +89,7 @@ export type MergeActivity = ActivityBase & {
   /** Merging a complete market set into collateral. */
   type: 'MERGE';
   /** Condition id of the market whose complete set was merged. */
-  conditionId: ConditionId;
+  conditionId: CtfConditionId;
   /** The collateral amount received from merging the complete set in USD. */
   amount: DecimalString;
   /** Human-readable title of the market whose complete set was merged. */
@@ -106,7 +106,7 @@ export type RedeemActivity = ActivityBase & {
   /** Redeeming resolved market proceeds. */
   type: 'REDEEM';
   /** Condition id of the market redeemed by the wallet. */
-  conditionId: ConditionId;
+  conditionId: CtfConditionId;
   /** The proceeds redeemed from the resolved market in USD. */
   amount: DecimalString;
   /** Human-readable title of the market redeemed by the wallet. */
@@ -123,7 +123,7 @@ export type ConversionActivity = ActivityBase & {
   /** A market conversion or migration activity. */
   type: 'CONVERSION';
   /** Condition id of the market involved in the conversion. */
-  conditionId: ConditionId;
+  conditionId: CtfConditionId;
   /** The amount converted or migrated for the market in USD. */
   amount: DecimalString;
   /** Human-readable title of the market involved in the conversion. */
@@ -185,7 +185,7 @@ export const TradeSchema = z
     proxyWallet: AddressSchema.nullish(),
     side: SideSchema.nullish(),
     asset: TokenIdSchema.nullish(),
-    conditionId: ConditionIdSchema.nullish(),
+    conditionId: CtfConditionIdSchema.nullish(),
     size: DecimalishSchema.nullish(),
     price: DecimalishSchema.nullish(),
     timestamp: EpochSecondsToMillisecondsSchema.nullish(),
@@ -213,7 +213,7 @@ const RawActivitySchema = z.object({
   timestamp: EpochSecondsToMillisecondsSchema.nullish(),
   conditionId: z.preprocess(
     (value) => (value === '' ? undefined : value),
-    ConditionIdSchema.optional(),
+    CtfConditionIdSchema.optional(),
   ),
   type: ActivityTypeSchema,
   size: DecimalishSchema.nullish(),

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import {
   ComboConditionIdSchema,
-  ConditionIdSchema,
+  CtfConditionIdSchema,
   DecimalishSchema,
   EpochSecondsToMillisecondsSchema,
   IsoCalendarDateStringSchema,
@@ -26,7 +26,7 @@ export const PositionSchema = z
   .object({
     proxyWallet: AddressSchema.nullish(),
     asset: TokenIdSchema.nullish(),
-    conditionId: ConditionIdSchema,
+    conditionId: CtfConditionIdSchema,
     size: DecimalishSchema.nullish(),
     avgPrice: DecimalishSchema.nullish(),
     initialValue: DecimalishSchema.nullish(),
@@ -62,7 +62,7 @@ export const ClosedPositionSchema = z
   .object({
     proxyWallet: AddressSchema.nullish(),
     asset: TokenIdSchema.nullish(),
-    conditionId: ConditionIdSchema.nullish(),
+    conditionId: CtfConditionIdSchema.nullish(),
     avgPrice: DecimalishSchema.nullish(),
     totalBought: DecimalishSchema.nullish(),
     realizedPnl: DecimalishSchema.nullish(),
@@ -97,7 +97,7 @@ export const MarketPositionSchema = z
     profileImage: z.string().nullish(),
     verified: z.boolean().nullish(),
     asset: TokenIdSchema.nullish(),
-    conditionId: ConditionIdSchema.nullish(),
+    conditionId: CtfConditionIdSchema.nullish(),
     avgPrice: DecimalishSchema.nullish(),
     size: DecimalishSchema.nullish(),
     currPrice: DecimalishSchema.nullish(),
@@ -160,7 +160,7 @@ export const ComboPositionLegSchema = z
   .object({
     leg_index: z.number().int(),
     leg_position_id: PositionIdSchema,
-    leg_condition_id: ConditionIdSchema,
+    leg_condition_id: CtfConditionIdSchema,
     leg_outcome_index: z.number().int(),
     leg_outcome_label: z.string().nullish(),
     leg_status: ComboPositionStatusSchema,

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+  ComboConditionIdSchema,
   ConditionIdSchema,
   DecimalishSchema,
   EpochSecondsToMillisecondsSchema,
@@ -193,7 +194,7 @@ export const ComboPositionLegSchema = z
 
 export const ComboPositionSchema = z
   .object({
-    combo_condition_id: ConditionIdSchema,
+    combo_condition_id: ComboConditionIdSchema,
     combo_position_id: PositionIdSchema,
     module_id: z.number().int(),
     user_address: AddressSchema,

--- a/packages/bindings/src/gamma/common.ts
+++ b/packages/bindings/src/gamma/common.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import {
   CategoryIdSchema,
   ClobRewardIdSchema,
-  ConditionIdSchema,
+  CtfConditionIdSchema,
   DecimalishSchema,
   DecimalStringSchema,
   EventIdSchema,
@@ -11,7 +11,7 @@ import {
   IsoCalendarDateStringSchema,
   IsoDateTimeStringSchema,
   MarketIdSchema,
-  OptionalConditionIdSchema,
+  OptionalCtfConditionIdSchema,
   TagIdSchema,
 } from '../shared';
 
@@ -67,7 +67,7 @@ export const TagReferenceSchema = z.object({
 
 export const RelatedMarketSchema = z.object({
   id: MarketIdSchema,
-  conditionId: OptionalConditionIdSchema,
+  conditionId: OptionalCtfConditionIdSchema,
   slug: z.string().nullish(),
   image: z.string().nullish(),
   volume: DecimalStringSchema.nullish(),
@@ -80,7 +80,7 @@ export const RelatedMarketSchema = z.object({
 
 export const ClobRewardsSchema = z.object({
   id: ClobRewardIdSchema,
-  conditionId: ConditionIdSchema,
+  conditionId: CtfConditionIdSchema,
   assetAddress: z.string(),
   rewardsAmount: DecimalishSchema,
   rewardsDailyRate: DecimalishSchema,

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import {
-  type ConditionId,
-  ConditionIdSchema,
+  type CtfConditionId,
+  CtfConditionIdSchema,
   DecimalishSchema,
   type DecimalString,
   DecimalStringSchema,
@@ -166,7 +166,7 @@ export type MarketTag = {
 export type Market = {
   id: MarketId;
   slug?: string | null;
-  conditionId: ConditionId | null;
+  conditionId: CtfConditionId | null;
   question?: string | null;
   description?: string | null;
   category?: string | null;
@@ -189,7 +189,7 @@ export const GammaMarketSchema = z.object({
   id: MarketIdSchema,
   question: z.string().nullish(),
   conditionId: z
-    .preprocess(emptyStringToNull, ConditionIdSchema.nullish())
+    .preprocess(emptyStringToNull, CtfConditionIdSchema.nullish())
     .transform(nullishToNull),
   slug: z.string().nullish(),
   twitterCardImage: z.string().nullish(),

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { type SignatureType, SignatureTypeSchema } from './clob/signature-type';
 import type { BaseUnits, DecimalString, EvmAddress, TokenId } from './shared';
 import {
-  ConditionIdSchema,
+  ComboConditionIdSchema,
   EpochMillisecondsSchema,
   EvmAddressSchema,
   type OrderSide,
@@ -199,7 +199,7 @@ export const RfqQuoteRequestSchema = RfqKnownInboundMessageSchema.extend({
   rfq_id: RfqIdSchema,
   requestor_public_id: RfqRequestorPublicIdSchema,
   leg_position_ids: z.array(PositionIdSchema),
-  condition_id: ConditionIdSchema,
+  condition_id: ComboConditionIdSchema,
   yes_position_id: PositionIdSchema,
   no_position_id: PositionIdSchema,
   direction: RfqDirectionSchema,
@@ -271,7 +271,7 @@ export const RfqConfirmationRequestSchema = RfqKnownInboundMessageSchema.extend(
     maker_address: EvmAddressSchema,
     signature_type: SignatureTypeSchema,
     leg_position_ids: z.array(PositionIdSchema),
-    condition_id: ConditionIdSchema,
+    condition_id: ComboConditionIdSchema,
     yes_position_id: PositionIdSchema,
     no_position_id: PositionIdSchema,
     direction: RfqDirectionSchema,

--- a/packages/bindings/src/shared.test.ts
+++ b/packages/bindings/src/shared.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { ComboConditionIdSchema, toComboConditionId } from './shared';
+
+const CANONICAL_COMBO_CONDITION_ID =
+  '0x032def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000';
+const COMBO_CONDITION_ID_PATTERN = /^0x03[0-9a-f]{60}$/;
+
+describe('shared ID parsers', () => {
+  describe('toComboConditionId', () => {
+    it('returns canonical bytes31 combo condition IDs', () => {
+      for (const value of [
+        CANONICAL_COMBO_CONDITION_ID,
+        `${CANONICAL_COMBO_CONDITION_ID}00`,
+        `${CANONICAL_COMBO_CONDITION_ID}01`,
+      ]) {
+        const conditionId = toComboConditionId(value);
+
+        expect(conditionId).toBe(CANONICAL_COMBO_CONDITION_ID);
+        expect(conditionId).toHaveLength(64);
+        expect(conditionId).toMatch(COMBO_CONDITION_ID_PATTERN);
+      }
+    });
+
+    it('rejects non-combo and non-binary outcome wire forms', () => {
+      expect(() =>
+        toComboConditionId(
+          '0x022def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000',
+        ),
+      ).toThrow(/combo condition ID/);
+      expect(() =>
+        toComboConditionId(`${CANONICAL_COMBO_CONDITION_ID}02`),
+      ).toThrow(/combo condition ID/);
+    });
+  });
+
+  describe('ComboConditionIdSchema', () => {
+    it('outputs canonical bytes31 combo condition IDs', () => {
+      const conditionId = ComboConditionIdSchema.parse(
+        `${CANONICAL_COMBO_CONDITION_ID}01`,
+      );
+
+      expect(conditionId).toBe(CANONICAL_COMBO_CONDITION_ID);
+      expect(conditionId).toHaveLength(64);
+      expect(conditionId).toMatch(COMBO_CONDITION_ID_PATTERN);
+    });
+  });
+});

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -48,7 +48,9 @@ export type ChatId = Tagged<string, 'ChatId'>;
 export type ClobRewardId = Tagged<string, 'ClobRewardId'>;
 export type CommentId = Tagged<string, 'CommentId'>;
 export type ComboConditionId = Tagged<HexString, 'ComboConditionId'>;
-export type ConditionId = Tagged<HexString, 'ConditionId'>;
+export type CtfConditionId = Tagged<HexString, 'CtfConditionId'>;
+/** @deprecated Use {@link CtfConditionId}. */
+export type ConditionId = CtfConditionId;
 export type CollectionId = Tagged<string, 'CollectionId'>;
 export type EventCreatorId = Tagged<string, 'EventCreatorId'>;
 export type EventExternalPartnerMappingId = Tagged<
@@ -118,15 +120,18 @@ export function toCommentId(value: string): CommentId {
   return toTaggedString<CommentId>(value);
 }
 
-export function toConditionId(value: string): ConditionId {
+export function toCtfConditionId(value: string): CtfConditionId {
   if (!isHexString(value) || (value.length !== 64 && value.length !== 66)) {
     throw new TypeError(
       `Expected a 31-byte or 32-byte hex string, received: ${value}`,
     );
   }
 
-  return value as ConditionId;
+  return value as CtfConditionId;
 }
+
+/** @deprecated Use {@link toCtfConditionId}. */
+export const toConditionId = toCtfConditionId;
 
 export function toComboConditionId(value: string): ComboConditionId {
   if (!isHexString(value)) {
@@ -278,11 +283,15 @@ export const BuilderCodeSchema = z.string().transform(toBuilderCode);
 export const ClobRewardIdSchema = z.string().transform(toClobRewardId);
 export const CommentIdSchema = z.string().transform(toCommentId);
 export const ComboConditionIdSchema = z.string().transform(toComboConditionId);
-export const ConditionIdSchema = z.string().transform(toConditionId);
-export const OptionalConditionIdSchema = z.preprocess(
+export const CtfConditionIdSchema = z.string().transform(toCtfConditionId);
+export const OptionalCtfConditionIdSchema = z.preprocess(
   (value) => (value === '' ? undefined : value),
-  ConditionIdSchema.optional(),
+  CtfConditionIdSchema.optional(),
 );
+/** @deprecated Use {@link CtfConditionIdSchema}. */
+export const ConditionIdSchema = CtfConditionIdSchema;
+/** @deprecated Use {@link OptionalCtfConditionIdSchema}. */
+export const OptionalConditionIdSchema = OptionalCtfConditionIdSchema;
 export const EvmAddressSchema = z.string().transform(toEvmAddress);
 export const EpochMillisecondsSchema = z
   .number()

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -47,6 +47,7 @@ export type CategoryId = Tagged<string, 'CategoryId'>;
 export type ChatId = Tagged<string, 'ChatId'>;
 export type ClobRewardId = Tagged<string, 'ClobRewardId'>;
 export type CommentId = Tagged<string, 'CommentId'>;
+export type ComboConditionId = Tagged<HexString, 'ComboConditionId'>;
 export type ConditionId = Tagged<HexString, 'ConditionId'>;
 export type CollectionId = Tagged<string, 'CollectionId'>;
 export type EventCreatorId = Tagged<string, 'EventCreatorId'>;
@@ -125,6 +126,32 @@ export function toConditionId(value: string): ConditionId {
   }
 
   return value as ConditionId;
+}
+
+export function toComboConditionId(value: string): ComboConditionId {
+  if (!isHexString(value)) {
+    throw new TypeError(
+      `Expected a protocol v2 combo condition ID, received: ${value}`,
+    );
+  }
+
+  const normalized = value.toLowerCase();
+
+  if (normalized.length === 64 && normalized.startsWith('0x03')) {
+    return normalized as ComboConditionId;
+  }
+
+  if (
+    normalized.length === 66 &&
+    normalized.startsWith('0x03') &&
+    (normalized.endsWith('00') || normalized.endsWith('01'))
+  ) {
+    return normalized.slice(0, -2) as ComboConditionId;
+  }
+
+  throw new TypeError(
+    `Expected a protocol v2 combo condition ID, received: ${value}`,
+  );
 }
 
 export function toCollectionId(value: string): CollectionId {
@@ -250,6 +277,7 @@ export const ApiKeySchema = z.string().transform(toApiKey);
 export const BuilderCodeSchema = z.string().transform(toBuilderCode);
 export const ClobRewardIdSchema = z.string().transform(toClobRewardId);
 export const CommentIdSchema = z.string().transform(toCommentId);
+export const ComboConditionIdSchema = z.string().transform(toComboConditionId);
 export const ConditionIdSchema = z.string().transform(toConditionId);
 export const OptionalConditionIdSchema = z.preprocess(
   (value) => (value === '' ? undefined : value),

--- a/packages/bindings/src/subscriptions/clob.ts
+++ b/packages/bindings/src/subscriptions/clob.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import {
-  ConditionIdSchema,
+  CtfConditionIdSchema,
   DecimalStringSchema,
   EpochMillisecondsStringSchema,
   EpochMillisecondsToIsoDateTimeStringSchema,
@@ -264,7 +264,7 @@ export const NewMarketEventSchema = z
     event_message: MarketEventMessageSchema.nullish(),
     timestamp: EpochMillisecondsStringSchema.nullish(),
     tags: z.array(z.string()).nullish(),
-    condition_id: ConditionIdSchema.nullish(),
+    condition_id: CtfConditionIdSchema.nullish(),
     active: z.boolean().nullish(),
     clob_token_ids: z.array(z.string()).nullish(),
     sports_market_type: z.string().nullish(),

--- a/packages/client/src/abis.test.ts
+++ b/packages/client/src/abis.test.ts
@@ -1,0 +1,41 @@
+import {
+  type ComboConditionId,
+  toComboConditionId,
+} from '@polymarket/bindings';
+import { expectEvmAddress } from '@polymarket/types';
+import { describe, expect, it } from 'vitest';
+import { mergeV2Call, redeemV2Call, splitV2Call } from './abis';
+
+const ROUTER_ADDRESS = expectEvmAddress(
+  '0x12121212006e4CD160D18e3f00711DA5c3372600',
+);
+const CONDITION_ID = toComboConditionId(
+  '0x032def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000',
+);
+const YES_POSITION_CONDITION_ID = `${CONDITION_ID}00` as ComboConditionId;
+const NO_POSITION_CONDITION_ID = `${CONDITION_ID}01` as ComboConditionId;
+
+describe('Protocol v2 ABI helpers', () => {
+  it('normalizes bytes32 combo condition wire forms before encoding', () => {
+    expect(splitV2Call(ROUTER_ADDRESS, YES_POSITION_CONDITION_ID, 1n)).toEqual(
+      splitV2Call(ROUTER_ADDRESS, CONDITION_ID, 1n),
+    );
+    expect(splitV2Call(ROUTER_ADDRESS, NO_POSITION_CONDITION_ID, 1n)).toEqual(
+      splitV2Call(ROUTER_ADDRESS, CONDITION_ID, 1n),
+    );
+
+    expect(mergeV2Call(ROUTER_ADDRESS, YES_POSITION_CONDITION_ID, 1n)).toEqual(
+      mergeV2Call(ROUTER_ADDRESS, CONDITION_ID, 1n),
+    );
+    expect(mergeV2Call(ROUTER_ADDRESS, NO_POSITION_CONDITION_ID, 1n)).toEqual(
+      mergeV2Call(ROUTER_ADDRESS, CONDITION_ID, 1n),
+    );
+
+    expect(
+      redeemV2Call(ROUTER_ADDRESS, YES_POSITION_CONDITION_ID, 1, 1n),
+    ).toEqual(redeemV2Call(ROUTER_ADDRESS, CONDITION_ID, 1, 1n));
+    expect(
+      redeemV2Call(ROUTER_ADDRESS, NO_POSITION_CONDITION_ID, 1, 1n),
+    ).toEqual(redeemV2Call(ROUTER_ADDRESS, CONDITION_ID, 1, 1n));
+  });
+});

--- a/packages/client/src/abis.test.ts
+++ b/packages/client/src/abis.test.ts
@@ -12,8 +12,11 @@ const ROUTER_ADDRESS = expectEvmAddress(
 const CONDITION_ID = toComboConditionId(
   '0x032def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000',
 );
-const YES_POSITION_CONDITION_ID = `${CONDITION_ID}00` as ComboConditionId;
-const NO_POSITION_CONDITION_ID = `${CONDITION_ID}01` as ComboConditionId;
+// Simulates untyped JS callers that bypass the branded parser.
+const YES_POSITION_CONDITION_ID =
+  `${CONDITION_ID}00` as unknown as ComboConditionId;
+const NO_POSITION_CONDITION_ID =
+  `${CONDITION_ID}01` as unknown as ComboConditionId;
 
 describe('Protocol v2 ABI helpers', () => {
   it('normalizes bytes32 combo condition wire forms before encoding', () => {

--- a/packages/client/src/abis.ts
+++ b/packages/client/src/abis.ts
@@ -1,4 +1,9 @@
-import type { ConditionId, PositionId, TokenId } from '@polymarket/bindings';
+import type {
+  ComboConditionId,
+  ConditionId,
+  PositionId,
+  TokenId,
+} from '@polymarket/bindings';
 import { type EvmAddress, type HexString, invariant } from '@polymarket/types';
 import { AbiFunction, AbiParameters } from 'ox';
 import { makeErrorGuard, UserInputError } from './errors';
@@ -296,7 +301,7 @@ export const SplitV2CallError = makeErrorGuard(UserInputError);
  */
 export function splitV2Call(
   routerAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: ComboConditionId,
   amount: bigint,
 ): TransactionCall {
   return {
@@ -319,7 +324,7 @@ export const MergeV2CallError = makeErrorGuard(UserInputError);
  */
 export function mergeV2Call(
   routerAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: ComboConditionId,
   amount: bigint,
 ): TransactionCall {
   return {
@@ -342,7 +347,7 @@ export const RedeemV2CallError = makeErrorGuard(UserInputError);
  */
 export function redeemV2Call(
   routerAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: ComboConditionId,
   outcomeIndex: 0 | 1,
   amount: bigint,
 ): TransactionCall {

--- a/packages/client/src/abis.ts
+++ b/packages/client/src/abis.ts
@@ -462,7 +462,9 @@ function expectUint256(value: bigint, label: string): bigint {
   return value;
 }
 
-function normalizeProtocolV2ConditionId(conditionId: string): HexString {
+function normalizeProtocolV2ConditionId(
+  conditionId: ComboConditionId,
+): HexString {
   if (PROTOCOL_V2_CONDITION_ID_BYTES31_PATTERN.test(conditionId)) {
     return conditionId.toLowerCase() as HexString;
   }

--- a/packages/client/src/abis.ts
+++ b/packages/client/src/abis.ts
@@ -1,6 +1,6 @@
 import type {
   ComboConditionId,
-  ConditionId,
+  CtfConditionId,
   PositionId,
   TokenId,
 } from '@polymarket/bindings';
@@ -235,7 +235,7 @@ export const SplitPositionCallError = makeErrorGuard(UserInputError);
 export function splitPositionCall(
   targetAddress: EvmAddress,
   collateralTokenAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: CtfConditionId,
   amount: bigint,
 ): TransactionCall {
   return {
@@ -260,7 +260,7 @@ export const MergePositionsCallError = makeErrorGuard(UserInputError);
 export function mergePositionsCall(
   targetAddress: EvmAddress,
   collateralTokenAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: CtfConditionId,
   amount: bigint,
 ): TransactionCall {
   return {
@@ -282,7 +282,7 @@ export function mergePositionsCall(
 export function ctfRedeemPositionsCall(
   conditionalTokensAddress: EvmAddress,
   collateralTokenAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: CtfConditionId,
 ): TransactionCall {
   return {
     data: encodeCtfRedeemPositionsCall(collateralTokenAddress, conditionId),
@@ -412,7 +412,7 @@ function encodeErc20TransferCall(
 
 function encodeSplitPositionCall(
   collateralTokenAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: CtfConditionId,
   amount: bigint,
 ): HexString {
   return AbiFunction.encodeData(CTF_SPLIT_POSITION_FUNCTION, [
@@ -426,7 +426,7 @@ function encodeSplitPositionCall(
 
 function encodeMergePositionsCall(
   collateralTokenAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: CtfConditionId,
   amount: bigint,
 ): HexString {
   return AbiFunction.encodeData(CTF_MERGE_POSITIONS_FUNCTION, [
@@ -440,7 +440,7 @@ function encodeMergePositionsCall(
 
 function encodeCtfRedeemPositionsCall(
   collateralTokenAddress: EvmAddress,
-  conditionId: ConditionId,
+  conditionId: CtfConditionId,
 ): HexString {
   return AbiFunction.encodeData(CTF_REDEEM_POSITIONS_FUNCTION, [
     collateralTokenAddress,

--- a/packages/client/src/abis.ts
+++ b/packages/client/src/abis.ts
@@ -471,13 +471,13 @@ function normalizeProtocolV2ConditionId(
 
   if (PROTOCOL_V2_CONDITION_ID_BYTES32_PATTERN.test(conditionId)) {
     const normalized = conditionId.toLowerCase();
-    if (normalized.endsWith('00')) {
+    if (normalized.endsWith('00') || normalized.endsWith('01')) {
       return normalized.slice(0, BYTES31_HEX_LENGTH) as HexString;
     }
   }
 
   throw new UserInputError(
-    'Protocol v2 condition ID must be bytes31, or bytes32 with a zero outcome byte',
+    'Protocol v2 condition ID must be bytes31, or bytes32 with a binary outcome byte',
   );
 }
 

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -1,7 +1,7 @@
 import {
   BuilderCodeSchema,
-  type ConditionId,
-  ConditionIdSchema,
+  type CtfConditionId,
+  CtfConditionIdSchema,
   OrderSideSchema,
   PaginationCursorSchema,
   type TickSizeValue,
@@ -316,7 +316,7 @@ export const ResolveConditionByTokenError = makeErrorGuard(
 export async function resolveConditionByToken(
   client: BaseClient,
   request: ResolveConditionByTokenRequest,
-): Promise<ConditionId> {
+): Promise<CtfConditionId> {
   const params = parseUserInput(request, ResolveConditionByTokenRequestSchema);
 
   return unwrap(
@@ -327,7 +327,7 @@ export async function resolveConditionByToken(
 }
 
 const FetchMarketInfoRequestSchema = z.object({
-  conditionId: ConditionIdSchema,
+  conditionId: CtfConditionIdSchema,
 });
 
 export type FetchMarketInfoRequest = z.input<
@@ -1061,7 +1061,7 @@ export function listCurrentRewards(
 }
 
 const ListMarketRewardsRequestSchema = z.object({
-  conditionId: ConditionIdSchema,
+  conditionId: CtfConditionIdSchema,
   cursor: PaginationCursorSchema.optional(),
   sponsored: z.boolean().optional(),
 });

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -1,5 +1,5 @@
 import {
-  ConditionIdSchema,
+  CtfConditionIdSchema,
   IsoDateTimeStringSchema,
   PaginationCursorSchema,
   PositionIdSchema,
@@ -49,7 +49,7 @@ const ListMarketsRequestSchema = z.object({
   clobTokenIds: z.array(z.string()).optional(),
   cursor: PaginationCursorSchema.optional(),
   pageSize: PageSizeSchema.optional(),
-  conditionIds: z.array(ConditionIdSchema).optional(),
+  conditionIds: z.array(CtfConditionIdSchema).optional(),
   cyom: z.boolean().optional(),
   decimalized: z.boolean().optional(),
   endDateMax: IsoDateTimeStringSchema.optional(),

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -1,4 +1,8 @@
-import { PaginationCursorSchema } from '@polymarket/bindings';
+import {
+  ComboConditionIdSchema,
+  PaginationCursorSchema,
+  PositionIdSchema,
+} from '@polymarket/bindings';
 import {
   type ClosedPosition,
   type ComboPosition,
@@ -98,8 +102,8 @@ const ListComboPositionsRequestSchema = z.object({
   user: z.string(),
   pageSize: PageSizeSchema.default(20),
   status: ComboPositionStatusSchema.optional(),
-  conditionId: z.string().optional(),
-  positionId: z.string().optional(),
+  conditionId: ComboConditionIdSchema.optional(),
+  positionId: PositionIdSchema.optional(),
 });
 
 const FetchPortfolioValueRequestSchema = z.object({

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -1,12 +1,12 @@
 import type {
   ComboConditionId,
-  ConditionId,
+  CtfConditionId,
   MarketId,
   PositionId,
   TokenId,
 } from '@polymarket/bindings';
 import {
-  ConditionIdSchema,
+  CtfConditionIdSchema,
   MarketIdSchema,
   PositionIdSchema,
 } from '@polymarket/bindings';
@@ -77,7 +77,7 @@ export type PrepareSplitMarketPositionRequest = {
   /** Amount of collateral to convert into market positions. */
   amount: bigint;
   /** Existing market condition ID that identifies the positions to mint. */
-  conditionId: string | ConditionId;
+  conditionId: string | CtfConditionId;
   /** Optional transaction metadata for workflows that support metadata. */
   metadata?: string;
 };
@@ -106,7 +106,7 @@ export type PrepareSplitPositionRequest =
 
 const PrepareSplitMarketPositionRequestSchema = z.object({
   amount: z.bigint().min(0n),
-  conditionId: ConditionIdSchema,
+  conditionId: CtfConditionIdSchema,
   metadata: GaslessTransactionMetadataSchema.optional(),
 }) satisfies z.ZodType<PrepareSplitMarketPositionRequest>;
 
@@ -449,7 +449,7 @@ export type PrepareMergeMarketPositionRequest = {
   /** Amount per complementary market position to merge. */
   amount: bigint | 'max';
   /** Existing market condition ID that identifies the positions to merge. */
-  conditionId: string | ConditionId;
+  conditionId: string | CtfConditionId;
   /** Optional transaction metadata for workflows that support metadata. */
   metadata?: string;
 };
@@ -484,7 +484,7 @@ type ParsedMergeComboPositionRequest = {
 
 const PrepareMergeMarketPositionRequestSchema = z.object({
   amount: z.union([z.bigint().positive(), z.literal('max')]),
-  conditionId: ConditionIdSchema,
+  conditionId: CtfConditionIdSchema,
   metadata: GaslessTransactionMetadataSchema.optional(),
 }) satisfies z.ZodType<PrepareMergeMarketPositionRequest>;
 
@@ -755,7 +755,7 @@ export function mergePositions(
  */
 export type PrepareRedeemMarketPositionsByConditionIdRequest = {
   /** Existing market condition ID that identifies the positions to redeem. */
-  conditionId: string | ConditionId;
+  conditionId: string | CtfConditionId;
   marketId?: never;
   amount?: never;
   positionId?: never;
@@ -804,7 +804,7 @@ export type PrepareRedeemMarketPositionsRequest =
   | PrepareRedeemMarketPositionsByMarketIdRequest;
 
 const PrepareRedeemMarketPositionsByConditionIdRequestSchema = z.object({
-  conditionId: ConditionIdSchema,
+  conditionId: CtfConditionIdSchema,
   marketId: z.never().optional(),
   amount: z.never().optional(),
   positionId: z.never().optional(),
@@ -1048,7 +1048,7 @@ function sendRedeemPositionsTransaction(
 
 type MarketClobContext = {
   marketId: MarketId;
-  conditionId: ConditionId;
+  conditionId: CtfConditionId;
   negRisk: boolean;
   adapterAddress: EvmAddress;
   positionErc1155Address: EvmAddress;
@@ -1056,7 +1056,7 @@ type MarketClobContext = {
 };
 
 type ResolveMarketClobContextRequest =
-  | { conditionId: ConditionId; marketId?: never }
+  | { conditionId: CtfConditionId; marketId?: never }
   | { marketId: MarketId; conditionId?: never };
 
 async function resolveMarketClobContext(
@@ -1136,7 +1136,7 @@ function normalizeMarketClobContext(
 }
 
 function resolveMergeAmount(
-  conditionId: ConditionId | ComboConditionId,
+  conditionId: CtfConditionId | ComboConditionId,
   balances: readonly bigint[],
   requestedAmount: bigint | 'max',
 ): bigint {

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -1,4 +1,5 @@
 import type {
+  ComboConditionId,
   ConditionId,
   MarketId,
   PositionId,
@@ -1135,7 +1136,7 @@ function normalizeMarketClobContext(
 }
 
 function resolveMergeAmount(
-  conditionId: ConditionId,
+  conditionId: ConditionId | ComboConditionId,
   balances: readonly bigint[],
   requestedAmount: bigint | 'max',
 ): bigint {

--- a/packages/client/src/protocol.test.ts
+++ b/packages/client/src/protocol.test.ts
@@ -1,4 +1,9 @@
-import { type PositionId, toPositionId } from '@polymarket/bindings';
+import {
+  type ComboConditionId,
+  type PositionId,
+  toComboConditionId,
+  toPositionId,
+} from '@polymarket/bindings';
 import { describe, expect, it } from 'vitest';
 import {
   type CanonicalComboLegs,
@@ -7,8 +12,9 @@ import {
   deriveComboPositionContext,
 } from './protocol';
 
-const CONDITION_ID =
-  '0x032def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000';
+const CONDITION_ID = toComboConditionId(
+  '0x032def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000',
+);
 
 describe('Protocol helpers', () => {
   describe('canonicalizeComboLegs', () => {
@@ -45,6 +51,12 @@ describe('Protocol helpers', () => {
           comboPosition(CONDITION_ID, 1),
         ],
       });
+    });
+
+    it('normalizes combo condition ID wire forms', () => {
+      expect(toComboConditionId(CONDITION_ID)).toBe(CONDITION_ID);
+      expect(toComboConditionId(`${CONDITION_ID}00`)).toBe(CONDITION_ID);
+      expect(toComboConditionId(`${CONDITION_ID}01`)).toBe(CONDITION_ID);
     });
   });
 
@@ -85,7 +97,10 @@ function legPosition(marker: number, outcome: number): PositionId {
   );
 }
 
-function comboPosition(conditionId: string, outcome: number): PositionId {
+function comboPosition(
+  conditionId: ComboConditionId,
+  outcome: number,
+): PositionId {
   return toPositionId(BigInt(`${conditionId}${byteHex(outcome)}`).toString());
 }
 

--- a/packages/client/src/protocol.ts
+++ b/packages/client/src/protocol.ts
@@ -1,6 +1,7 @@
 import {
-  type ConditionId,
+  type ComboConditionId,
   type PositionId,
+  toComboConditionId,
   toPositionId,
 } from '@polymarket/bindings';
 import type { Tagged } from '@polymarket/types';
@@ -18,7 +19,7 @@ export type CanonicalComboLegs = Tagged<
 >;
 
 export type ComboPositionContext = {
-  conditionId: ConditionId;
+  conditionId: ComboConditionId;
   positionIds: [yes: PositionId, no: PositionId];
 };
 
@@ -41,8 +42,9 @@ export function deriveComboPositionContext(
       [COMBINATORIAL_MODULE_ID, encodedLegs],
     ),
   );
-  const conditionId =
-    `0x03${baseHash.slice(34)}0000000000000000000000000000` as ConditionId;
+  const conditionId = toComboConditionId(
+    `0x03${baseHash.slice(34)}0000000000000000000000000000`,
+  );
 
   return {
     conditionId,
@@ -117,7 +119,7 @@ export function canonicalizeComboLegs(
 }
 
 export type DecodedComboOutcomePositionId = {
-  conditionId: ConditionId;
+  conditionId: ComboConditionId;
   outcomeIndex: 0 | 1;
 };
 
@@ -146,7 +148,7 @@ export function decodeComboOutcomePositionId(
   }
 
   return {
-    conditionId: `0x${hex.slice(0, -2)}` as ConditionId,
+    conditionId: toComboConditionId(`0x${hex.slice(0, -2)}`),
     outcomeIndex,
   };
 }

--- a/packages/client/tests/integration/positions.test.ts
+++ b/packages/client/tests/integration/positions.test.ts
@@ -1,3 +1,4 @@
+import { toComboConditionId } from '@polymarket/bindings';
 import {
   createSecureClient,
   preproduction,
@@ -9,8 +10,9 @@ import { describe, expect, it, publicClient } from './fixtures';
 import { findHighVolumeLowPriceMarket } from './markets';
 
 const TEST_COMBO_AMOUNT = 1_000_000n;
-const TEST_COMBO_CONDITION_ID =
-  '0x034eabdeca272641d98717d8ca2f8e5f330000000000000000000000000000';
+const TEST_COMBO_CONDITION_ID = toComboConditionId(
+  '0x034eabdeca272641d98717d8ca2f8e5f330000000000000000000000000000',
+);
 const TEST_COMBO_LEGS = [
   '920454018917169090762848014984037642864617754825717966757321143422977835520',
   '1012585296795354377868537359137497102116066671623168081060942028909450362880',
@@ -176,7 +178,7 @@ async function fetchComboShares(client: SecureClient): Promise<number> {
     })
     .firstPage();
   const combo = page.items.find(
-    (position) => String(position.conditionId) === TEST_COMBO_CONDITION_ID,
+    (position) => position.conditionId === TEST_COMBO_CONDITION_ID,
   );
 
   if (combo === undefined) {


### PR DESCRIPTION
## Summary
- add distinct `CtfConditionId` and `ComboConditionId` brands and schemas
- keep existing `ConditionId`, `ConditionIdSchema`, `OptionalConditionIdSchema`, and `toConditionId` exports as deprecated CTF aliases
- normalize supported combo condition wire forms to canonical bytes31 condition IDs
- thread combo condition IDs through combo portfolio bindings, RFQ payload bindings, and protocol v2 call builders
- migrate market/CTF bindings and client internals to the explicit CTF brand

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @polymarket/bindings build`
- `pnpm vitest packages/bindings/src/shared.test.ts packages/client/src/abis.test.ts packages/client/src/protocol.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide type/schema refactor across bindings and client; wrong brand at an API boundary could cause parse failures or incorrect tx encoding, though deprecated aliases limit breakage for CTF callers.
> 
> **Overview**
> Introduces separate **`CtfConditionId`** and **`ComboConditionId`** branded types (with Zod schemas and parsers) so CTF market IDs and protocol v2 combo IDs are not interchangeable at compile time or parse time. **`toComboConditionId`** accepts canonical `0x03…` bytes31 IDs and normalizes bytes32 wire forms ending in `00` or `01` to bytes31; invalid prefixes or outcome bytes are rejected.
> 
> Existing **`ConditionId`** / **`ConditionIdSchema`** / **`toConditionId`** remain as **deprecated aliases** for the CTF brand to preserve backward compatibility.
> 
> Bindings and client code are retargeted: **CTF** schemas/types for CLOB, gamma, activity, and standard positions; **combo** schemas for combo portfolio rows, RFQ quote/confirmation payloads, protocol v2 router **`split`/`merge`/`redeem`**, and combo position listing filters. Protocol helpers and ABI encoding now normalize combo condition wire forms before on-chain calls. Tests cover combo ID parsing and v2 ABI normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f93cfc35020631bb526376e662b809fe5fe840d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->