### PR TITLE
fix: update brace-expansion lockfile entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1167,8 +1167,8 @@ packages:
   bn.js@5.2.3:
     resolution: {integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3139,7 +3139,7 @@ snapshots:
 
   bn.js@5.2.3: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3570,7 +3570,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minipass@7.1.3: {}
 


### PR DESCRIPTION
Updates the lockfile to resolve GHSA-jxxr-4gwj-5jf2 / CVE-2026-45149 for `brace-expansion`.

`brace-expansion` is pulled in through dev tooling only:

```text
rimraf -> glob -> minimatch -> brace-expansion
```

This is not part of the published SDK runtime dependency graph, so SDK consumers are not exposed through `@polymarket/client`. The practical risk is limited to maintainer/dev-tooling usage where an attacker can control brace-expansion input.

I kept this intentionally lockfile-only:

- `brace-expansion` `5.0.5` -> `5.0.6`
- no package manifest changes
- no broader dependency refresh

Verification:

- `pnpm install --frozen-lockfile`
- OSV no longer reports `brace-expansion`
- `pnpm lint`
- `pnpm typecheck`
