### PR TITLE
feat(bindings): expose parentEventId on Event

### DIFF
--- a/.changeset/event-parent-event-id.md
+++ b/.changeset/event-parent-event-id.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": minor
+"@polymarket/client": minor
+---
+
+Expose `parentEventId` on `Event` so child events such as sports "more markets" events link back to their parent event. The value is normalized to the same `EventId` type as `Event.id`.

--- a/packages/bindings/src/gamma/event.test.ts
+++ b/packages/bindings/src/gamma/event.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { EventSchema } from './event';
+
+describe('EventSchema', () => {
+  it('exposes parentEventId as a string event id', () => {
+    const event = EventSchema.parse({
+      id: '570555',
+      parentEventId: 570146,
+    });
+
+    expect(event.parentEventId).toBe('570146');
+  });
+
+  it('keeps parentEventId nullish when absent', () => {
+    expect(EventSchema.parse({ id: '570146' }).parentEventId).toBeUndefined();
+    expect(
+      EventSchema.parse({ id: '570146', parentEventId: null }).parentEventId,
+    ).toBeNull();
+  });
+});

--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -371,6 +371,7 @@ export type EventPartner = {
 
 export type Event = {
   id: EventId;
+  parentEventId?: EventId | null;
   ticker?: string | null;
   slug?: string | null;
   title?: string | null;
@@ -440,7 +441,7 @@ export const GammaEventSchema = z.object({
   volume1yr: DecimalishSchema.nullish(),
   featuredImage: z.string().nullish(),
   disqusThread: z.string().nullish(),
-  parentEventId: z.number().int().nullish(),
+  parentEventId: EventIdSchema.nullish(),
   enableOrderBook: z.boolean().nullish(),
   liquidityAmm: DecimalishSchema.nullish(),
   liquidityClob: DecimalishSchema.nullish(),
@@ -562,6 +563,7 @@ export type SportsMetadata = z.infer<typeof SportsMetadataSchema>;
 function normalizeEvent(event: GammaEvent): Event {
   return {
     id: event.id,
+    parentEventId: event.parentEventId,
     ticker: event.ticker,
     slug: event.slug,
     title: event.title,


### PR DESCRIPTION
## Summary

The wire schema already parsed `parentEventId` but `normalizeEvent` dropped it, so the public `Event` never exposed it. Sports "more markets" events carry this field as a link to their parent game event.

- `Event.parentEventId?: EventId | null`, top-level next to `id`.
- Wire value arrives as an integer while event ids are strings; it now goes through `EventIdSchema` so the value is the same branded `EventId` type as `Event.id` and feeds directly into `fetchEvent({ id: child.parentEventId })`.
- Mirrors py-sdk PR Polymarket/py-sdk#96 (same gap reported in Polymarket/py-sdk#93).

Not in scope: the `listEvents` `parentEventId` request filter still only accepts a number, same as the other ID filters (`ids`, `seriesIds`). Aligning the filter inputs with branded string IDs is a broader consistency change worth a separate pass.

## Verification

- `pnpm lint`, `pnpm build`, `pnpm typecheck` pass.
- `pnpm test:types`, `pnpm test:bindings` (15), `pnpm test:client` (123) pass.
- New bindings tests cover int-to-`EventId` normalization and absent/null defaults (the regression here was the normalizer silently dropping the field).
- Live smoke against the built client: `fetchEvent({ id: '570555' })` returns `parentEventId === '570146'`, round-trips via `fetchEvent({ id: child.parentEventId })`, and the parent's own `parentEventId` is undefined.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, read-only API surface on event parsing with targeted tests; no auth or write-path changes.
> 
> **Overview**
> **Exposes `parentEventId` on the public `Event` type** so child events (e.g. sports “more markets”) can reference their parent. The Gamma wire field was already parsed but **`normalizeEvent` now forwards it** instead of dropping it.
> 
> **`parentEventId` is typed and parsed as `EventId`**, matching `Event.id`: wire integers are normalized to string IDs via `EventIdSchema` (replacing a raw `number` on the schema). New bindings tests cover int→string normalization and absent/null handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1903b610430bf194ea4e92f5b26afe4629fd49d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->