### PR TITLE
docs: clarify secure client account binding

### DIFF
--- a/.changeset/secure-client-account-binding.md
+++ b/.changeset/secure-client-account-binding.md
@@ -1,0 +1,4 @@
+---
+---
+
+No version bump for SDK direction documentation clarifying `SecureClient` account binding.

--- a/docs/sdk-direction.md
+++ b/docs/sdk-direction.md
@@ -36,6 +36,8 @@ The SDK should hide internal service boundaries where possible while staying clo
 
 - Existing EOA, Poly Proxy, and Poly Safe wallets must continue to authenticate and trade.
 - Deposit Wallet is the current wallet setup direction. Existing EOA, Poly Proxy, and Poly Safe wallets must remain supported.
+- A `SecureClient` is architecturally bound to one Polymarket account, identified by the authenticated signer and selected account/funder wallet. The `wallet` option is not a per-action balance lookup address; it is the account wallet used for authentication, balances, order funding, and transaction execution.
+- Per-action APIs should not accept alternate wallet or user overrides that would make reads and execution target different accounts. Relayer API keys must match the same authenticated account binding; relayer submission failures for a signer/wallet pair should be treated as account configuration issues, not worked around with action-level wallet overrides.
 - `SecureClient.setupGaslessWallet` should treat Proxy-bound and Safe-bound clients as already gasless and preserve the existing wallet binding.
 - Do not make wallet migration implicit. Existing wallet-bound clients should remain usable as Deposit Wallet support evolves.
 


### PR DESCRIPTION
## Summary
- document that `SecureClient` is bound to one signer/account-wallet pair
- clarify that action-level wallet overrides should not split balance reads from transaction execution
- note that relayer keys must match the same account binding

## Verification
- `pnpm --config.engine-strict=false lint`
- `pnpm --config.engine-strict=false -r --sort --if-present run typecheck`

Note: local shell has Node v22.22.3 while the repo requires >=24, so checks were run with pnpm engine-strict disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Documents **`SecureClient` account binding** in `docs/sdk-direction.md` under **Wallet Direction**, plus a no-version-bump changeset entry.
> 
> **`SecureClient`** is defined as tied to one Polymarket account (authenticated signer + account/funder wallet). The **`wallet`** option is described as the account wallet for auth, balances, funding, and execution—not a per-action balance lookup.
> 
> Per-action APIs should not take alternate wallet/user overrides that split reads from execution. Relayer API keys must match that binding; relayer failures for a signer/wallet pair are account configuration issues, not something to fix with action-level wallet overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544ddd0a08b7eda6f1139569d656abf6eff52515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->