### PR TITLE
fix(bindings): normalize empty-string decimal fields in order and trade responses

### DIFF
--- a/.changeset/dev-259-empty-string-decimals.md
+++ b/.changeset/dev-259-empty-string-decimals.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Normalize empty-string decimal fields from order and trade responses: order `makingAmount`/`takingAmount` map `""` to `"0"`, and maker order `feeRateBps` maps `""` to `null`, matching py-sdk behavior.

--- a/packages/bindings/src/clob/account.test.ts
+++ b/packages/bindings/src/clob/account.test.ts
@@ -44,4 +44,19 @@ describe('ClobTradeSchema', () => {
     expect(trade.matchedAt).toBe('2026-05-05T16:00:29.000Z');
     expect(trade.updatedAt).toBe('2026-05-05T16:00:40.000Z');
   });
+
+  it('normalizes empty maker fee_rate_bps to null', () => {
+    const trade = ClobTradeSchema.parse({
+      ...baseTrade,
+      maker_orders: [
+        { ...baseTrade.maker_orders[0], fee_rate_bps: '' },
+        { ...baseTrade.maker_orders[0], fee_rate_bps: '25' },
+      ],
+      match_time: '1777996829',
+      last_update: '1777996840',
+    });
+
+    expect(trade.makerOrders[0]?.feeRateBps).toBeNull();
+    expect(trade.makerOrders[1]?.feeRateBps).toBe('25');
+  });
 });

--- a/packages/bindings/src/clob/account.ts
+++ b/packages/bindings/src/clob/account.ts
@@ -8,6 +8,7 @@ import {
   EpochMillisecondsSchema,
   EpochMillisecondsToIsoDateTimeStringSchema,
   EvmAddressSchema,
+  emptyStringToNull,
   NotificationIdSchema,
   OptionalEpochMillisecondsToIsoDateTimeStringSchema,
   TokenIdSchema,
@@ -97,7 +98,7 @@ export const MakerOrderSchema = z
     // Normalize to null so consumers never see '' as a DecimalString. This
     // matches py-sdk, where MakerOrder.fee_rate_bps is nullable.
     fee_rate_bps: z.preprocess(
-      (value) => (value === '' ? null : value),
+      emptyStringToNull,
       DecimalStringSchema.nullable(),
     ),
     maker_address: z.string(),

--- a/packages/bindings/src/clob/account.ts
+++ b/packages/bindings/src/clob/account.ts
@@ -93,7 +93,13 @@ export type OpenOrdersPage = z.infer<typeof OpenOrdersPageSchema>;
 export const MakerOrderSchema = z
   .object({
     asset_id: TokenIdSchema,
-    fee_rate_bps: DecimalStringSchema,
+    // The API serializes a missing maker fee rate as an empty string.
+    // Normalize to null so consumers never see '' as a DecimalString. This
+    // matches py-sdk, where MakerOrder.fee_rate_bps is nullable.
+    fee_rate_bps: z.preprocess(
+      (value) => (value === '' ? null : value),
+      DecimalStringSchema.nullable(),
+    ),
     maker_address: z.string(),
     matched_amount: DecimalStringSchema,
     order_id: z.string(),

--- a/packages/bindings/src/clob/order-response.test.ts
+++ b/packages/bindings/src/clob/order-response.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { OrderPostStatus, OrderResponseSchema } from './order-response';
+
+describe('OrderResponseSchema', () => {
+  it('normalizes empty making/taking amounts on a live order to zero', () => {
+    const response = OrderResponseSchema.parse({
+      errorMsg: '',
+      makingAmount: '',
+      orderID: 'order-1',
+      status: 'live',
+      success: true,
+      takingAmount: '',
+    });
+
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.status).toBe(OrderPostStatus.LIVE);
+      expect(response.makingAmount).toBe('0');
+      expect(response.takingAmount).toBe('0');
+    }
+  });
+
+  it('passes populated making/taking amounts through unchanged', () => {
+    const response = OrderResponseSchema.parse({
+      errorMsg: '',
+      makingAmount: '10.5',
+      orderID: 'order-2',
+      status: 'matched',
+      success: true,
+      takingAmount: '21',
+      tradeIDs: ['trade-1'],
+    });
+
+    expect(response.ok).toBe(true);
+    if (response.ok) {
+      expect(response.makingAmount).toBe('10.5');
+      expect(response.takingAmount).toBe('21');
+    }
+  });
+});

--- a/packages/bindings/src/clob/order-response.ts
+++ b/packages/bindings/src/clob/order-response.ts
@@ -6,13 +6,22 @@ import {
   TxHashSchema,
 } from '../shared';
 
+// The API serializes unset decimal fields as empty strings, e.g. the
+// making/taking amounts on an order that rests on the book without matching.
+// Normalize to '0' so consumers never see '' as a DecimalString. This matches
+// py-sdk's RawOrderResponse normalization.
+const EmptyStringToZeroDecimalStringSchema = z.preprocess(
+  (value) => (value === '' ? '0' : value),
+  DecimalStringSchema,
+);
+
 export const RawOrderResponseSchema = z.object({
   errorMsg: z.string(),
-  makingAmount: DecimalStringSchema,
+  makingAmount: EmptyStringToZeroDecimalStringSchema,
   orderID: z.string(),
   status: z.string(),
   success: z.boolean(),
-  takingAmount: DecimalStringSchema,
+  takingAmount: EmptyStringToZeroDecimalStringSchema,
   tradeIDs: z.array(z.string()).default([]),
   transactionsHashes: z.array(z.string()).default([]),
 });

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -9,6 +9,7 @@ import {
   EventIdSchema,
   type EvmAddress,
   EvmAddressSchema,
+  emptyStringToNull,
   IsoCalendarDateStringSchema,
   type IsoDateTimeString,
   IsoDateTimeStringSchema,
@@ -473,10 +474,6 @@ export function normalizeMarket(market: GammaMarket): Market {
       label: tag.label,
     })),
   };
