### PR TITLE
Add Combo market catalog support

### DIFF
--- a/.changeset/combo-market-catalog.md
+++ b/.changeset/combo-market-catalog.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Add `listComboMarkets` for fetching Combo market catalog entries with typed response bindings and SDK-owned pagination.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@
 
 - Prefer `type` over `interface` unless an interface is clearly needed, such as when a class implements it or declaration extensibility is a deliberate requirement.
 - Prefer function declarations over arrow functions unless there is a clear reason to use an arrow function.
-- When a type is specific to a single function, such as a one-off params object, argument union, or return shape, colocate that `type` directly above the function declaration. Promote it to a shared or domain abstraction only when it is reused, part of the public model, or needed to express a real abstraction boundary.
+- When a definition is specific to a single function, such as a one-off params object, argument union, request schema, exported request type, error union, or error guard, colocate it directly above the function declaration. Put internal helper-only aliases immediately above the helper that uses them. Promote definitions upward only when they are reused, part of the public model, form a domain abstraction, or improve the public API surface.
 - Treat property-access-derived types like `SecureClient['signatureType']` as a code smell in most cases. Prefer a named domain type when the value is part of the public or shared model.
 - Do not use indexed-access-derived types like `SomeType['field']` in implementation code, public APIs, examples, TSDoc, or docs. This is non-negotiable; define and use a named type instead.
 - Prefer simple, local code. Accept small duplication when it keeps logic easier to read.

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -5,12 +5,23 @@ import type {
 } from '@polymarket/types';
 import { z } from 'zod';
 import { type SignatureType, SignatureTypeSchema } from './clob/signature-type';
-import type { BaseUnits, DecimalString, EvmAddress, TokenId } from './shared';
+import type {
+  BaseUnits,
+  CtfConditionId,
+  DecimalString,
+  EvmAddress,
+  MarketId,
+  TokenId,
+} from './shared';
 import {
   ComboConditionIdSchema,
+  CtfConditionIdSchema,
+  DecimalStringSchema,
   EpochMillisecondsSchema,
   EvmAddressSchema,
+  MarketIdSchema,
   type OrderSide,
+  PaginationCursorSchema,
   type PositionId,
   PositionIdSchema,
   type RfqId,
@@ -90,6 +101,105 @@ export const RfqConfirmationDecisionSchema = z.enum(RfqConfirmationDecision);
 export const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
 export const RfqRequestedSizeUnitSchema = z.enum(RfqRequestedSizeUnit);
 export const RfqErrorCodeSchema = z.enum(RfqErrorCode);
+
+export type ComboMarket = {
+  id: MarketId;
+  conditionId: CtfConditionId;
+  slug: string;
+  title: string;
+  outcomes: ComboMarketOutcomes;
+  image: string;
+  volume: number;
+  tags: string[];
+};
+
+export type ComboMarketOutcome = {
+  label: string;
+  positionId: PositionId;
+  price: DecimalString;
+};
+
+export type ComboMarketOutcomes = {
+  yes: ComboMarketOutcome;
+  no: ComboMarketOutcome;
+};
+
+export const ComboMarketSchema = z
+  .object({
+    id: MarketIdSchema,
+    condition_id: CtfConditionIdSchema,
+    position_ids: z.array(PositionIdSchema),
+    slug: z.string(),
+    title: z.string(),
+    outcomes: z.array(z.string()),
+    outcome_prices: z.array(DecimalStringSchema),
+    image: z.string(),
+    volume: z.number(),
+    tags: z.array(z.string()),
+  })
+  .superRefine((market, context) => {
+    if (market.outcomes.length !== 2) {
+      context.addIssue({
+        code: 'custom',
+        message: `Expected binary combo market outcomes, received ${market.outcomes.length}.`,
+        path: ['outcomes'],
+      });
+    }
+
+    if (market.position_ids.length !== market.outcomes.length) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Expected position_ids and outcomes to have matching lengths.',
+        path: ['position_ids'],
+      });
+    }
+
+    if (market.outcome_prices.length !== market.outcomes.length) {
+      context.addIssue({
+        code: 'custom',
+        message:
+          'Expected outcome_prices and outcomes to have matching lengths.',
+        path: ['outcome_prices'],
+      });
+    }
+  })
+  .transform(
+    (market): ComboMarket => ({
+      conditionId: market.condition_id,
+      id: market.id,
+      image: market.image,
+      outcomes: {
+        yes: {
+          label: market.outcomes[0] as string,
+          positionId: market.position_ids[0] as PositionId,
+          price: market.outcome_prices[0] as DecimalString,
+        },
+        no: {
+          label: market.outcomes[1] as string,
+          positionId: market.position_ids[1] as PositionId,
+          price: market.outcome_prices[1] as DecimalString,
+        },
+      },
+      slug: market.slug,
+      tags: market.tags,
+      title: market.title,
+      volume: market.volume,
+    }),
+  );
+
+export const ListComboMarketsResponseSchema = z
+  .object({
+    markets: z.array(ComboMarketSchema),
+    next_cursor: PaginationCursorSchema.nullish(),
+  })
+  .transform((response) => ({
+    markets: response.markets,
+    nextCursor: response.next_cursor ?? undefined,
+  }));
+
+export type ListComboMarketsResponse = z.infer<
+  typeof ListComboMarketsResponseSchema
+>;
 
 const BigIntStringToDecimalStringSchema = z
   .string()

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -19,6 +19,10 @@ import {
   MarketSchema,
   type TagReference,
 } from '@polymarket/bindings/gamma';
