### PR TITLE
feat(client): support protected market orders

### DIFF
--- a/.changeset/dev-277-protected-market-orders.md
+++ b/.changeset/dev-277-protected-market-orders.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Add `maxPrice` and `minPrice` protection fields to market order requests.

--- a/packages/client/src/actions/orders/market.test.ts
+++ b/packages/client/src/actions/orders/market.test.ts
@@ -1,36 +1,6 @@
-import { OrderSide, OrderType } from '@polymarket/bindings';
+import { OrderSide } from '@polymarket/bindings';
 import { describe, expect, it } from 'vitest';
-import {
-  adjustBuyAmountForFees,
-  computeMarketOrderAmounts,
-  PrepareMarketOrderParamsSchema,
-} from './market';
-
-describe('PrepareMarketOrderParamsSchema', () => {
-  it('accepts a max price on buy market orders', () => {
-    expect(
-      PrepareMarketOrderParamsSchema.safeParse({
-        amount: 100,
-        maxPrice: '0.55',
-        orderType: OrderType.FOK,
-        side: OrderSide.BUY,
-        tokenId: '123',
-      }).success,
-    ).toBe(true);
-  });
-
-  it('accepts a min price on sell market orders', () => {
-    expect(
-      PrepareMarketOrderParamsSchema.safeParse({
-        minPrice: '0.54',
-        orderType: OrderType.FAK,
-        shares: 180,
-        side: OrderSide.SELL,
-        tokenId: '123',
-      }).success,
-    ).toBe(true);
-  });
-});
+import { adjustBuyAmountForFees, computeMarketOrderAmounts } from './market';
 
 describe('computeMarketOrderAmounts', () => {
   it('encodes a buy max price as minimum shares received', () => {

--- a/packages/client/src/actions/orders/market.test.ts
+++ b/packages/client/src/actions/orders/market.test.ts
@@ -1,5 +1,68 @@
+import { OrderSide, OrderType } from '@polymarket/bindings';
 import { describe, expect, it } from 'vitest';
-import { adjustBuyAmountForFees } from './market';
+import {
+  adjustBuyAmountForFees,
+  computeMarketOrderAmounts,
+  PrepareMarketOrderParamsSchema,
+} from './market';
+
+describe('PrepareMarketOrderParamsSchema', () => {
+  it('accepts a max price on buy market orders', () => {
+    expect(
+      PrepareMarketOrderParamsSchema.safeParse({
+        amount: 100,
+        maxPrice: '0.55',
+        orderType: OrderType.FOK,
+        side: OrderSide.BUY,
+        tokenId: '123',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('accepts a min price on sell market orders', () => {
+    expect(
+      PrepareMarketOrderParamsSchema.safeParse({
+        minPrice: '0.54',
+        orderType: OrderType.FAK,
+        shares: 180,
+        side: OrderSide.SELL,
+        tokenId: '123',
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe('computeMarketOrderAmounts', () => {
+  it('encodes a buy max price as minimum shares received', () => {
+    expect(
+      computeMarketOrderAmounts({
+        amount: 100,
+        price: 0.55,
+        protectPrice: true,
+        side: OrderSide.BUY,
+        tickSize: 0.01,
+      }),
+    ).toEqual({
+      offeredAmount: 100_000_000n,
+      requestedAmount: 181_818_200n,
+    });
+  });
+
+  it('encodes a sell min price as minimum proceeds received', () => {
+    expect(
+      computeMarketOrderAmounts({
+        amount: 180,
+        price: 0.54,
+        protectPrice: true,
+        side: OrderSide.SELL,
+        tickSize: 0.01,
+      }),
+    ).toEqual({
+      offeredAmount: 180_000_000n,
+      requestedAmount: 97_200_000n,
+    });
+  });
+});
 
 describe('adjustBuyAmountForFees', () => {
   it('keeps the amount unchanged when max spend covers amount plus fees', () => {

--- a/packages/client/src/actions/orders/market.ts
+++ b/packages/client/src/actions/orders/market.ts
@@ -10,6 +10,7 @@ import {
 import type { EvmAddress } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseSecureClient } from '../../clients';
+import { UserInputError } from '../../errors';
 import {
   fetchBuilderFeeRates,
   fetchMarketInfo,
@@ -35,10 +36,12 @@ export const PrepareMarketOrderParamsSchema = z.discriminatedUnion('side', [
     side: z.literal(OrderSide.BUY),
     amount: PositiveDecimalNumberSchema,
     maxSpend: PositiveDecimalNumberSchema.optional(),
+    maxPrice: PositiveDecimalNumberSchema.optional(),
   }),
   BasePrepareMarketOrderParamsSchema.extend({
     side: z.literal(OrderSide.SELL),
     shares: PositiveDecimalNumberSchema,
+    minPrice: PositiveDecimalNumberSchema.optional(),
   }),
 ]) satisfies z.ZodType<PrepareMarketOrderRequest>;
 
@@ -54,6 +57,7 @@ export async function prepareMarketOrderDraft(
   const amounts = computeMarketOrderAmounts({
     amount: context.resolvedAmount,
     price: context.price,
+    protectPrice: hasProtectedPrice(params),
     side: params.side,
     tickSize: context.tickSize,
   });
@@ -101,13 +105,7 @@ async function resolveMarketOrderContext(
     tokenId: params.tokenId,
   });
   const amount = params.side === OrderSide.BUY ? params.amount : params.shares;
-  const price = await resolveEstimatedMarketPrice(client, {
-    amount,
-    orderType: params.orderType,
-    side: params.side,
-    tickSize,
-    tokenId: params.tokenId,
-  });
+  const price = await resolveMarketOrderPrice(client, params, amount, tickSize);
   const negRisk = await fetchNegRisk(client, {
     tokenId: params.tokenId,
   });
@@ -131,9 +129,62 @@ async function resolveMarketOrderContext(
   };
 }
 
-function computeMarketOrderAmounts(params: {
+async function resolveMarketOrderPrice(
+  client: BaseSecureClient,
+  params: PrepareMarketOrderDraftParams,
+  amount: number,
+  tickSize: TickSizeValue,
+): Promise<number> {
+  if (params.side === OrderSide.BUY && params.maxPrice !== undefined) {
+    return resolveProtectedMarketPrice(params.maxPrice, tickSize, 'maxPrice');
+  }
+
+  if (params.side === OrderSide.SELL && params.minPrice !== undefined) {
+    return resolveProtectedMarketPrice(params.minPrice, tickSize, 'minPrice');
+  }
+
+  return resolveEstimatedMarketPrice(client, {
+    amount,
+    orderType: params.orderType,
+    side: params.side,
+    tickSize,
+    tokenId: params.tokenId,
+  });
+}
+
+function resolveProtectedMarketPrice(
+  price: number,
+  tickSize: TickSizeValue,
+  field: 'maxPrice' | 'minPrice',
+): number {
+  const roundConfig = resolveRoundingConfig(tickSize);
+
+  if (price < tickSize || price > 1 - tickSize) {
+    throw new UserInputError(
+      `${field} must be between ${tickSize} and ${1 - tickSize} for tick size ${tickSize}.`,
+    );
+  }
+
+  if (decimalPlaces(price) > roundConfig.price) {
+    throw new UserInputError(
+      `${field} must conform to tick size ${tickSize} with at most ${roundConfig.price} decimal places.`,
+    );
+  }
+
+  return price;
+}
+
+function hasProtectedPrice(params: PrepareMarketOrderDraftParams): boolean {
+  return (
+    (params.side === OrderSide.BUY && params.maxPrice !== undefined) ||
+    (params.side === OrderSide.SELL && params.minPrice !== undefined)
+  );
+}
+
+export function computeMarketOrderAmounts(params: {
   amount: number;
   price: number;
+  protectPrice?: boolean;
   side: OrderSide;
   tickSize: TickSizeValue;
 }): {
@@ -151,7 +202,9 @@ function computeMarketOrderAmounts(params: {
       rawTakerAmount = roundUp(rawTakerAmount, roundConfig.amount + 4);
 
       if (decimalPlaces(rawTakerAmount) > roundConfig.amount) {
-        rawTakerAmount = roundDown(rawTakerAmount, roundConfig.amount);
+        rawTakerAmount = params.protectPrice
+          ? roundUp(rawTakerAmount, roundConfig.amount)
+          : roundDown(rawTakerAmount, roundConfig.amount);
       }
     }
 
@@ -167,7 +220,9 @@ function computeMarketOrderAmounts(params: {
     rawTakerAmount = roundUp(rawTakerAmount, roundConfig.amount + 4);
 
     if (decimalPlaces(rawTakerAmount) > roundConfig.amount) {
-      rawTakerAmount = roundDown(rawTakerAmount, roundConfig.amount);
+      rawTakerAmount = params.protectPrice
+        ? roundUp(rawTakerAmount, roundConfig.amount)
+        : roundDown(rawTakerAmount, roundConfig.amount);
     }
   }
 

--- a/packages/client/src/actions/orders/prepare.ts
+++ b/packages/client/src/actions/orders/prepare.ts
@@ -61,6 +61,7 @@ export const PrepareMarketOrderError = makeErrorGuard(
  * ```ts
  * const workflow = await prepareMarketOrder(client, {
  *   amount: 10,
+ *   maxPrice: '0.55',
  *   side: OrderSide.BUY,
  *   tokenId: '123',
  * });
@@ -163,8 +164,9 @@ export const PrepareMarketOrderPostingError = PrepareMarketOrderError;
  * @example
  * ```ts
  * const workflow = await prepareMarketOrderPosting(client, {
- *   amount: 10,
- *   side: OrderSide.BUY,
+ *   minPrice: '0.54',
+ *   shares: 10,
+ *   side: OrderSide.SELL,
  *   tokenId: '123',
  * });
  * ```

--- a/packages/client/src/actions/orders/trade.ts
+++ b/packages/client/src/actions/orders/trade.ts
@@ -56,6 +56,16 @@ export const CreateMarketOrderError = makeErrorGuard(
  *
  * @throws {@link CreateMarketOrderError}
  * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const order = await createMarketOrder(client, {
+ *   amount: '100',
+ *   maxPrice: '0.55',
+ *   side: OrderSide.BUY,
+ *   tokenId: '123',
+ * });
+ * ```
  */
 export function createMarketOrder(
   client: BaseSecureClient,
@@ -90,6 +100,16 @@ export const PlaceMarketOrderError = makeErrorGuard(
  *
  * @throws {@link PlaceMarketOrderError}
  * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const response = await placeMarketOrder(client, {
+ *   minPrice: '0.54',
+ *   shares: '180',
+ *   side: OrderSide.SELL,
+ *   tokenId: '123',
+ * });
+ * ```
  */
 export function placeMarketOrder(
   client: BaseSecureClient,

--- a/packages/client/src/actions/orders/types.ts
+++ b/packages/client/src/actions/orders/types.ts
@@ -57,6 +57,16 @@ export type PrepareMarketBuyOrderRequest = BasePrepareMarketOrderRequest & {
    * fees. Leave it unset to pay fees on top of `amount`.
    */
   maxSpend?: number | string;
+
+  /**
+   * Highest acceptable price per share for the BUY.
+   *
+   * The order may only fill at this price or better. For FOK, the full
+   * `amount` must fill within this bound or the order is killed. For FAK, any
+   * immediately available liquidity within this bound fills and the remainder
+   * is canceled.
+   */
+  maxPrice?: number | string;
 };
 
 export type PrepareMarketSellOrderRequest = BasePrepareMarketOrderRequest & {
@@ -70,6 +80,16 @@ export type PrepareMarketSellOrderRequest = BasePrepareMarketOrderRequest & {
    * 6-decimal base unit.
    */
   shares: number | string;
+
+  /**
+   * Lowest acceptable price per share for the SELL.
+   *
+   * The order may only fill at this price or better. For FOK, all `shares`
+   * must fill within this bound or the order is killed. For FAK, any
+   * immediately available liquidity within this bound fills and the remainder
+   * is canceled.
+   */
+  minPrice?: number | string;
 };
 
 export type PrepareMarketOrderRequest =

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -37,7 +37,16 @@ export type SecureTradingActions = {
    * @throws {@link CreateMarketOrderError}
    * Thrown on failure.
    *
-   * @example
+   * @example Basic market buy
+   * ```ts
+   * const order = await client.createMarketOrder({
+   *   amount: 10,
+   *   side: OrderSide.BUY,
+   *   tokenId: '123',
+   * });
+   * ```
+   *
+   * @example Protected market buy
    * ```ts
    * const order = await client.createMarketOrder({
    *   amount: 10,
@@ -54,7 +63,18 @@ export type SecureTradingActions = {
    * @throws {@link PlaceMarketOrderError}
    * Thrown on failure.
    *
-   * @example
+   * @example Basic market buy
+   * ```ts
+   * const response = await client.placeMarketOrder({
+   *   amount: 10,
+   *   side: OrderSide.BUY,
+   *   tokenId: '123',
+   * });
+   *
+   * // response: OrderResponse
+   * ```
+   *
+   * @example Protected market sell
    * ```ts
    * const response = await client.placeMarketOrder({
    *   minPrice: '0.54',

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -41,6 +41,7 @@ export type SecureTradingActions = {
    * ```ts
    * const order = await client.createMarketOrder({
    *   amount: 10,
+   *   maxPrice: '0.55',
    *   side: OrderSide.BUY,
    *   tokenId: '123',
    * });
@@ -56,8 +57,9 @@ export type SecureTradingActions = {
    * @example
    * ```ts
    * const response = await client.placeMarketOrder({
-   *   amount: 10,
-   *   side: OrderSide.BUY,
+   *   minPrice: '0.54',
+   *   shares: 10,
+   *   side: OrderSide.SELL,
    *   tokenId: '123',
    * });
    *


### PR DESCRIPTION
## Summary
- add BUY `maxPrice` and SELL `minPrice` protection to market order requests
- use explicit protected prices without fetching the order book for a quote
- preserve protected price bounds when rounding market-order amounts

## Linear
- DEV-277

## Testing
- `PATH="/Users/brainjammer/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm test:client packages/client/src/actions/orders/market.test.ts`
- `PATH="/Users/brainjammer/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm lint`
- `PATH="/Users/brainjammer/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm typecheck`
- `PATH="/Users/brainjammer/.nvm/versions/node/v24.14.0/bin:$PATH" pnpm test:client`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how market orders are priced and how maker/taker amounts are rounded when protection is enabled, which directly affects signed order economics; behavior is additive and validated but mistakes in rounding could weaken price guarantees.
> 
> **Overview**
> Market orders can now cap execution price with optional **`maxPrice`** on buys and **`minPrice`** on sells, so fills only occur at that price or better (FOK/FAK behavior unchanged at the API level).
> 
> When either field is set, the SDK **skips the order-book estimate** and uses the supplied price after tick-size and range validation (`UserInputError` if invalid). **`computeMarketOrderAmounts`** gains a `protectPrice` mode that **rounds up** the derived leg (minimum shares received on buy, minimum proceeds on sell) instead of rounding down, so the signed order still enforces the protection bound after decimal rounding.
> 
> Request schemas, public types, JSDoc examples, and unit tests cover the new encoding behavior; patch changeset for `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06a1ee9b67a190279a33dfbef3aa0c752f6d812e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->