### PR TITLE
feat(rfq): support confirmed trade broadcasts

### DIFF
--- a/.changeset/calm-trades-broadcast.md
+++ b/.changeset/calm-trades-broadcast.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": minor
+"@polymarket/client": minor
+---
+
+Add confirmed combo trade broadcasts to RFQ quoter sessions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@
 - When you discover a real boundary inconsistency between underlying CLOB, Gamma, Data, and relayer APIs, append a concise note to `../api-gateway/docs/api-boundary-notes.md`.
 - Future work includes `@polymarket/react`, which should build on the same core model with a higher-level frontend-oriented surface.
 - Each action in `packages/client/src/actions/` has a corresponding bound method in a decorator under `packages/client/src/decorators/`. When you change an action — its signature, parameter types, TSDoc, or examples — verify the matching decorator method is also updated. The decorator method is the public surface most consumers see.
+- The `@polymarket/client` root entry point exports decorators, so new public client additions must be re-exported by the corresponding decorator module.
 - Do not leak `ky` details outside of `ServiceClient`. Keep `ky` instances, types, and option shapes internal, and expose Polymarket-specific abstractions instead.
 - Wallet-library integrations must stay isolated to their entry points and optional peer dependencies. If `viem` is an optional peer tied to the `viem` entry point, non-`viem` code paths must not import `viem`. Apply the same rule to future entry points for other wallet libraries such as Ethers, Privy, Safe SDK, or Turnkey.
 

--- a/packages/bindings/src/rfq.test.ts
+++ b/packages/bindings/src/rfq.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { RfqQuoterInboundMessageSchema } from './rfq';
+
+describe('RFQ quoter inbound messages', () => {
+  it('parses confirmed trade broadcasts without maker identity', () => {
+    const message = RfqQuoterInboundMessageSchema.parse({
+      type: 'RFQ_TRADE',
+      rfq_id: 'rfq-1',
+      requestor_public_id: 'req-1',
+      condition_id:
+        '0x032def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000',
+      leg_position_ids: ['1', '2'],
+      direction: 'BUY',
+      side: 'YES',
+      price_e6: '125000',
+      size_e6: '800000',
+      tx_hash:
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+      executed_at: 1_780_854_786_039,
+    });
+
+    expect(message).toMatchObject({
+      type: 'trade',
+      rfqId: 'rfq-1',
+      requestorPublicId: 'req-1',
+      price: '0.125',
+      size: '0.8',
+    });
+    expect(message).not.toHaveProperty('makerAddress');
+  });
+});

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -286,6 +286,7 @@ export enum RfqKnownInboundType {
   ConfirmationRequest = 'RFQ_CONFIRMATION_REQUEST',
   ConfirmationAck = 'ACK_RFQ_CONFIRMATION_RESPONSE',
   ExecutionUpdate = 'RFQ_EXECUTION_UPDATE',
+  Trade = 'RFQ_TRADE',
   Error = 'RFQ_ERROR',
 }
 