+import {
+  type ComboMarket,
+  ListComboMarketsResponseSchema,
+} from '@polymarket/bindings/rfq';
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../clients';
@@ -225,6 +229,88 @@ export function listMarkets(
         .andThen(validateWith(ListMarketsKeysetResponseSchema))
         .map((response) => ({
           items: response.items,
+          hasMore: response.nextCursor !== undefined,
+          nextCursor: response.nextCursor,
+        })),
+    params.cursor,
+  );
+}
+
+const ListComboMarketsRequestSchema = z.object({
+  cursor: PaginationCursorSchema.optional(),
+  pageSize: PageSizeSchema.max(100).optional(),
+  exclude: z.array(CtfConditionIdSchema).optional(),
+});
+
+export type ListComboMarketsRequest = z.input<
+  typeof ListComboMarketsRequestSchema
+>;
+
+export type ListComboMarketsError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const ListComboMarketsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Lists markets available for Combos.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
+ * @throws {@link ListComboMarketsError}
+ * Thrown on failure.
+ *
+ * @example
+ * Fetch the first page of results:
+ * ```ts
+ * const result = listComboMarkets(client, {
+ *   pageSize: 10,
+ * });
+ *
+ * const firstPage = await result.firstPage();
+ *
+ * // Optionally, fetch additional pages:
+ * for await (const page of result.from(firstPage.nextCursor)) {
+ *   // page.items: ComboMarket[]
+ * }
+ * ```
+ *
+ * @example
+ * Omit markets the caller has already displayed:
+ * ```ts
+ * const result = listComboMarkets(client, {
+ *   exclude: ['0x4cd77d456c83e7d8c569a8fb8f6396c3f40154f657e6d970733e2b1b6a7110ff'],
+ *   pageSize: 10,
+ * });
+ * ```
+ */
+export function listComboMarkets(
+  client: BaseClient,
+  request: ListComboMarketsRequest = {},
+): Paginated<ComboMarket[]> {
+  const params = parseUserInput(request, ListComboMarketsRequestSchema);
+
+  return paginate(
+    (cursor) =>
+      client.rfq
+        .get('/v1/rfq/combo-markets', {
+          params: toComboMarketsSearchParams({
+            ...params,
+            cursor: cursor ?? params.cursor,
+          }),
+        })
+        .andThen(validateWith(ListComboMarketsResponseSchema))
+        .map((response) => ({
+          items: response.markets,
           hasMore: response.nextCursor !== undefined,
           nextCursor: response.nextCursor,
         })),
@@ -532,6 +618,25 @@ function toMarketsSearchParams(params: ListMarketsParams): URLSearchParams {
       marketMakerAddresses: 'market_maker_address',
       pageSize: 'limit',
     }),
+  );
+}
+
+type ListComboMarketsParams = z.output<typeof ListComboMarketsRequestSchema>;
+
+function toComboMarketsSearchParams(
+  params: ListComboMarketsParams,
+): URLSearchParams {
+  return toSearchParams(
+    {
+      cursor: params.cursor,
+      exclude: params.exclude?.join(','),
+      pageSize: params.pageSize,
+    },
+    {
+      cursor: 'cursor',
+      exclude: 'exclude',
+      pageSize: 'limit',
+    },
   );
 }
 

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -82,6 +82,8 @@ type PublicContext = {
   /** @internal */
   data: ServiceClient;
   /** @internal */
+  rfq: ServiceClient;
+  /** @internal */
   webSockets: PublicWebSocketManagers;
 };
 