-}
-
-function emptyStringToNull(value: unknown): unknown {
-  return value === '' ? null : value;
 }
 
 function nullishToNull<T>(value: T | null | undefined): T | null {

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -420,6 +420,15 @@ export type TickSizeValue = z.output<typeof TickSizeValueSchema>;
 
 export type { EvmAddress, TxHash };
 
+/**
+ * Preprocess helper for upstream fields that serialize missing values as empty
+ * strings. Use as `z.preprocess(emptyStringToNull, Schema.nullable())`, or
+ * with `.nullish()` when the field can also be absent.
+ */
+export function emptyStringToNull(value: unknown): unknown {
+  return value === '' ? null : value;
+}
+
 function toEvmAddress(value: string): EvmAddress {
   return expectEvmAddress(value);
 }


### PR DESCRIPTION
## Summary

The CLOB API serializes unset decimal fields as empty strings, which leaked into the SDK as `"" as DecimalString`:

- `makingAmount`/`takingAmount` on a live resting order come back as `""`. Confirmed in the API source: the live-order response is constructed with only order ID, success, and status, and the response struct serializes string zero values without `omitempty`.
- `MakerOrder.fee_rate_bps` can come back as `""` for the same reason.

A consumer doing `Number("")` gets `0`, `parseFloat("")` gets `NaN`, and `Decimal()`/`BigNumber()` constructors throw.

## Changes

- `RawOrderResponseSchema`: `makingAmount`/`takingAmount` normalize `""` to `"0"`, matching py-sdk's `RawOrderResponse` normalization.
- `MakerOrderSchema`: `fee_rate_bps` normalizes `""` to `null` and `feeRateBps` is now nullable, matching py-sdk where the field is `None` when absent.
- Top-level `ClobTrade.feeRateBps` is intentionally unchanged, matching py-sdk.

## Verification

- New tests fail on `main` and pass with the change (verified by stashing the source edits and rerunning).
- `pnpm build`, `pnpm typecheck`, `pnpm lint` clean.
- Full suite green: bindings 13 tests, client 123 tests, 0 regressions.

Reported in #119.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Boundary-only Zod preprocessing with tests; maker `feeRateBps` becomes nullable, a small typing change for consumers.
> 
> **Overview**
> CLOB bindings now **normalize API empty strings** on decimal fields so consumers never get `""` typed as `DecimalString`.
> 
> **Order post responses** (`RawOrderResponseSchema`): `makingAmount` and `takingAmount` preprocess `""` → `"0"` (e.g. live resting orders), aligned with py-sdk.
> 
> **Trade maker orders** (`MakerOrderSchema`): `fee_rate_bps` preprocesses `""` → `null`, so **`feeRateBps` is nullable** on nested maker orders; top-level trade `feeRateBps` is unchanged.
> 
> `emptyStringToNull` is **exported from `shared`** and reused in gamma market parsing (local duplicate removed). New Vitest coverage for order responses and maker `fee_rate_bps`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889a6526fd7657fed247b998e46e07b69e459a85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->