### PR TITLE
Use production deposit wallet fixture for combo positions tests

### DIFF
--- a/.changeset/quiet-combo-tests.md
+++ b/.changeset/quiet-combo-tests.md
@@ -1,0 +1,4 @@
+---
+---
+
+No version bump for combo positions integration test fixture cleanup.

--- a/packages/client/tests/integration/positions.test.ts
+++ b/packages/client/tests/integration/positions.test.ts
@@ -1,9 +1,5 @@
 import { toComboConditionId } from '@polymarket/bindings';
-import {
-  createSecureClient,
-  preproduction,
-  type SecureClient,
-} from '@polymarket/client';
+import { createSecureClient, type SecureClient } from '@polymarket/client';
 import { expectPresent } from '@polymarket/types';
 import { vi } from 'vitest';
 import { describe, expect, it, publicClient } from './fixtures';
@@ -102,17 +98,9 @@ describe('Positions', () => {
 
   describe('and a Combo', () => {
     it('splits a combo position by legs', async ({
-      depositWalletAddress,
-      depositWalletSigner,
-      relayerAuthentication,
+      secureClientWithDepositWallet,
     }) => {
-      const secureClient = await createSecureClient({
-        apiKey: relayerAuthentication,
-        signer: depositWalletSigner,
-        wallet: depositWalletAddress,
-        environment: preproduction,
-      });
-
+      const secureClient = secureClientWithDepositWallet;
       const initialShares = await fetchComboShares(secureClient);
 
       await secureClient
@@ -133,18 +121,10 @@ describe('Positions', () => {
     });
 
     it('merges a combo position by legs', async ({
-      depositWalletAddress,
-      depositWalletSigner,
-      relayerAuthentication,
+      secureClientWithDepositWallet,
       skip,
     }) => {
-      const secureClient = await createSecureClient({
-        apiKey: relayerAuthentication,
-        signer: depositWalletSigner,
-        wallet: depositWalletAddress,
-        environment: preproduction,
-      });
-
+      const secureClient = secureClientWithDepositWallet;
       const initialShares = await fetchComboShares(secureClient);
 
       if (initialShares === 0) {

--- a/packages/client/tests/integration/positions.test.ts
+++ b/packages/client/tests/integration/positions.test.ts
@@ -116,7 +116,7 @@ describe('Positions', () => {
             initialShares,
           );
         },
-        { timeout: 15_000 },
+        { timeout: 20_000 },
       );
     });
 
@@ -144,7 +144,7 @@ describe('Positions', () => {
             initialShares,
           );
         },
-        { timeout: 15_000 },
+        { timeout: 20_000 },
       );
     });
   });


### PR DESCRIPTION
## Summary
- remove the preproduction environment override from combo positions integration tests
- use the existing `secureClientWithDepositWallet` fixture so the tests run against production config

## Verification
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture and timeout tweaks; combo tests now exercise production instead of preproduction, which may change CI behavior but not shipped code.
> 
> **Overview**
> Combo **split/merge** integration tests no longer build a `SecureClient` with **`preproduction`**; they use the shared **`secureClientWithDepositWallet`** fixture so combo flows run against the same **production** config as other deposit-wallet tests.
> 
> The combo **`vi.waitFor`** timeouts increase from **15s to 20s**. A changeset records **no package version bump** for this test cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e741d8810ef8a86124a745567bdece9fae5d54b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->