### PR TITLE
fix(client): reject whitespace-only search queries

### DIFF
--- a/.changeset/search-query-trim.md
+++ b/.changeset/search-query-trim.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Reject whitespace-only search queries and trim leading or trailing search input.

--- a/packages/client/src/actions/search.ts
+++ b/packages/client/src/actions/search.ts
@@ -28,7 +28,7 @@ import { validateWith } from '../response';
 import { snakeCase, toSearchParams } from './params';
 
 const SearchRequestSchema = z.object({
-  q: z.string().min(1),
+  q: z.string().trim().min(1),
   ascending: z.boolean().optional(),
   cache: z.boolean().optional(),
   cursor: PaginationCursorSchema.optional(),

--- a/packages/client/tests/integration/search.test.ts
+++ b/packages/client/tests/integration/search.test.ts
@@ -1,3 +1,4 @@
+import { UserInputError } from '@polymarket/client';
 import { describe, expect, it } from './fixtures';
 
 describe('Search', () => {
@@ -33,6 +34,10 @@ describe('Search', () => {
           }),
         );
       }
+    });
+
+    it('rejects whitespace-only queries', ({ publicClient }) => {
+      expect(() => publicClient.search({ q: '   ' })).toThrow(UserInputError);
     });
   });
 });


### PR DESCRIPTION
## Summary
- trim search query input during validation
- reject whitespace-only search terms before issuing a request
- add integration coverage for the invalid input path

Linear: DEV-230

## Verification
- pnpm test:client:integration search.test.ts
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation-only change on the search client with no auth or data-path impact.
> 
> **Overview**
> Tightens **search** input validation so `q` is trimmed before length checks, which blocks whitespace-only terms from reaching the API and normalizes queries with accidental leading/trailing spaces.
> 
> Adds an integration test that `publicClient.search({ q: '   ' })` throws **`UserInputError`**, and a **`@polymarket/client`** patch changeset for the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3e64a7e01201ef79d315b3803d4fe39b8fe8af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->