@@ -450,6 +451,34 @@ export const RfqExecutionUpdateSchema = RfqKnownInboundMessageSchema.extend({
 
 export type RfqExecutionUpdate = z.infer<typeof RfqExecutionUpdateSchema>;
 
+export const RfqTradeSchema = RfqKnownInboundMessageSchema.extend({
+  type: z.literal(RfqKnownInboundType.Trade),
+  rfq_id: RfqIdSchema,
+  requestor_public_id: RfqRequestorPublicIdSchema,
+  condition_id: ComboConditionIdSchema,
+  leg_position_ids: z.array(PositionIdSchema),
+  direction: RfqDirectionSchema,
+  side: RfqSideSchema,
+  price_e6: BigIntStringToDecimalStringSchema,
+  size_e6: BigIntStringToDecimalStringSchema,
+  tx_hash: TxHashSchema,
+  executed_at: EpochMillisecondsSchema,
+}).transform((message) => ({
+  conditionId: message.condition_id,
+  direction: message.direction,
+  executedAt: message.executed_at,
+  legPositionIds: message.leg_position_ids,
+  price: message.price_e6,
+  requestorPublicId: message.requestor_public_id,
+  rfqId: message.rfq_id,
+  side: message.side,
+  size: message.size_e6,
+  txHash: message.tx_hash,
+  type: 'trade' as const,
+}));
+
+export type RfqTrade = z.infer<typeof RfqTradeSchema>;
+
 export const RfqErrorMessageSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.Error),
   request_type: z.string().optional(),
@@ -477,6 +506,7 @@ export const RfqQuoterInboundMessageSchema = z.discriminatedUnion('type', [
   RfqConfirmationRequestSchema,
   RfqConfirmationAckSchema,
   RfqExecutionUpdateSchema,
+  RfqTradeSchema,
   RfqErrorMessageSchema,
 ]);
 

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -11,6 +11,7 @@ import type {
   RfqRequestedSize,
   RfqRequestorPublicId,
   RfqSide,
+  RfqTrade,
 } from '@polymarket/bindings/rfq';
 import { PolymarketError } from '@polymarket/types';
 import type { BaseSecureClient } from '../clients';
@@ -38,6 +39,7 @@ export type {
   RfqQuoteRequest,
   RfqRequestedSize,
   RfqRequestorPublicId,
+  RfqTrade,
 };
 
 /**
@@ -284,12 +286,18 @@ export interface RfqConfirmationRequestEvent extends RfqConfirmationRequest {
 export interface RfqExecutionUpdateEvent extends RfqExecutionUpdate {}
 
 /**
+ * Confirmed combo trade broadcast visible to all authenticated quoters.
+ */
+export interface RfqTradeEvent extends RfqTrade {}
+
+/**
  * Event emitted by an RFQ session.
  */
 export type RfqEvent =
   | RfqQuoteRequestEvent
   | RfqConfirmationRequestEvent
-  | RfqExecutionUpdateEvent;
+  | RfqExecutionUpdateEvent
+  | RfqTradeEvent;
 
 export interface RfqSession extends AsyncIterable<RfqEvent> {
   /**

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -20,6 +20,8 @@ export type {
   RfqRequestedSize,
   RfqRequestorPublicId,
   RfqSession,
+  RfqTrade,
+  RfqTradeEvent,
 } from '../actions/rfq';
 export {
   OpenRfqSessionError,

--- a/packages/client/src/websockets/rfq/events.ts
+++ b/packages/client/src/websockets/rfq/events.ts
@@ -8,6 +8,7 @@ import {
   type RfqId,
   type RfqQuoteId,
   type RfqQuoteRequest,
+  type RfqTrade,
 } from '@polymarket/bindings/rfq';
 import type {
   RfqCancelQuoteAck,
@@ -17,6 +18,7 @@ import type {
   RfqQuoteReference,
   RfqQuoteRequestEvent,
   RfqQuoteResponse,
+  RfqTradeEvent,
 } from '../../actions/rfq';
 
 export interface RfqEventController {
@@ -67,6 +69,10 @@ export function toConfirmationRequestEvent(
 export function toExecutionUpdateEvent(
   message: RfqExecutionUpdate,
 ): RfqExecutionUpdateEvent {
+  return message;
+}
+
+export function toTradeEvent(message: RfqTrade): RfqTradeEvent {
   return message;
 }
 

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -36,6 +36,7 @@ import {
   toQuoteAck,
   toQuoteCancelAck,
   toQuoteRequestEvent,
+  toTradeEvent,
 } from './events';
 import {
   createAuthMessage,
@@ -299,6 +300,9 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
         return;
       case 'execution_update':
         this.#queue.push(toExecutionUpdateEvent(message));
+        return;
+      case 'trade':
+        this.#queue.push(toTradeEvent(message));
         return;
       case 'rfq_error':
         this.#handleRfqError(message);

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -183,6 +183,27 @@ export function executionUpdateMessage() {
   return JSON.stringify(executionUpdateFrame());
 }
 
+function tradeFrame() {
+  return {
+    condition_id:
+      '0x032def24bfb0c5c57fb236fac08b94236a000000000000000000000000000000',
+    direction: 'BUY',
+    executed_at: 1_780_854_786_039,
+    leg_position_ids: ['1', '2'],
+    price_e6: '125000',
+    requestor_public_id: 'req-1',
+    rfq_id: RFQ_ID,
+    side: 'YES',
+    size_e6: '800000',
+    tx_hash: TX_HASH,
+    type: 'RFQ_TRADE',
+  };
+}
+
+export function tradeMessage() {
+  return JSON.stringify(tradeFrame());
+}
+
 function rfqErrorFrame(options: {
   code: string;
   error: string;

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -28,6 +28,7 @@ import {
   recordOutboundFrame,
   rfqErrorMessage,
   TX_HASH,
+  tradeMessage,
   unknownRfqMessage,
 } from './rfq-frames';
 
@@ -82,6 +83,7 @@ describe('RFQ sessions', () => {
               socket.send(confirmationAckMessage(decision));
               if (decision === 'CONFIRM') {
                 socket.send(executionUpdateMessage());
+                socket.send(tradeMessage());
               }
             }
           });
@@ -338,6 +340,44 @@ describe('RFQ sessions', () => {
             expect(event).toMatchObject({
               rfqId: RFQ_ID,
               status: 'CONFIRMED',
+              txHash: TX_HASH,
+            });
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+
+    it('yields confirmed trade broadcasts', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            await event.quote({ price: 0.45 });
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            await event.confirm();
+            continue;
+          }
+
+          if (event.type === 'trade') {
+            expect(event).toMatchObject({
+              direction: 'BUY',
+              legPositionIds: ['1', '2'],
+              price: '0.125',
+              requestorPublicId: 'req-1',
+              rfqId: RFQ_ID,
+              side: 'YES',
+              size: '0.8',
               txHash: TX_HASH,
             });
 


### PR DESCRIPTION
## Summary
- parse the new `RFQ_TRADE` quoter frame
- expose confirmed trades as typed `trade` events on `RfqSession`
- convert exact wire `price_e6` and `size_e6` strings into SDK decimal strings
- preserve `rfq_id` and pseudonymous `requestor_public_id`; no maker identity is exposed

## Verification
- `pnpm typecheck`
- `pnpm test:bindings -- --run` (20 tests)
- `pnpm test:client -- --run` (123 tests)
- focused WebSocket integration flow parsed successfully; credential-dependent integration tests remain environment-gated

Server implementation: Polymarket/combos-rfq#110

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive WebSocket message handling and public event types only; existing RFQ flows are unchanged aside from an extra event after confirmation.
> 
> **Overview**
> Adds support for **`RFQ_TRADE`** wire frames so authenticated RFQ quoters receive **confirmed combo trade broadcasts** on the same WebSocket session as quote and execution events.
> 
> **Bindings** parse `RFQ_TRADE` into a typed **`trade`** message: wire `price_e6` / `size_e6` become SDK decimal strings; fields include `rfqId`, pseudonymous `requestorPublicId`, legs, direction, side, `txHash`, and `executedAt`. **Maker identity is not included** on this broadcast shape.
> 
> **Client** extends `RfqEvent` with **`RfqTradeEvent`** (`event.type === 'trade'`) and enqueues those events from the quoter WebSocket handler. Public types are re-exported through actions and the RFQ decorator. Integration and schema tests cover parsing and the end-to-end confirm → execution update → trade flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749d590ff7e8e7f5b9529d29b3d13636b52da7c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->