### PR TITLE
fix(client): split rejected RPC batches

### DIFF
--- a/.changeset/rpc-batch-split-retry.md
+++ b/.changeset/rpc-batch-split-retry.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Retry rejected JSON-RPC `eth_call` batches by recursively splitting them into smaller batches.

--- a/packages/client/src/rpc.test.ts
+++ b/packages/client/src/rpc.test.ts
@@ -79,6 +79,50 @@ describe('JsonRpcClient', () => {
     ).resolves.toEqual(['0xaaaa', '0xbbbb']);
   });
 
+  it('recovers failed eth_call batches while preserving result order', async () => {
+    const to = expectEvmAddress('0x0000000000000000000000000000000000000001');
+    let requestCount = 0;
+
+    server.use(
+      http.post(root, async ({ request }) => {
+        requestCount += 1;
+
+        const body = (await request.json()) as
+          | {
+              id: number;
+              params: [{ data: string }];
+            }
+          | unknown[];
+
+        if (Array.isArray(body)) {
+          return new HttpResponse(null, { status: 500 });
+        }
+
+        return HttpResponse.json({
+          jsonrpc: '2.0',
+          id: body.id,
+          result: body.params[0].data,
+        });
+      }),
+    );
+    const client = new JsonRpcClient({ url: root });
+
+    await expect(
+      client.ethCallBatch([
+        { to, data: '0x11111111' },
+        { to, data: '0x22222222' },
+        { to, data: '0x33333333' },
+        { to, data: '0x44444444' },
+      ]),
+    ).resolves.toEqual([
+      '0x11111111',
+      '0x22222222',
+      '0x33333333',
+      '0x44444444',
+    ]);
+    expect(requestCount).toBe(7);
+  });
+
   it('wraps JSON-RPC errors as rejected requests', async () => {
     const to = expectEvmAddress('0x0000000000000000000000000000000000000001');
     server.use(

--- a/packages/client/src/rpc.ts
+++ b/packages/client/src/rpc.ts
@@ -80,6 +80,36 @@ export class JsonRpcClient {
       return [];
     }
 
+    return this.#ethCallBatchWithSplit(requests);
+  }
+
+  async #ethCallBatchWithSplit(
+    requests: readonly EthCallRequest[],
+  ): Promise<HexString[]> {
+    if (requests.length === 1) {
+      return [await this.ethCall(requests[0] as EthCallRequest)];
+    }
+
+    try {
+      return await this.#postEthCallBatch(requests);
+    } catch (error) {
+      if (!(error instanceof RequestRejectedError) || error.status < 500) {
+        throw error;
+      }
+
+      const midpoint = Math.ceil(requests.length / 2);
+      const [left, right] = await Promise.all([
+        this.#ethCallBatchWithSplit(requests.slice(0, midpoint)),
+        this.#ethCallBatchWithSplit(requests.slice(midpoint)),
+      ]);
+
+      return [...left, ...right];
+    }
+  }
+
+  async #postEthCallBatch(
+    requests: readonly EthCallRequest[],
+  ): Promise<HexString[]> {
     const responses = await this.#postBatch<HexString>(
       requests.map((request, index) => ({
         jsonrpc: '2.0',


### PR DESCRIPTION
## Summary
- Retry rejected JSON-RPC `eth_call` batches by recursively splitting them into parallel half-size batches.
- Fall back to a normal single `ethCall` when splitting reaches one request.
- Preserve result ordering across split retries.

## Verification
- `pnpm vitest --project client packages/client/src/rpc.test.ts --run`
- `pnpm vitest --project client-integration packages/client/tests/integration/approvals.test.ts --run -t "submits a combined trading-setup approval workflow"`
- `pnpm lint`
- `pnpm typecheck`

Also attempted the full client integration suite; it did not complete cleanly because live services returned rate limits, geoblock responses, and request timeouts unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to client RPC batching; only triggers extra parallel requests after server-side batch failures (5xx), with no auth or data-model changes.
> 
> **Overview**
> **`ethCallBatch`** now retries when the JSON-RPC provider rejects a **batch** HTTP request with a **5xx** status, instead of failing the whole call set.
> 
> On that failure, the client **splits the batch in half**, retries both halves **in parallel** via `#ethCallBatchWithSplit`, and **concatenates** results so callers (e.g. approval checks) still see the same **index order**. A batch of one **falls back** to a normal single **`ethCall`**. Non-**`RequestRejectedError`** failures and rejections with **status &lt; 500** are **unchanged**—they still propagate immediately.
> 
> A new unit test simulates **500** on array batch POSTs while single-call POSTs succeed, and asserts ordered results plus the expected number of HTTP round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41ec200477627131fde20c721d5a240082bc1f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->