### PR TITLE
Update production RFQ quoter websocket

### DIFF
--- a/.changeset/production-rfq-quoter-ws.md
+++ b/.changeset/production-rfq-quoter-ws.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Update the production RFQ quoter WebSocket URL.

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -142,7 +142,7 @@ export const production: EnvironmentConfig = {
   gamma: 'https://gamma-api.polymarket.com',
   data: 'https://data-api.polymarket.com',
   rtdsWs: 'wss://ws-live-data.polymarket.com',
-  rfqQuoterWs: 'wss://combos-rfq-gateway-quoter-preprod.polymarket.sh/ws/rfq',
+  rfqQuoterWs: 'wss://combos-rfq-gateway-quoter.polymarket.sh/ws/rfq',
   sportsWs: 'wss://sports-api.polymarket.com/ws',
   relayerMaxPolls: 100,
   relayerPollFrequencyMs: 2000,


### PR DESCRIPTION
## Summary
- update production `rfqQuoterWs` to `wss://combos-rfq-gateway-quoter.polymarket.sh/ws/rfq`
- add a patch changeset for `@polymarket/client`

## Verification
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Misconfigured RFQ WebSocket URLs can break live quoting for production clients; change is limited to one environment constant plus a release changeset.
> 
> **Overview**
> Points **production** `rfqQuoterWs` at the live RFQ quoter gateway (`combos-rfq-gateway-quoter.polymarket.sh`) instead of the previous **preprod** host, so `RfqQuoterWebSocketManager` in production uses the correct WebSocket endpoint.
> 
> Includes a **patch** changeset for `@polymarket/client` documenting the URL update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ac8027e0b16fc33b9d7e06e6feadf94946139a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->