### PR TITLE
feat(client): add Openfort wallet provider entrypoint

### DIFF
--- a/.changeset/wise-otters-trade.md
+++ b/.changeset/wise-otters-trade.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Add an `@polymarket/client/openfort` entrypoint with a `signerFrom` factory that signs and trades with Openfort EVM backend wallets. The entrypoint mirrors the Privy integration: Node-only runtime guards, the shared `Signer` contract, the same public error mapping, and a direct transaction handle that waits for receipts. `@openfort/openfort-node` is a new optional peer dependency.

--- a/env.d.ts
+++ b/env.d.ts
@@ -8,6 +8,9 @@ declare namespace NodeJS {
     POLYMARKET_PROXY_WALLET: string | undefined;
     POLYMARKET_SAFE_PRIVATE_KEY: string | undefined;
     POLYMARKET_SAFE_WALLET: string | undefined;
+    OPENFORT_TEST_SECRET_KEY: string | undefined;
+    OPENFORT_TEST_WALLET_SECRET: string | undefined;
+    OPENFORT_TEST_ACCOUNT_ID: string | undefined;
     PRIVY_TEST_APP_ID: string | undefined;
     PRIVY_TEST_APP_SECRET: string | undefined;
     PRIVY_TEST_WALLET_ID: string | undefined;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -30,6 +30,10 @@
       "types": "./dist/ethers-v5.d.ts",
       "default": "./dist/ethers-v5.js"
     },
