### PR TITLE
feat(rfq): expose confirmed trade broadcasts

### DIFF
--- a/.changeset/calm-trades-broadcast.md
+++ b/.changeset/calm-trades-broadcast.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": minor
+"@polymarket/client": minor
+---
+
+Add confirmed combo trade broadcasts to RFQ quoter sessions.

--- a/packages/bindings/src/rfq.test.ts
+++ b/packages/bindings/src/rfq.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { RfqQuoterInboundMessageSchema } from './rfq';
+
+describe('RFQ quoter inbound messages', () => {
+  it('parses confirmed trade broadcasts without maker identity', () => {
+    const message = RfqQuoterInboundMessageSchema.parse({
+      type: 'RFQ_TRADE',
+      rfq_id: 'rfq-1',
+      requester_id: 'req-1',
+      condition_id:
+        '0x032def24bfb0c5c57fb236fac08b94236a0000000000000000000000000000',
+      leg_position_ids: ['1', '2'],
+      direction: 'BUY',
+      side: 'YES',
+      price_e6: '125000',
+      size_e6: '800000',
+      executed_at: 1_780_854_786_039,
+    });
+
+    expect(message).toMatchObject({
+      type: 'trade',
+      rfqId: 'rfq-1',
+      requesterId: 'req-1',
+      price: '0.125',
+      size: '0.8',
+    });
+    expect(message).not.toHaveProperty('makerAddress');
+    expect(message).not.toHaveProperty('txHash');
+  });
+});

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -272,6 +272,7 @@ export enum RfqKnownInboundType {
   ConfirmationRequest = 'RFQ_CONFIRMATION_REQUEST',
   ConfirmationAck = 'ACK_RFQ_CONFIRMATION_RESPONSE',
   ExecutionUpdate = 'RFQ_EXECUTION_UPDATE',
+  Trade = 'RFQ_TRADE',
   Error = 'RFQ_ERROR',
 }
 
