### PR TITLE
docs: clarify testing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,10 @@
 - Default client tests to integration-style coverage.
 - Do not mock API responses unless explicitly requested or unless mocking is necessary to isolate a boundary under test.
 - For tests involving async iterators, especially integration tests, prefer idiomatic consumer usage such as `for await (...)` so the test reads like final SDK DX. Manual iterator calls like `iterator.next()` are acceptable in unit tests or narrow cases where they make the behavior materially easier to isolate or understand.
+- Add tests when they protect user-facing behavior, public API contracts, integration boundaries, or regressions that are likely to recur.
+- Do not add tests reflexively for every small implementation change. For narrow schema or mechanical changes, prefer existing broader coverage plus `typecheck` or build verification when that gives enough confidence.
+- Prefer extending an existing high-signal test suite over creating a new narrow unit-test file.
+- A good test should catch a plausible future regression, not just prove that the current diff works.
 
 
 ## Response contract


### PR DESCRIPTION
## Summary
- add guidance on when tests are valuable versus reflexive
- prefer user-facing/API-boundary coverage and existing high-signal suites
- clarify that narrow schema/mechanical changes can rely on broader coverage plus typecheck/build verification when sufficient

## Verification
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent/contributor guidelines; no product code or CI behavior is modified.
> 
> **Overview**
> **Expands contributor testing guidance** in `AGENTS.md` without changing runtime or test code.
> 
> The **Testing** section now states when to add tests (user-facing behavior, public API contracts, integration boundaries, likely regressions) and when not to (avoid reflexive tests on small mechanical changes). For narrow schema or mechanical edits, it points contributors toward existing broader coverage plus `typecheck`/build when that is enough. It also prefers extending high-signal suites over new narrow unit-test files and defines a good test as one that would catch a plausible future regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a771cf9eb92b3e953db520de7895f323a4c1a3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->