+    "./openfort": {
+      "types": "./dist/openfort.d.ts",
+      "default": "./dist/openfort.js"
+    },
     "./privy": {
       "types": "./dist/privy.d.ts",
       "default": "./dist/privy.js"
@@ -50,6 +54,9 @@
       "ethers-v5": [
         "./dist/ethers-v5.d.ts"
       ],
+      "openfort": [
+        "./dist/openfort.d.ts"
+      ],
       "privy": [
         "./dist/privy.d.ts"
       ],
@@ -67,6 +74,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
+    "@openfort/openfort-node": "^0.10.5",
     "@privy-io/node": "^0.15.0",
     "ethers-v5": "npm:ethers@^5.8.0",
     "tsup": "^8.5.1",
@@ -75,11 +83,15 @@
   },
   "license": "MIT",
   "peerDependencies": {
+    "@openfort/openfort-node": "^0.10.5",
     "@privy-io/node": "^0.15.0",
     "ethers-v5": "^5.8.0",
     "viem": "^2.46.3"
   },
   "peerDependenciesMeta": {
+    "@openfort/openfort-node": {
+      "optional": true
+    },
     "@privy-io/node": {
       "optional": true
     },

--- a/packages/client/src/openfort.ts
+++ b/packages/client/src/openfort.ts
@@ -1,0 +1,237 @@
+import process from 'node:process';
+import type { EvmAccount, Openfort } from '@openfort/openfort-node';
+import {
+  expectEvmAddress,
+  expectEvmSignature,
+  expectTxHash,
+  type HexString,
+  invariant,
+  never,
+  type TxHash,
+} from '@polymarket/types';
+import {
+  type Chain,
+  createPublicClient,
+  createWalletClient,
+  http,
+  WaitForTransactionReceiptTimeoutError,
+} from 'viem';
+import { toAccount } from 'viem/accounts';
+import { waitForTransactionReceipt } from 'viem/actions';
+import * as viemChains from 'viem/chains';
+import {
+  SigningError,
+  TimeoutError,
+  TransactionFailedError,
+  TransportError,
+} from './errors';
+import type {
+  Signer,
+  SignerTransactionRequest,
+  TransactionHandle,
+  TransactionOutcome,
+  TypedDataPayload,
+} from './types';
+
+invariant(
+  process.release.name === 'node',
+  'The @polymarket/client/openfort entrypoint requires a Node.js runtime.',
+);
+invariant(
+  typeof window === 'undefined' && typeof document === 'undefined',
+  'The @polymarket/client/openfort entrypoint cannot be imported in a browser-like runtime.',
+);
+
+export type OpenfortWalletConfig = {
+  openfort: Openfort;
+  /** The Openfort EVM backend wallet account ID (starts with `acc_`). */
+  accountId: string;
+};
+
+const allChains = Object.values(viemChains) as Chain[];
+
+/**
+ * Creates a signer backed by an Openfort EVM backend wallet.
+ *
+ * Signing requests are executed by the Openfort backend wallet, so private
+ * key material never leaves the wallet infrastructure. Transactions are
+ * prepared and broadcast directly to the blockchain, with the transaction
+ * signed by the backend wallet.
+ *
+ * @example
+ * ```ts
+ * const secureClient = await createSecureClient({
+ *   signer: signerFrom({
+ *     openfort: new Openfort(process.env.OPENFORT_SECRET_KEY, {
+ *       walletSecret: process.env.OPENFORT_WALLET_SECRET,
+ *     }),
+ *     accountId: 'acc_...',
+ *   }),
+ * });
+ * ```
+ */
+export function signerFrom(config: OpenfortWalletConfig): Signer {
+  let accountPromise: Promise<EvmAccount> | undefined;
+
+  function resolveAccount(): Promise<EvmAccount> {
+    accountPromise ??= config.openfort.accounts.evm.backend
+      .get({ id: config.accountId })
+      .catch((error: unknown) => {
+        // Drop the cached promise so a later call can retry.
+        accountPromise = undefined;
+        throw SigningError.fromError(
+          error,
+          `Could not resolve Openfort backend wallet ${config.accountId}`,
+        );
+      });
+
+    return accountPromise;
+  }
+
+  return {
+    async getAddress() {
+      return expectEvmAddress((await resolveAccount()).address);
+    },
+    async signTypedData(payload) {
+      return signTypedData(await resolveAccount(), payload);
+    },
+    async signMessage(message) {
+      return signMessage(await resolveAccount(), message);
+    },
+    async sendTransaction(request) {
+      return new DirectTransactionHandle(
+        await sendTransaction(await resolveAccount(), request),
+        request.chainId,
+      );
+    },
+  };
+}
+
+async function signTypedData(account: EvmAccount, payload: TypedDataPayload) {
+  try {
+    const signature = await account.signTypedData({
+      domain: payload.domain,
+      message: payload.message,
+      primaryType: payload.primaryType,
+      types: payload.types as Record<
+        string,
+        Array<{ name: string; type: string }>
+      >,
+    });
+
+    return expectEvmSignature(signature);
+  } catch (error) {
+    throw SigningError.fromError(error);
+  }
+}
+
+async function signMessage(account: EvmAccount, message: HexString) {
+  try {
+    const signature = await account.signMessage({
+      message: { raw: message },
+    });
+
+    return expectEvmSignature(signature);
+  } catch (error) {
+    throw SigningError.fromError(error);
+  }
+}
+
+async function sendTransaction(
+  account: EvmAccount,
+  request: SignerTransactionRequest,
+): Promise<TxHash> {
+  try {
+    const walletClient = createWalletClient({
+      account: toAccount({
+        address: account.address,
+        signMessage(parameters) {
+          return account.signMessage(parameters);
+        },
+        signTransaction(transaction) {
+          return account.signTransaction(transaction);
+        },
+        signTypedData(typedData) {
+          return account.signTypedData(typedData);
+        },
+      }),
+      chain: resolveChain(request.chainId),
+      transport: http(),
+    });
+
+    const hash = await walletClient.sendTransaction({
+      data: request.data,
+      to: request.to,
+      value: request.value,
+    });
+
+    return expectTxHash(hash);
+  } catch (error) {
+    throw SigningError.fromError(error);
+  }
+}
+
+class DirectTransactionHandle implements TransactionHandle {
+  readonly transactionId = null;
+
+  readonly #chainId: number;
+  #transactionHash: TxHash;
+
+  constructor(transactionHash: TxHash, chainId: number) {
+    this.#chainId = chainId;
+    this.#transactionHash = transactionHash;
+  }
+
+  get transactionHash() {
+    return this.#transactionHash;
+  }
+
+  async wait(): Promise<TransactionOutcome> {
+    try {
+      const receipt = await waitForTransactionReceipt(
+        createPublicClient({
+          chain: resolveChain(this.#chainId),
+          transport: http(),
+        }),
+        {
+          hash: this.#transactionHash,
+        },
+      );
+
+      const transactionHash = expectTxHash(receipt.transactionHash);
+      this.#transactionHash = transactionHash;
+
+      if (receipt.status === 'reverted') {
+        throw new TransactionFailedError(
+          `Transaction ${transactionHash} reverted`,
+        );
+      }
+
+      return {
+        transactionHash,
+        transactionId: null,
+      };
+    } catch (error) {
+      if (error instanceof WaitForTransactionReceiptTimeoutError) {
+        throw new TimeoutError(
+          `Timed out waiting for transaction ${this.#transactionHash} to settle`,
+          { cause: error },
+        );
+      }
+
+      throw TransportError.fromError(error);
+    }
+  }
+}
+
+function resolveChain(chainId: number) {
+  const chain = allChains.find((candidate) => candidate.id === chainId);
+
+  if (chain !== undefined) {
+    return chain;
+  }
+
+  never(
+    `Unsupported chain ID for direct Openfort transaction wait: ${chainId}`,
+  );
+}

--- a/packages/client/tests/integration/openfort.test.ts
+++ b/packages/client/tests/integration/openfort.test.ts
@@ -1,0 +1,155 @@
+import Openfort from '@openfort/openfort-node';
+import { OrderSide } from '@polymarket/bindings';
+import { AssetType } from '@polymarket/bindings/clob';
+import {
+  type ApiKeyAuthorization,
+  createSecureClient,
+  type EvmAddress,
+  WalletType,
+} from '@polymarket/client';
+import {
+  cancelOrder,
+  fetchApiKeys,
+  fetchBalanceAllowance,
+} from '@polymarket/client/actions';
+import {
+  type OpenfortWalletConfig,
+  signerFrom,
+} from '@polymarket/client/openfort';
+import { expectPresent } from '@polymarket/types';
+import type { TestContext } from 'vitest';
+import { describe, expect, it, runMeteredTests } from './fixtures';
+import { expectAcceptedOrderResponse } from './helpers';
+
+const TEST_MARKET_SLUG = 'eth-flipped-in-2026';
+
+type Skip = TestContext['skip'];
+
+type OpenfortTestAccount = {
+  hasCollateralBalance: boolean;
+  wallet: OpenfortWalletConfig;
+  walletAddress: EvmAddress;
+};
+
+let openfortTestAccountPromise: Promise<OpenfortTestAccount> | undefined;
+
+describe('openfort', () => {
+  it('authenticates a secure client', async ({
+    builderAuthentication,
+    skip,
+  }) => {
+    const account = await setupOpenfortTestAccount({
+      builderAuthentication,
+      skip,
+    });
+    const secureClient = await createSecureClient({
+      signer: signerFrom(account.wallet),
+      wallet: account.walletAddress,
+    });
+
+    await expect(fetchApiKeys(secureClient)).resolves.toBeDefined();
+  });
+
+  it.runIf(runMeteredTests)(
+    'places and cancels a limit order',
+    async ({ builderAuthentication, publicClient, skip }) => {
+      const account = await setupOpenfortTestAccount({
+        builderAuthentication,
+        skip,
+      });
+
+      if (!account.hasCollateralBalance) {
+        skip('Openfort test wallet has no collateral balance');
+      }
+
+      const market = await publicClient.fetchMarket({
+        slug: TEST_MARKET_SLUG,
+      });
+      const yesTokenId = expectPresent(market.outcomes.yes.tokenId);
+      const price = expectPresent(market.trading.minimumTickSize);
+      const size = expectPresent(market.trading.minimumOrderSize);
+      const secureClient = await createSecureClient({
+        signer: signerFrom(account.wallet),
+        wallet: account.walletAddress,
+      });
+
+      const response = await secureClient.placeLimitOrder({
+        price,
+        size,
+        side: OrderSide.BUY,
+        tokenId: yesTokenId,
+      });
+
+      expect(response.ok).toBe(true);
+      const acceptedResponse = expectAcceptedOrderResponse(response);
+
+      await expect(
+        cancelOrder(secureClient, { orderId: acceptedResponse.orderId }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          canceled: expect.arrayContaining([acceptedResponse.orderId]),
+        }),
+      );
+    },
+    120_000,
+  );
+});
+
+type SetupOpenfortTestAccountRequest = {
+  builderAuthentication: ApiKeyAuthorization;
+  skip: Skip;
+};
+
+function setupOpenfortTestAccount(request: SetupOpenfortTestAccountRequest) {
+  openfortTestAccountPromise ??= createOpenfortTestAccount(request);
+
+  return openfortTestAccountPromise;
+}
+
+async function createOpenfortTestAccount({
+  builderAuthentication,
+  skip,
+}: SetupOpenfortTestAccountRequest): Promise<OpenfortTestAccount> {
+  const wallet: OpenfortWalletConfig = {
+    openfort: new Openfort(loadOpenfortEnv('OPENFORT_TEST_SECRET_KEY', skip), {
+      walletSecret: loadOpenfortEnv('OPENFORT_TEST_WALLET_SECRET', skip),
+    }),
+    accountId: loadOpenfortEnv('OPENFORT_TEST_ACCOUNT_ID', skip),
+  };
+  const secureClient = await createSecureClient({
+    apiKey: builderAuthentication,
+    signer: signerFrom(wallet),
+  });
+  const depositWalletClient = await secureClient.setupGaslessWallet();
+
+  expect(depositWalletClient.account.walletType).toBe(
+    WalletType.DEPOSIT_WALLET,
+  );
+
+  const hasCollateralBalance =
+    (
+      await fetchBalanceAllowance(depositWalletClient, {
+        assetType: AssetType.COLLATERAL,
+      })
+    ).balance !== '0';
+
+  if (hasCollateralBalance && runMeteredTests) {
+    await depositWalletClient.setupTradingApprovals();
+  }
+
+  return {
+    hasCollateralBalance,
+    wallet,
+    walletAddress: depositWalletClient.account.wallet,
+  };
+}
+
+function loadOpenfortEnv(name: string, skip: Skip): string {
+  const value = process.env[name];
+
+  if (value === undefined) {
+    skip(`${name} is not set`);
+  }
+
+  return value;
+}

--- a/packages/client/tsup.config.ts
+++ b/packages/client/tsup.config.ts
@@ -22,7 +22,7 @@ export default defineConfig(() => [
     format: ['esm'],
   },
   {
-    entry: ['src/node.ts', 'src/privy.ts'],
+    entry: ['src/node.ts', 'src/openfort.ts', 'src/privy.ts'],
     outDir: 'dist',
     sourcemap: true,
     treeshake: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@openfort/openfort-node':
+        specifier: ^0.10.5
+        version: 0.10.5(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))
       '@privy-io/node':
         specifier: ^0.15.0
         version: 0.15.0(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))
@@ -775,6 +778,35 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@openfort/openfort-node@0.10.5':
+    resolution: {integrity: sha512-+0q+oIUvRertRsAYOrJiOoRvZI1c3ox4pDVHGJh9kFErEyOutCZwH2pAh8k1/mPIH391XD7jNky6Au9TAJHVoA==}
+    peerDependencies:
+      '@solana-program/compute-budget': '>=0.7.0'
+      '@solana-program/system': '>=0.7.0'
+      '@solana-program/token': '>=0.7.0'
+      '@solana/kit': '>=6.0.0'
+      '@solana/kora': '>=0.1.0'
+      '@solana/transaction-confirmation': '>=6.0.0'
+      viem: '>=2.0.0'
+    peerDependenciesMeta:
+      '@solana-program/compute-budget':
+        optional: true
+      '@solana-program/system':
+        optional: true
+      '@solana-program/token':
+        optional: true
+      '@solana/kit':
+        optional: true
+      '@solana/kora':
+        optional: true
+      '@solana/transaction-confirmation':
+        optional: true
+      viem:
+        optional: true
+
+  '@openfort/shield-js@0.1.37':
+    resolution: {integrity: sha512-DiSTo0keqbAtkG4vG/07lrRoDjgonDSNmyEHNillByaBoDlna/kDBf5r1FWVYXskwXVUv7UA8YDtk9cgYdATUg==}
+
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
@@ -1121,6 +1153,10 @@ packages:
   aes-js@3.0.0:
     resolution: {integrity: sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==}
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -1150,9 +1186,26 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios-retry@4.5.0:
+    resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
+    peerDependencies:
+      axios: 0.x || 1.x
+
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+
+  axios@1.17.0:
+    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
   bech32@1.1.4:
     resolution: {integrity: sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==}
@@ -1178,6 +1231,9 @@ packages:
   brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
 
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1187,6 +1243,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
 
   canonicalize@2.1.0:
     resolution: {integrity: sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==}
@@ -1217,6 +1277,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1249,6 +1313,10 @@ packages:
       supports-color:
         optional: true
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -1261,6 +1329,10 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   elliptic@6.6.1:
     resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
@@ -1271,8 +1343,24 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
@@ -1339,6 +1427,19 @@ packages:
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
     engines: {node: '>=6 <7 || >=8'}
@@ -1352,9 +1453,20 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1368,6 +1480,10 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1375,14 +1491,30 @@ packages:
     resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -1417,6 +1549,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-retry-allowed@2.2.0:
+    resolution: {integrity: sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==}
+    engines: {node: '>=10'}
 
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
@@ -1567,6 +1703,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1574,6 +1714,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -1754,6 +1902,10 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -2136,6 +2288,9 @@ packages:
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
     engines: {node: '>=18'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -2875,6 +3030,27 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@openfort/openfort-node@0.10.5(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))':
+    dependencies:
+      '@openfort/shield-js': 0.1.37
+      axios: 1.17.0
+      axios-retry: 4.5.0(axios@1.17.0)
+      bs58: 6.0.0
+      jose: 6.2.2
+      zod: 3.25.76
+    optionalDependencies:
+      viem: 2.47.10(typescript@6.0.2)(zod@4.3.6)
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@openfort/shield-js@0.1.37':
+    dependencies:
+      axios: 1.15.0
+      axios-retry: 4.5.0(axios@1.15.0)
+    transitivePeerDependencies:
+      - debug
+
   '@oxc-project/types@0.122.0': {}
 
   '@privy-io/node@0.15.0(viem@2.47.10(typescript@6.0.2)(zod@4.3.6))':
@@ -3107,6 +3283,12 @@ snapshots:
 
   aes-js@3.0.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
@@ -3127,7 +3309,39 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  asynckit@0.4.0: {}
+
+  axios-retry@4.5.0(axios@1.15.0):
+    dependencies:
+      axios: 1.15.0
+      is-retry-allowed: 2.2.0
+
+  axios-retry@4.5.0(axios@1.17.0):
+    dependencies:
+      axios: 1.17.0
+      is-retry-allowed: 2.2.0
+
+  axios@1.15.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.17.0:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   balanced-match@4.0.4: {}
+
+  base-x@5.0.1: {}
 
   bech32@1.1.4: {}
 
@@ -3149,12 +3363,21 @@ snapshots:
 
   brorand@1.1.0: {}
 
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
+
   bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
       esbuild: 0.27.4
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
 
   canonicalize@2.1.0: {}
 
@@ -3180,6 +3403,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@4.1.1: {}
 
   confbox@0.1.8: {}
@@ -3200,6 +3427,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  delayed-stream@1.0.0: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
@@ -3207,6 +3436,12 @@ snapshots:
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   elliptic@6.6.1:
     dependencies:
@@ -3225,7 +3460,22 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.27.4:
     optionalDependencies:
@@ -3368,6 +3618,16 @@ snapshots:
       mlly: 1.8.2
       rollup: 4.60.0
 
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   fs-extra@7.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -3383,7 +3643,27 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   glob-parent@5.1.2:
     dependencies:
@@ -3404,14 +3684,26 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphql@16.13.2: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hash.js@1.1.7:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
 
   headers-polyfill@4.0.3: {}
 
@@ -3420,6 +3712,13 @@ snapshots:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-id@4.1.3: {}
 
@@ -3442,6 +3741,8 @@ snapshots:
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
+
+  is-retry-allowed@2.2.0: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -3557,12 +3858,20 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  math-intrinsics@1.1.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   minimalistic-assert@1.0.1: {}
 
@@ -3731,6 +4040,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prettier@2.8.8: {}
+
+  proxy-from-env@2.1.0: {}
 
   quansync@0.2.11: {}
 
@@ -4078,5 +4389,7 @@ snapshots:
       yargs-parser: 21.1.1
 
   yoctocolors-cjs@2.1.3: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
       "@polymarket/client/actions": ["./packages/client/src/actions"],
       "@polymarket/client/decorators": ["./packages/client/src/decorators"],
       "@polymarket/client/ethers-v5": ["./packages/client/src/ethers-v5.ts"],
+      "@polymarket/client/openfort": ["./packages/client/src/openfort.ts"],
       "@polymarket/client/privy": ["./packages/client/src/privy.ts"],
       "@polymarket/client/viem": ["./packages/client/src/viem.ts"],
       "@polymarket/types": ["./packages/types/src"]


### PR DESCRIPTION
## Summary

Adds an `@polymarket/client/openfort` entrypoint that lets server-side applications sign and trade with Openfort EVM backend wallets, mirroring the existing Privy entrypoint.

- `packages/client/src/openfort.ts` exports `signerFrom(config: OpenfortWalletConfig): Signer` implementing the shared `Signer` contract (`getAddress`, `signTypedData`, `signMessage`, `sendTransaction`).
- Same structure as `privy.ts`: Node-only runtime guards, `SigningError` mapping at the signing boundary, and a direct transaction handle that waits for receipts via viem (`TimeoutError`, `TransactionFailedError`, `TransportError`).
- The backend wallet account is resolved once per signer and cached, with the cache dropped on failure so later calls retry. Signing methods come from the resolved `EvmAccount`, which hashes typed data and messages locally via viem and signs the digest through the Openfort backend wallet API, so key material stays in the wallet infrastructure.
- `sendTransaction` wraps the backend wallet in a viem local account and broadcasts directly (prepare, sign via Openfort, `eth_sendRawTransaction`). It deliberately does not use Openfort's `accounts.evm.backend.sendTransaction`, which is an EIP-7702 delegation + gas sponsorship flow that mutates the account on-chain and requires a policy. Direct submission matches the Privy entrypoint's semantics.
- `@openfort/openfort-node` added as an optional peer dependency (type-only import in the entrypoint, so there is no runtime dependency in the built output beyond the instance the caller passes in).
- New `./openfort` entry in `exports` / `typesVersions`, tsup node-platform entry, and root tsconfig path alias.
- Integration test `tests/integration/openfort.test.ts` mirrors `privy.test.ts` and skips unless `OPENFORT_TEST_SECRET_KEY`, `OPENFORT_TEST_WALLET_SECRET`, and `OPENFORT_TEST_ACCOUNT_ID` are set.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm build` all pass.
- `pnpm vitest run --project client`: 123 tests pass, no type errors.
- `pnpm vitest run --project client-integration packages/client/tests/integration/openfort.test.ts`: skips cleanly when `OPENFORT_TEST_*` env vars are unset.
- Verified the signer mapping against `@openfort/openfort-node@0.10.5` source: `EvmAccount.signTypedData`/`signMessage` hash locally with viem and sign via the backend wallet `sign` endpoint with v-normalization; `signTransaction` serializes, signs the digest, and reassembles the signed transaction.
- Smoke-tested the built `dist/openfort.js`: exports, signer shape, `SigningError` mapping, and retry-after-failed-resolution behavior.
- Built output contains no runtime import of `@openfort/openfort-node` (type-only), keeping the optional peer isolated to this entrypoint.

The integration test needs Openfort test credentials (funded test backend wallet) to run unskipped; not exercised in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new server-side signing and on-chain send path for trading, but it follows the existing Privy entrypoint pattern and is additive behind an optional peer dependency.
> 
> **Overview**
> Adds **`@polymarket/client/openfort`** so server apps can plug Openfort EVM backend wallets into the same **`Signer`** / **`createSecureClient`** flow as Privy. **`signerFrom`** resolves the backend account by `accountId` (cached, retried on failure), delegates **typed data**, **message**, and **transaction** signing to Openfort, and broadcasts via viem with a **direct** receipt-waiting handle (same error mapping as Privy).
> 
> Wires the new subpath through **package exports**, **tsup** node build, **tsconfig** paths, and an **optional** **`@openfort/openfort-node`** peer. Adds **integration tests** (auth + metered place/cancel) gated on **`OPENFORT_TEST_*`** env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53b6707b59193c846772b444bf0a12df5718813f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->