@@ -436,6 +437,32 @@ export const RfqExecutionUpdateSchema = RfqKnownInboundMessageSchema.extend({
 
 export type RfqExecutionUpdate = z.infer<typeof RfqExecutionUpdateSchema>;
 
+export const RfqTradeSchema = RfqKnownInboundMessageSchema.extend({
+  type: z.literal(RfqKnownInboundType.Trade),
+  rfq_id: RfqIdSchema,
+  requester_id: RfqRequestorPublicIdSchema,
+  condition_id: ComboConditionIdSchema,
+  leg_position_ids: z.array(PositionIdSchema),
+  direction: RfqDirectionSchema,
+  side: RfqSideSchema,
+  price_e6: E6BigIntStringToDecimalStringSchema,
+  size_e6: E6BigIntStringToDecimalStringSchema,
+  executed_at: EpochMillisecondsSchema,
+}).transform((message) => ({
+  conditionId: message.condition_id,
+  direction: message.direction,
+  executedAt: message.executed_at,
+  legPositionIds: message.leg_position_ids,
+  price: message.price_e6,
+  requesterId: message.requester_id,
+  rfqId: message.rfq_id,
+  side: message.side,
+  size: message.size_e6,
+  type: 'trade' as const,
+}));
+
+export type RfqTrade = z.infer<typeof RfqTradeSchema>;
+
 export const RfqErrorMessageSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.Error),
   request_type: z.string().optional(),
@@ -463,6 +490,7 @@ export const RfqQuoterInboundMessageSchema = z.discriminatedUnion('type', [
   RfqConfirmationRequestSchema,
   RfqConfirmationAckSchema,
   RfqExecutionUpdateSchema,
+  RfqTradeSchema,
   RfqErrorMessageSchema,
 ]);
 

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -11,6 +11,7 @@ import type {
   RfqRequestedSize,
   RfqRequestorPublicId,
   RfqSide,
+  RfqTrade,
 } from '@polymarket/bindings/rfq';
 import { PolymarketError } from '@polymarket/types';
 import type { BaseSecureClient } from '../clients';
@@ -38,6 +39,7 @@ export type {
   RfqQuoteRequest,
   RfqRequestedSize,
   RfqRequestorPublicId,
+  RfqTrade,
 };
 
 /**
@@ -284,12 +286,18 @@ export interface RfqConfirmationRequestEvent extends RfqConfirmationRequest {
 export interface RfqExecutionUpdateEvent extends RfqExecutionUpdate {}
 
 /**
+ * Confirmed combo trade broadcast visible to all authenticated quoters.
+ */
+export interface RfqTradeEvent extends RfqTrade {}
+
+/**
  * Event emitted by an RFQ session.
  */
 export type RfqEvent =
   | RfqQuoteRequestEvent
   | RfqConfirmationRequestEvent
-  | RfqExecutionUpdateEvent;
+  | RfqExecutionUpdateEvent
+  | RfqTradeEvent;
 
 export interface RfqSession extends AsyncIterable<RfqEvent> {
   /**

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -20,6 +20,8 @@ export type {
   RfqRequestedSize,
   RfqRequestorPublicId,
   RfqSession,
+  RfqTrade,
+  RfqTradeEvent,
 } from '../actions/rfq';
 export {
   OpenRfqSessionError,

--- a/packages/client/src/websockets/rfq/events.ts
+++ b/packages/client/src/websockets/rfq/events.ts
@@ -8,6 +8,7 @@ import {
   type RfqId,
   type RfqQuoteId,
   type RfqQuoteRequest,
+  type RfqTrade,
 } from '@polymarket/bindings/rfq';
 import type {
   RfqCancelQuoteAck,
@@ -17,6 +18,7 @@ import type {
   RfqQuoteReference,
   RfqQuoteRequestEvent,
   RfqQuoteResponse,
+  RfqTradeEvent,
 } from '../../actions/rfq';
 
 export interface RfqEventController {
@@ -67,6 +69,10 @@ export function toConfirmationRequestEvent(
 export function toExecutionUpdateEvent(
   message: RfqExecutionUpdate,
 ): RfqExecutionUpdateEvent {
+  return message;
+}
+
+export function toTradeEvent(message: RfqTrade): RfqTradeEvent {
   return message;
 }
 

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -36,6 +36,7 @@ import {
   toQuoteAck,
   toQuoteCancelAck,
   toQuoteRequestEvent,
+  toTradeEvent,
 } from './events';
 import {
   createAuthMessage,
@@ -299,6 +300,9 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
         return;
       case 'execution_update':
         this.#queue.push(toExecutionUpdateEvent(message));
+        return;
+      case 'trade':
+        this.#queue.push(toTradeEvent(message));
         return;
       case 'rfq_error':
         this.#handleRfqError(message);

--- a/packages/client/tests/integration/rfq-frames.ts
+++ b/packages/client/tests/integration/rfq-frames.ts
@@ -183,6 +183,26 @@ export function executionUpdateMessage() {
   return JSON.stringify(executionUpdateFrame());
 }
 
+function tradeFrame() {
+  return {
+    condition_id:
+      '0x032def24bfb0c5c57fb236fac08b94236a000000000000000000000000000000',
+    direction: 'BUY',
+    executed_at: 1_780_854_786_039,
+    leg_position_ids: ['1', '2'],
+    price_e6: '125000',
+    requester_id: 'req-1',
+    rfq_id: RFQ_ID,
+    side: 'YES',
+    size_e6: '800000',
+    type: 'RFQ_TRADE',
+  };
+}
+
+export function tradeMessage() {
+  return JSON.stringify(tradeFrame());
+}
+
 function rfqErrorFrame(options: {
   code: string;
   error: string;

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -28,6 +28,7 @@ import {
   recordOutboundFrame,
   rfqErrorMessage,
   TX_HASH,
+  tradeMessage,
   unknownRfqMessage,
 } from './rfq-frames';
 
@@ -82,6 +83,7 @@ describe('RFQ sessions', () => {
               socket.send(confirmationAckMessage(decision));
               if (decision === 'CONFIRM') {
                 socket.send(executionUpdateMessage());
+                socket.send(tradeMessage());
               }
             }
           });
@@ -340,6 +342,44 @@ describe('RFQ sessions', () => {
               status: 'CONFIRMED',
               txHash: TX_HASH,
             });
+
+            await session.close();
+            break;
+          }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+
+    it('yields confirmed trade broadcasts', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+
+      try {
+        for await (const event of session) {
+          if (event.type === 'quote_request') {
+            await event.quote({ price: 0.45 });
+            continue;
+          }
+
+          if (event.type === 'confirmation_request') {
+            await event.confirm();
+            continue;
+          }
+
+          if (event.type === 'trade') {
+            expect(event).toMatchObject({
+              direction: 'BUY',
+              legPositionIds: ['1', '2'],
+              price: '0.125',
+              requesterId: 'req-1',
+              rfqId: RFQ_ID,
+              side: 'YES',
+              size: '0.8',
+            });
+            expect(event).not.toHaveProperty('txHash');
 
             await session.close();
             break;


### PR DESCRIPTION
## Summary
- expose confirmed public `RFQ_TRADE` websocket frames as typed `RfqTradeEvent` session events
- use the finalized public wire contract: `requester_id`, combo `condition_id`, legs, direction, side, price, size, and execution timestamp
- intentionally omit the settlement transaction hash from public trade events; participating makers retain it on private `RFQ_EXECUTION_UPDATE` messages

## Scope
- implemented directly from `main`, independently of Cesare's reverted branch and commits
- follows the existing bindings schema, action/decorator export, websocket dispatch, and integration-test patterns
- pairs with https://github.com/Polymarket/combos-rfq/pull/110

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:bindings -- --run` (20 tests)
- `pnpm test:client -- --run` (127 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive minor-version API and websocket handling aligned with existing RFQ message patterns; no changes to auth, signing, or settlement paths.
> 
> **Overview**
> RFQ quoter sessions now surface **`RFQ_TRADE`** websocket frames as typed **`trade`** events on the existing `RfqEvent` stream, so authenticated quoters can observe confirmed combo fills without parsing raw messages.
> 
> **Bindings** add `RfqTradeSchema` for the public wire shape (`requester_id`, combo `condition_id`, legs, direction, side, e6 price/size, `executed_at`) and map it to camelCase `type: 'trade'`. **`tx_hash` and maker identity are not part of this event**—those stay on private `RFQ_EXECUTION_UPDATE` for participating makers.
> 
> The **client** exports `RfqTrade` / `RfqTradeEvent`, enqueues trade events from the quoter websocket handler (same pattern as `execution_update`), and adds unit plus integration coverage for parsing and end-to-end session delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c76b5aaba07f3a2011bff6723fcce4da993ae2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->