@@ -154,6 +156,11 @@ abstract class AbstractClient<TContext extends PublicContext> {
   /** @internal */
   get data(): ServiceClient {
     return this.context.data;
+  }
+
+  /** @internal */
+  get rfq(): ServiceClient {
+    return this.context.rfq;
   }
 
   /** @internal */
@@ -285,6 +292,7 @@ class BasePublicClient<
         root: config.environment.relayer,
         resolveHeaders: (request) => this.resolveRelayerHeaders(request),
       }),
+      rfq: new ServiceClient({ root: config.environment.rfq }),
       rpc: new JsonRpcClient({ url: config.environment.rpc }),
       webSockets: {
         clobMarket: new ClobMarketWebSocketManager({
@@ -499,6 +507,7 @@ class BaseSecureClient<
       rpc: new JsonRpcClient({ url: config.environment.rpc }),
       gamma: new ServiceClient({ root: config.environment.gamma }),
       data: new ServiceClient({ root: config.environment.data }),
+      rfq: new ServiceClient({ root: config.environment.rfq }),
       secureClob: new ServiceClient({
         resolveHeaders: async (request) => ({
           ...(await this.resolveClobHeaders(request)),

--- a/packages/client/src/decorators/discovery.ts
+++ b/packages/client/src/decorators/discovery.ts
@@ -11,6 +11,7 @@ import type {
   TagReference,
   Team,
 } from '@polymarket/bindings/gamma';
+import type { ComboMarket } from '@polymarket/bindings/rfq';
 import {
   type FetchCommentsByIdRequest,
   type FetchEventRequest,
@@ -33,6 +34,7 @@ import {
   fetchSeries,
   fetchSportsMarketTypes,
   fetchTag,
+  type ListComboMarketsRequest,
   type ListCommentsByUserAddressRequest,
   type ListCommentsRequest,
   type ListEventsRequest,
@@ -40,6 +42,7 @@ import {
   type ListSeriesRequest,
   type ListTagsRequest,
   type ListTeamsRequest,
+  listComboMarkets,
   listComments,
   listCommentsByUserAddress,
   listEvents,
@@ -171,6 +174,50 @@ export type DiscoveryActions = {
    * ```
    */
   listMarkets(request?: ListMarketsRequest): Paginated<Market[]>;
+
+  /**
+   * Lists markets available for Combos.
+   *
+   * @throws {@link ListComboMarketsError}
+   * Thrown on failure.
+   *
+   * @example
+   * Fetch the first page of results:
+   * ```ts
+   * const paginator = client.listComboMarkets({
+   *   pageSize: 10,
+   * });
+   *
+   * const firstPage = await paginator.firstPage();
+   *
+   * // Optionally, fetch additional pages:
+   * for await (const page of paginator.from(firstPage.nextCursor)) {
+   *   // page.items: ComboMarket[]
+   * }
+   * ```
+   *
+   * @example
+   * Loop through all pages with `for await`:
+   * ```ts
+   * const paginator = client.listComboMarkets({
+   *   pageSize: 10,
+   * });
+   *
+   * for await (const page of paginator) {
+   *   // page.items: ComboMarket[]
+   * }
+   * ```
+   *
+   * @example
+   * Omit markets the caller has already displayed:
+   * ```ts
+   * const paginator = client.listComboMarkets({
+   *   exclude: ['0x4cd77d456c83e7d8c569a8fb8f6396c3f40154f657e6d970733e2b1b6a7110ff'],
+   *   pageSize: 10,
+   * });
+   * ```
+   */
+  listComboMarkets(request?: ListComboMarketsRequest): Paginated<ComboMarket[]>;
 
   /**
    * Fetches a market.
@@ -551,6 +598,7 @@ export function discoveryActions(client: BaseClient): DiscoveryActions {
     fetchEvent: fetchEvent.bind(null, client),
     fetchEventTags: fetchEventTags.bind(null, client),
     listMarkets: listMarkets.bind(null, client),
+    listComboMarkets: listComboMarkets.bind(null, client),
     fetchMarket: fetchMarket.bind(null, client),
     fetchMarketTags: fetchMarketTags.bind(null, client),
     listSeries: listSeries.bind(null, client),
@@ -585,6 +633,7 @@ export {
   FetchSeriesError,
   FetchSportsMarketTypesError,
   FetchTagError,
+  ListComboMarketsError,
   ListCommentsByUserAddressError,
   ListCommentsError,
   ListEventsError,

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -59,6 +59,8 @@ export type EnvironmentConfig = {
   /** @internal */
   data: string;
   /** @internal */
+  rfq: string;
+  /** @internal */
   rtdsWs: string;
   /** @internal */
   sportsWs: string;
@@ -141,6 +143,7 @@ export const production: EnvironmentConfig = {
   relayer: 'https://relayer-v2.polymarket.com',
   gamma: 'https://gamma-api.polymarket.com',
   data: 'https://data-api.polymarket.com',
+  rfq: 'https://combos-rfq-api.polymarket.sh',
   rtdsWs: 'wss://ws-live-data.polymarket.com',
   rfqQuoterWs: 'wss://combos-rfq-gateway-quoter-preprod.polymarket.sh/ws/rfq',
   sportsWs: 'wss://sports-api.polymarket.com/ws',

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -42,45 +42,6 @@ describe('Markets', () => {
     });
   });
 
-  describe('listComboMarkets', () => {
-    it('fetches combo markets with structured outcomes', async ({
-      publicClient,
-    }) => {
-      const page = await publicClient
-        .listComboMarkets({ pageSize: 1 })
-        .firstPage()
-        .then(expectNonEmptyPage);
-      const [comboMarket] = page.items;
-
-      expect(comboMarket).toEqual(
-        expect.objectContaining({
-          conditionId: expect.any(String),
-          id: expect.any(String),
-          outcomes: {
-            yes: expect.any(Object),
-            no: expect.any(Object),
-          },
-          slug: expect.any(String),
-          title: expect.any(String),
-        }),
-      );
-      expect(comboMarket.outcomes.yes).toEqual(
-        expect.objectContaining({
-          label: expect.any(String),
-          positionId: expect.any(String),
-          price: expect.any(String),
-        }),
-      );
-      expect(comboMarket.outcomes.no).toEqual(
-        expect.objectContaining({
-          label: expect.any(String),
-          positionId: expect.any(String),
-          price: expect.any(String),
-        }),
-      );
-    });
-  });
-
   describe('fetchMarket', () => {
     it('fetches a market by id and slug', async ({ publicClient }) => {
       const marketById = await publicClient.fetchMarket({

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -42,6 +42,45 @@ describe('Markets', () => {
     });
   });
 
+  describe('listComboMarkets', () => {
+    it('fetches combo markets with structured outcomes', async ({
+      publicClient,
+    }) => {
+      const page = await publicClient
+        .listComboMarkets({ pageSize: 1 })
+        .firstPage()
+        .then(expectNonEmptyPage);
+      const [comboMarket] = page.items;
+
+      expect(comboMarket).toEqual(
+        expect.objectContaining({
+          conditionId: expect.any(String),
+          id: expect.any(String),
+          outcomes: {
+            yes: expect.any(Object),
+            no: expect.any(Object),
+          },
+          slug: expect.any(String),
+          title: expect.any(String),
+        }),
+      );
+      expect(comboMarket.outcomes.yes).toEqual(
+        expect.objectContaining({
+          label: expect.any(String),
+          positionId: expect.any(String),
+          price: expect.any(String),
+        }),
+      );
+      expect(comboMarket.outcomes.no).toEqual(
+        expect.objectContaining({
+          label: expect.any(String),
+          positionId: expect.any(String),
+          price: expect.any(String),
+        }),
+      );
+    });
+  });
+
   describe('fetchMarket', () => {
     it('fetches a market by id and slug', async ({ publicClient }) => {
       const marketById = await publicClient.fetchMarket({


### PR DESCRIPTION
## Summary
- add RFQ REST environment wiring and public `client.listComboMarkets(...)` pagination
- add Combo market bindings with binary `outcomes.yes/no` objects including `positionId` and `price`
- add live markets integration coverage and repo guidance for colocating action-specific definitions

## Verification
- `pnpm lint`
- `pnpm vitest --project client-integration packages/client/tests/integration/markets.test.ts`
- `pnpm --filter @polymarket/bindings build`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only discovery API following existing pagination patterns; no auth, signing, or trading flow changes.
> 
> **Overview**
> Adds **Combo market catalog** discovery: consumers can paginate markets eligible for Combos via **`client.listComboMarkets`** (and the low-level **`listComboMarkets`** action), backed by a new RFQ REST **`ServiceClient`** and production **`environment.rfq`** URL.
> 
> **Bindings** introduce **`ComboMarket`** / **`ListComboMarketsResponse`** Zod schemas that validate binary markets and map wire arrays into **`outcomes.yes`** / **`outcomes.no`** objects with **`label`**, **`positionId`**, and **`price`**. Request options include **`cursor`**, **`pageSize`** (max 100), and **`exclude`** condition IDs. **`AGENTS.md`** is updated to require colocating action-specific types/schemas above their functions.
> 
> Integration coverage asserts live combo market pages return the structured outcome shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc6f19d372c2dda42794c9eab069a352fa158ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->