### PR TITLE
feat(rfq): expose RFQ error IDs

### DIFF
--- a/.changeset/rfq-error-id.md
+++ b/.changeset/rfq-error-id.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Expose RFQ error identifiers and signature-validation error codes to quoter clients.

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -82,6 +82,8 @@ export enum RfqErrorCode {
   InvalidRfq = 'INVALID_RFQ',
   InvalidRfqState = 'INVALID_RFQ_STATE',
   InvalidRole = 'INVALID_ROLE',
+  InvalidSignature = 'INVALID_SIGNATURE',
+  InternalError = 'INTERNAL_ERROR',
   LegMetadataUnavailable = 'LEG_METADATA_UNAVAILABLE',
   MakerAlreadyResponded = 'MAKER_ALREADY_RESPONDED',
   MakerNotRequired = 'MAKER_NOT_REQUIRED',
@@ -438,6 +440,7 @@ export type RfqExecutionUpdate = z.infer<typeof RfqExecutionUpdateSchema>;
 
 export const RfqErrorMessageSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.Error),
+  error_id: z.string().optional(),
   request_type: z.string().optional(),
   rfq_id: RfqIdSchema.optional(),
   quote_id: RfqQuoteIdSchema.optional(),
@@ -446,6 +449,7 @@ export const RfqErrorMessageSchema = RfqKnownInboundMessageSchema.extend({
   request: z.unknown().optional(),
 }).transform((message) => ({
   code: message.code,
+  errorId: message.error_id,
   message: message.error,
   quoteId: message.quote_id,
   requestType: message.request_type,

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -92,6 +92,8 @@ export type RfqQuoteResponse = {
 export type RfqQuoteRejectedErrorOptions = {
   /** RFQ error code for the rejected quote. */
   code?: RfqErrorCode;
+  /** Error identifier for the rejected quote. */
+  errorId?: string;
   /** RFQ identifier for the rejected quote. */
   rfqId: RfqId;
 };
@@ -103,6 +105,7 @@ export class RfqQuoteRejectedError extends PolymarketError {
   override name = 'RfqQuoteRejectedError' as const;
 
   readonly code: RfqErrorCode | undefined;
+  readonly errorId: string | undefined;
   readonly rfqId: RfqId;
 
   constructor(
@@ -111,6 +114,7 @@ export class RfqQuoteRejectedError extends PolymarketError {
   ) {
     super(message, options);
     this.code = options.code;
+    this.errorId = options.errorId;
     this.rfqId = options.rfqId;
   }
 }
@@ -132,6 +136,8 @@ export const RfqQuoteError = makeErrorGuard(
 export type RfqCancelQuoteRejectedErrorOptions = {
   /** RFQ error code for the rejected cancellation request. */
   code?: RfqErrorCode;
+  /** Error identifier for the rejected cancellation request. */
+  errorId?: string;
   /** RFQ identifier for the cancellation request. */
   rfqId: RfqId;
   /** Quote identifier for the cancellation request. */
@@ -145,6 +151,7 @@ export class RfqCancelQuoteRejectedError extends PolymarketError {
   override name = 'RfqCancelQuoteRejectedError' as const;
 
   readonly code: RfqErrorCode | undefined;
+  readonly errorId: string | undefined;
   readonly rfqId: RfqId;
   readonly quoteId: RfqQuoteId;
 
@@ -154,6 +161,7 @@ export class RfqCancelQuoteRejectedError extends PolymarketError {
   ) {
     super(message, options);
     this.code = options.code;
+    this.errorId = options.errorId;
     this.rfqId = options.rfqId;
     this.quoteId = options.quoteId;
   }
@@ -172,6 +180,8 @@ export const RfqCancelQuoteError = makeErrorGuard(
 export type RfqConfirmationRejectedErrorOptions = {
   /** RFQ error code for the rejected confirmation decision. */
   code?: RfqErrorCode;
+  /** Error identifier for the rejected confirmation decision. */
+  errorId?: string;
   /** RFQ identifier for the rejected confirmation decision. */
   rfqId: RfqId;
   /** Quote identifier for the rejected confirmation decision. */
@@ -185,6 +195,7 @@ export class RfqConfirmationRejectedError extends PolymarketError {
   override name = 'RfqConfirmationRejectedError' as const;
 
   readonly code: RfqErrorCode | undefined;
+  readonly errorId: string | undefined;
   readonly rfqId: RfqId;
   readonly quoteId: RfqQuoteId;
 
@@ -194,6 +205,7 @@ export class RfqConfirmationRejectedError extends PolymarketError {
   ) {
     super(message, options);
     this.code = options.code;
+    this.errorId = options.errorId;
     this.rfqId = options.rfqId;
     this.quoteId = options.quoteId;
   }

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -334,6 +334,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
         quoteAckKey(message.rfqId),
         new RfqQuoteRejectedError(message.message, {
           code: message.code,
+          errorId: message.errorId,
           rfqId: message.rfqId,
         }),
       );
@@ -350,6 +351,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
         quoteCancelAckKey(message.rfqId, message.quoteId),
         new RfqCancelQuoteRejectedError(message.message, {
           code: message.code,
+          errorId: message.errorId,
           quoteId: message.quoteId,
           rfqId: message.rfqId,
         }),
@@ -367,6 +369,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
         confirmationAckKey(message.rfqId, message.quoteId),
         new RfqConfirmationRejectedError(message.message, {
           code: message.code,
+          errorId: message.errorId,
           quoteId: message.quoteId,
           rfqId: message.rfqId,
         }),

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -185,6 +185,7 @@ export function executionUpdateMessage() {
 
 function rfqErrorFrame(options: {
   code: string;
+  errorId?: string;
   error: string;
   quoteId?: string;
   requestType: string;
@@ -192,6 +193,7 @@ function rfqErrorFrame(options: {
 }) {
   return {
     code: options.code,
+    error_id: options.errorId,
     error: options.error,
     quote_id: options.quoteId,
     request_type: options.requestType,
@@ -202,6 +204,7 @@ function rfqErrorFrame(options: {
 
 export function rfqErrorMessage(options: {
   code: string;
+  errorId?: string;
   error: string;
   quoteId?: string;
   requestType: string;

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -627,6 +627,7 @@ describe('RFQ sessions', () => {
               socket.send(
                 rfqErrorMessage({
                   code: 'SUBMISSION_WINDOW_CLOSED',
+                  errorId: 'reqerr-1',
                   error: 'submission window closed',
                   requestType: 'RFQ_QUOTE',
                   rfqId: RFQ_ID,
@@ -650,6 +651,7 @@ describe('RFQ sessions', () => {
 
             await expect(quote).rejects.toMatchObject({
               code: 'SUBMISSION_WINDOW_CLOSED',
+              errorId: 'reqerr-1',
               message: 'submission window closed',
               name: 'RfqQuoteRejectedError',
               rfqId: event.rfqId,


### PR DESCRIPTION
## Summary
- Parse RFQ error_id payloads.
- Expose errorId on RFQ rejection errors.
- Recognize INVALID_SIGNATURE and INTERNAL_ERROR.

## Validation
- pnpm lint
- pnpm build
- pnpm typecheck
- pnpm test:bindings
- pnpm test:client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, backward-compatible wire and TypeScript fields with no change to RFQ trading or signing behavior.
> 
> **Overview**
> RFQ quoter clients can now read server-issued **error identifiers** when quote, cancel, or confirmation requests are rejected.
> 
> Inbound `RFQ_ERROR` frames optionally carry `error_id`, which bindings parse as `errorId` and the quoter passes through on `RfqQuoteRejectedError`, `RfqCancelQuoteRejectedError`, and `RfqConfirmationRejectedError`. **`INVALID_SIGNATURE`** and **`INTERNAL_ERROR`** are added to `RfqErrorCode` so typed handling matches the backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30aef9d3a47958f3c6e54366f77df82e8d801bc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->