### PR TITLE
feat(client): fork environment configs

### DIFF
--- a/.changeset/fork-environment-configs.md
+++ b/.changeset/fork-environment-configs.md
@@ -1,5 +1,2 @@
 ---
-'@polymarket/client': minor
 ---
-
-Refactor environment configuration into REST and websocket endpoint objects with optional headers. Add support for deriving custom environments from production, keep `preproduction` as a production fork, and move deployed protocol addresses under `environment.contracts` while keeping `walletDerivation` top-level.

--- a/.changeset/fork-environment-configs.md
+++ b/.changeset/fork-environment-configs.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/client': minor
+---
+
+Refactor environment configuration into REST and websocket endpoint objects with optional headers. Add `forkEnvironmentConfig` for deriving custom environments from production, export `staging`, and move deployed protocol addresses under `environment.contracts` while keeping `walletDerivation` top-level.

--- a/.changeset/fork-environment-configs.md
+++ b/.changeset/fork-environment-configs.md
@@ -2,4 +2,4 @@
 '@polymarket/client': minor
 ---
 
-Refactor environment configuration into REST and websocket endpoint objects with optional headers. Add `forkEnvironmentConfig` for deriving custom environments from production, export `staging`, and move deployed protocol addresses under `environment.contracts` while keeping `walletDerivation` top-level.
+Refactor environment configuration into REST and websocket endpoint objects with optional headers. Add `forkEnvironmentConfig` for deriving custom environments from production, keep `preproduction` as a production fork, and move deployed protocol addresses under `environment.contracts` while keeping `walletDerivation` top-level.

--- a/.changeset/fork-environment-configs.md
+++ b/.changeset/fork-environment-configs.md
@@ -2,4 +2,4 @@
 '@polymarket/client': minor
 ---
 
-Refactor environment configuration into REST and websocket endpoint objects with optional headers. Add `forkEnvironmentConfig` for deriving custom environments from production, keep `preproduction` as a production fork, and move deployed protocol addresses under `environment.contracts` while keeping `walletDerivation` top-level.
+Refactor environment configuration into REST and websocket endpoint objects with optional headers. Add support for deriving custom environments from production, keep `preproduction` as a production fork, and move deployed protocol addresses under `environment.contracts` while keeping `walletDerivation` top-level.

--- a/packages/client/src/ServiceClient.test.ts
+++ b/packages/client/src/ServiceClient.test.ts
@@ -120,6 +120,30 @@ describe('ServiceClient', () => {
     });
   });
 
+  it('sends configured headers with requests', async () => {
+    server.use(
+      http.get(`${root}/headers`, ({ request }) => {
+        expect(request.headers.get('CF-Access-Client-Id')).toBe('client-id');
+        expect(request.headers.get('CF-Access-Client-Secret')).toBe(
+          'client-secret',
+        );
+
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const client = new ServiceClient({
+      headers: {
+        'CF-Access-Client-Id': 'client-id',
+        'CF-Access-Client-Secret': 'client-secret',
+      },
+      root,
+    });
+
+    await expect(unwrap(client.get('/headers'))).resolves.toBeInstanceOf(
+      Response,
+    );
+  });
+
   it('identifies unreadable HTML errors when the server is unknown', async () => {
     server.use(
       http.get(

--- a/packages/client/src/ServiceClient.ts
+++ b/packages/client/src/ServiceClient.ts
@@ -17,6 +17,7 @@ export type RequestHeadersResolver = (
 
 export type ServiceClientConfig = {
   root: string;
+  headers?: HeadersInit;
   resolveHeaders?: RequestHeadersResolver;
 };
 
@@ -46,10 +47,12 @@ export type ServiceClientDeleteOptions = {
  */
 export class ServiceClient {
   readonly #client: KyInstance;
+  readonly #headers?: HeadersInit;
   readonly #resolveHeaders?: RequestHeadersResolver;
 
-  constructor({ root, resolveHeaders }: ServiceClientConfig) {
+  constructor({ root, headers, resolveHeaders }: ServiceClientConfig) {
     this.#client = ky.create({ prefixUrl: root, throwHttpErrors: false });
+    this.#headers = headers;
     this.#resolveHeaders = resolveHeaders;
   }
 
@@ -123,7 +126,11 @@ export class ServiceClient {
   ): Promise<Response> {
     const request = this.#createRequest(method, path, options);
     const resolvedHeaders = await this.#resolveHeaders?.(request);
-    const headers = this.#mergeHeaders(request.headers, resolvedHeaders);
+    const headers = this.#mergeHeaders(
+      this.#headers,
+      request.headers,
+      resolvedHeaders,
+    );
 
     if (request.body !== undefined && !headers.has('content-type')) {
       headers.set('content-type', 'application/json');

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -83,8 +83,8 @@ describe('prepareTradingApprovals', () => {
         request: {
           chainId: production.chainId,
           ...erc20ApprovalCall(
-            production.collateralToken,
-            production.perpsDepositContract,
+            production.contracts.collateralToken,
+            production.contracts.perpsDepositContract,
             MAX_UINT256,
           ),
         },
@@ -100,8 +100,8 @@ describe('prepareTradingApprovals', () => {
         request: {
           chainId: production.chainId,
           ...erc1155ApprovalForAllCall(
-            production.conditionalTokens,
-            production.standardExchange,
+            production.contracts.conditionalTokens,
+            production.contracts.standardExchange,
             true,
           ),
         },

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -477,85 +477,87 @@ async function resolveMissingTradingApprovals(
 function getRequiredTradingApprovals(
   client: BaseSecureClient,
 ): TradingApprovalRequirements {
+  const { contracts } = client.environment;
+
   return {
     erc20: [
       {
         amount: MAX_UINT256,
-        spenderAddress: client.environment.standardExchange,
-        tokenAddress: client.environment.collateralToken,
+        spenderAddress: contracts.standardExchange,
+        tokenAddress: contracts.collateralToken,
       },
       {
         amount: MAX_UINT256,
-        spenderAddress: client.environment.negRiskExchange,
-        tokenAddress: client.environment.collateralToken,
+        spenderAddress: contracts.negRiskExchange,
+        tokenAddress: contracts.collateralToken,
       },
       {
         amount: MAX_UINT256,
-        spenderAddress: client.environment.negRiskAdapter,
-        tokenAddress: client.environment.collateralToken,
+        spenderAddress: contracts.negRiskAdapter,
+        tokenAddress: contracts.collateralToken,
       },
       {
         amount: MAX_UINT256,
-        spenderAddress: client.environment.collateralAdapter,
-        tokenAddress: client.environment.collateralToken,
+        spenderAddress: contracts.collateralAdapter,
+        tokenAddress: contracts.collateralToken,
       },
       {
         amount: MAX_UINT256,
-        spenderAddress: client.environment.negRiskCollateralAdapter,
-        tokenAddress: client.environment.collateralToken,
+        spenderAddress: contracts.negRiskCollateralAdapter,
+        tokenAddress: contracts.collateralToken,
       },
       {
         amount: MAX_UINT256,
-        spenderAddress: client.environment.protocolV2Router,
-        tokenAddress: client.environment.collateralToken,
+        spenderAddress: contracts.protocolV2Router,
+        tokenAddress: contracts.collateralToken,
       },
       {
         amount: MAX_UINT256,
-        spenderAddress: client.environment.exchangeV3,
-        tokenAddress: client.environment.collateralToken,
+        spenderAddress: contracts.exchangeV3,
+        tokenAddress: contracts.collateralToken,
       },
       {
         amount: MAX_UINT256,
-        spenderAddress: client.environment.perpsDepositContract,
-        tokenAddress: client.environment.collateralToken,
+        spenderAddress: contracts.perpsDepositContract,
+        tokenAddress: contracts.collateralToken,
       },
     ],
     erc1155: [
       {
-        operatorAddress: client.environment.standardExchange,
-        tokenAddress: client.environment.conditionalTokens,
+        operatorAddress: contracts.standardExchange,
+        tokenAddress: contracts.conditionalTokens,
       },
       {
-        operatorAddress: client.environment.negRiskExchange,
-        tokenAddress: client.environment.conditionalTokens,
+        operatorAddress: contracts.negRiskExchange,
+        tokenAddress: contracts.conditionalTokens,
       },
       {
-        operatorAddress: client.environment.negRiskAdapter,
-        tokenAddress: client.environment.conditionalTokens,
+        operatorAddress: contracts.negRiskAdapter,
+        tokenAddress: contracts.conditionalTokens,
       },
       {
-        operatorAddress: client.environment.collateralAdapter,
-        tokenAddress: client.environment.conditionalTokens,
+        operatorAddress: contracts.collateralAdapter,
+        tokenAddress: contracts.conditionalTokens,
       },
       {
-        operatorAddress: client.environment.negRiskCollateralAdapter,
-        tokenAddress: client.environment.conditionalTokens,
+        operatorAddress: contracts.negRiskCollateralAdapter,
+        tokenAddress: contracts.conditionalTokens,
       },
       {
-        operatorAddress: client.environment.autoRedeemOperator,
-        tokenAddress: client.environment.conditionalTokens,
+        operatorAddress: contracts.autoRedeemOperator,
+        tokenAddress: contracts.conditionalTokens,
       },
       {
-        operatorAddress: client.environment.protocolV2Router,
-        tokenAddress: client.environment.positionManager,
+        operatorAddress: contracts.protocolV2Router,
+        tokenAddress: contracts.positionManager,
       },
       {
-        operatorAddress: client.environment.exchangeV3,
-        tokenAddress: client.environment.positionManager,
+        operatorAddress: contracts.exchangeV3,
+        tokenAddress: contracts.positionManager,
       },
       {
-        operatorAddress: client.environment.autoRedeemOperator,
-        tokenAddress: client.environment.positionManager,
+        operatorAddress: contracts.autoRedeemOperator,
+        tokenAddress: contracts.positionManager,
       },
     ],
   };

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -456,7 +456,7 @@ async function* prepareProxyWalletGaslessTransaction(
   // relayer when executing the transaction — the relayer applies its own
   // gas estimation at submission time. The validator only checks non-empty.
   const gasLimit = '10000000';
-  const relayHub = client.environment.relayHub;
+  const relayHub = client.environment.contracts.relayHub;
   const relay = ZERO_ADDRESS;
 
   const hash = buildProxyTransactionHash(
@@ -542,7 +542,7 @@ async function* prepareSafeWalletGaslessTransaction(
   });
   const transaction = aggregateSafeTransactionCalls(
     params.calls,
-    client.environment.safeMultisend,
+    client.environment.contracts.safeMultisend,
   );
 
   const safePayload = createSafeTypedDataPayload({

--- a/packages/client/src/actions/orders/context.ts
+++ b/packages/client/src/actions/orders/context.ts
@@ -29,6 +29,6 @@ export function resolveExchangeAddress(
   negRisk: boolean,
 ): EvmAddress {
   return negRisk
-    ? client.environment.negRiskExchange
-    : client.environment.standardExchange;
+    ? client.environment.contracts.negRiskExchange
+    : client.environment.contracts.standardExchange;
 }

--- a/packages/client/src/actions/orders/trade.ts
+++ b/packages/client/src/actions/orders/trade.ts
@@ -261,11 +261,11 @@ async function ensureOrderApproval(
       ? await approveErc20(client, {
           amount: 'max',
           spenderAddress: exchangeAddress,
-          tokenAddress: client.environment.collateralToken,
+          tokenAddress: client.environment.contracts.collateralToken,
         })
       : await approveErc1155ForAll(client, {
           operatorAddress: exchangeAddress,
-          tokenAddress: client.environment.conditionalTokens,
+          tokenAddress: client.environment.contracts.conditionalTokens,
         });
 
   await handle.wait();

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -973,9 +973,10 @@ export async function preparePerpsDeposit(
   request: DepositToPerpsRequest,
 ): Promise<PerpsDepositWorkflow> {
   const params = parseUserInput(request, DepositToPerpsRequestSchema);
+  const { contracts } = client.environment;
   const call = perpsDepositCall(
-    client.environment.perpsDepositContract,
-    client.environment.collateralToken,
+    contracts.perpsDepositContract,
+    contracts.collateralToken,
     params.amount,
     client.account.signer,
   );
@@ -993,7 +994,7 @@ export async function preparePerpsDeposit(
       calls: [call],
       metadata:
         params.metadata ??
-        `Deposit ${params.amount} of ${client.environment.collateralToken} to Perps`,
+        `Deposit ${params.amount} of ${contracts.collateralToken} to Perps`,
     });
   }.call(null);
 }
@@ -1032,7 +1033,7 @@ export async function withdrawFromPerps(
     type: 'withdraw' as const,
     args: {
       account: client.account.signer,
-      token: client.environment.collateralToken,
+      token: client.environment.contracts.collateralToken,
       amount: params.amount.toString(),
       to: client.account.wallet,
     },
@@ -1231,8 +1232,8 @@ async function signPerpsWithdraw(
       createPerpsWithdrawTypedDataPayload({
         account: client.account.signer,
         chainId: client.environment.chainId,
-        contract: client.environment.perpsDepositContract,
-        token: client.environment.collateralToken,
+        contract: client.environment.contracts.perpsDepositContract,
+        token: client.environment.contracts.collateralToken,
         to: client.account.wallet,
         ...request,
       }),

--- a/packages/client/src/actions/positions.ts
+++ b/packages/client/src/actions/positions.ts
@@ -259,7 +259,7 @@ export async function prepareSplitMarketPosition(
   });
   const call = splitPositionCall(
     context.adapterAddress,
-    client.environment.collateralToken,
+    client.environment.contracts.collateralToken,
     context.conditionId,
     params.amount,
   );
@@ -308,12 +308,12 @@ export async function prepareSplitComboPosition(
     PrepareSplitComboPositionRequestSchema,
   );
   const prepareConditionCall = combinatorialPrepareConditionCall(
-    client.environment.combinatorialModule,
+    client.environment.contracts.combinatorialModule,
     params.legs,
   );
   const combo = deriveComboPositionContext(params.legs);
   const splitCall = splitV2Call(
-    client.environment.protocolV2Router,
+    client.environment.contracts.protocolV2Router,
     combo.conditionId,
     params.amount,
   );
@@ -557,7 +557,7 @@ export async function prepareMergeMarketPosition(
   );
   const call = mergePositionsCall(
     context.adapterAddress,
-    client.environment.collateralToken,
+    client.environment.contracts.collateralToken,
     context.conditionId,
     amount,
   );
@@ -606,14 +606,14 @@ export async function prepareMergeComboPosition(
     PrepareMergeComboPositionRequestSchema,
   );
   const prepareConditionCall = combinatorialPrepareConditionCall(
-    client.environment.combinatorialModule,
+    client.environment.contracts.combinatorialModule,
     params.legs,
   );
   const combo = deriveComboPositionContext(params.legs);
   const balances = decodeErc1155BalanceOfBatchResult(
     await client.rpc.ethCall(
       erc1155BalanceOfBatchCall(
-        client.environment.positionManager,
+        client.environment.contracts.positionManager,
         client.account.wallet,
         combo.positionIds,
       ),
@@ -621,7 +621,7 @@ export async function prepareMergeComboPosition(
   );
   const amount = resolveMergeAmount(combo.conditionId, balances, params.amount);
   const mergeCall = mergeV2Call(
-    client.environment.protocolV2Router,
+    client.environment.contracts.protocolV2Router,
     combo.conditionId,
     amount,
   );
@@ -877,7 +877,7 @@ export async function prepareRedeemMarketPositions(
   );
   const call = ctfRedeemPositionsCall(
     context.adapterAddress,
-    client.environment.collateralToken,
+    client.environment.contracts.collateralToken,
     context.conditionId,
   );
 
@@ -927,7 +927,7 @@ export async function prepareRedeemComboPosition(
   const balance = decodeErc1155BalanceOfResult(
     await client.rpc.ethCall(
       erc1155BalanceOfCall(
-        client.environment.positionManager,
+        client.environment.contracts.positionManager,
         client.account.wallet,
         params.positionId,
       ),
@@ -939,7 +939,7 @@ export async function prepareRedeemComboPosition(
   }
 
   const call = redeemV2Call(
-    client.environment.protocolV2Router,
+    client.environment.contracts.protocolV2Router,
     decoded.conditionId,
     decoded.outcomeIndex,
     balance,
@@ -1086,11 +1086,11 @@ async function resolveMarketClobContext(
   return {
     ...marketContext,
     adapterAddress: marketContext.negRisk
-      ? client.environment.negRiskCollateralAdapter
-      : client.environment.collateralAdapter,
+      ? client.environment.contracts.negRiskCollateralAdapter
+      : client.environment.contracts.collateralAdapter,
     positionErc1155Address: marketContext.negRisk
-      ? client.environment.negRiskAdapter
-      : client.environment.conditionalTokens,
+      ? client.environment.contracts.negRiskAdapter
+      : client.environment.contracts.conditionalTokens,
   };
 }
 

--- a/packages/client/src/actions/transfers.ts
+++ b/packages/client/src/actions/transfers.ts
@@ -66,7 +66,7 @@ export const PrepareErc20TransferError = makeErrorGuard(UserInputError);
  * const workflow = await prepareErc20Transfer(client, {
  *   amount: 1n,
  *   recipientAddress: client.account.signer,
- *   tokenAddress: client.environment.collateralToken,
+ *   tokenAddress: client.environment.contracts.collateralToken,
  * });
  * ```
  *

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -18,7 +18,7 @@ import {
   vi,
 } from 'vitest';
 import { createSecureClient } from './clients';
-import { production } from './environments';
+import { forkEnvironmentConfig } from './environments';
 import type { ApiKeyAuthorization, Signer } from './types';
 import {
   deriveBeaconDepositWalletAddress,
@@ -35,12 +35,12 @@ const signerAddress = expectEvmAddress(
   '0x0000000000000000000000000000000000000001',
 );
 
-const environment = {
-  ...production,
-  clob: clobRoot,
-  relayer: relayerRoot,
+const environment = forkEnvironmentConfig({
+  name: 'test',
+  clob: { rest: clobRoot },
+  relayer: { rest: relayerRoot },
   rpc: rpcRoot,
-};
+});
 
 const credentials: ApiKeyCreds = {
   key: ApiKeySchema.parse('key'),

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -291,30 +291,50 @@ class BasePublicClient<
     super({
       apiKey: config.apiKey,
       environment: config.environment,
-      data: new ServiceClient({ root: config.environment.data }),
-      gamma: new ServiceClient({ root: config.environment.gamma }),
+      data: new ServiceClient({
+        headers: config.environment.data.headers,
+        root: config.environment.data.rest,
+      }),
+      gamma: new ServiceClient({
+        headers: config.environment.gamma.headers,
+        root: config.environment.gamma.rest,
+      }),
       clob: new ServiceClient({
-        root: config.environment.clob,
+        headers: config.environment.clob.headers,
+        root: config.environment.clob.rest,
         resolveHeaders: (request) => this.resolveClobHeaders(request),
       }),
       relayer: new ServiceClient({
-        root: config.environment.relayer,
+        headers: config.environment.relayer.headers,
+        root: config.environment.relayer.rest,
         resolveHeaders: (request) => this.resolveRelayerHeaders(request),
       }),
-      rfq: new ServiceClient({ root: config.environment.rfq }),
-      perps: new ServiceClient({ root: config.environment.perpsApi }),
+      rfq: new ServiceClient({
+        headers: config.environment.rfq.headers,
+        root: config.environment.rfq.rest,
+      }),
+      perps: new ServiceClient({
+        headers: config.environment.perps.headers,
+        root: config.environment.perps.rest,
+      }),
       rpc: new JsonRpcClient({ url: config.environment.rpc }),
       webSockets: {
         clobMarket: new ClobMarketWebSocketManager({
-          url: config.environment.clobMarketWs,
+          headers: config.environment.clob.market.headers,
+          url: config.environment.clob.market.ws,
         }),
         sports: new SportsWebSocketManager({
-          url: config.environment.sportsWs,
+          headers: config.environment.sports.headers,
+          url: config.environment.sports.ws,
         }),
-        rtds: new RtdsWebSocketManager(config.environment.rtdsWs),
-        perpsSubscriptions: new PerpsSubscriptionManager(
-          config.environment.perpsWs,
-        ),
+        rtds: new RtdsWebSocketManager({
+          headers: config.environment.rtds.headers,
+          url: config.environment.rtds.ws,
+        }),
+        perpsSubscriptions: new PerpsSubscriptionManager({
+          headers: config.environment.perps.headers,
+          url: config.environment.perps.ws,
+        }),
       },
     });
   }
@@ -511,53 +531,77 @@ class BaseSecureClient<
       environment: config.environment,
       signer: config.signer,
       clob: new ServiceClient({
-        root: config.environment.clob,
+        headers: config.environment.clob.headers,
+        root: config.environment.clob.rest,
         resolveHeaders: (request) => this.resolveClobHeaders(request),
       }),
       relayer: new ServiceClient({
-        root: config.environment.relayer,
+        headers: config.environment.relayer.headers,
+        root: config.environment.relayer.rest,
         resolveHeaders: (request) => this.resolveRelayerHeaders(request),
       }),
       rpc: new JsonRpcClient({ url: config.environment.rpc }),
-      gamma: new ServiceClient({ root: config.environment.gamma }),
-      data: new ServiceClient({ root: config.environment.data }),
-      rfq: new ServiceClient({ root: config.environment.rfq }),
-      perps: new ServiceClient({ root: config.environment.perpsApi }),
+      gamma: new ServiceClient({
+        headers: config.environment.gamma.headers,
+        root: config.environment.gamma.rest,
+      }),
+      data: new ServiceClient({
+        headers: config.environment.data.headers,
+        root: config.environment.data.rest,
+      }),
+      rfq: new ServiceClient({
+        headers: config.environment.rfq.headers,
+        root: config.environment.rfq.rest,
+      }),
+      perps: new ServiceClient({
+        headers: config.environment.perps.headers,
+        root: config.environment.perps.rest,
+      }),
       secureClob: new ServiceClient({
+        headers: config.environment.clob.headers,
         resolveHeaders: async (request) => ({
           ...(await this.resolveClobHeaders(request)),
           ...(await this.#createL2Headers(request)),
         }),
-        root: config.environment.clob,
+        root: config.environment.clob.rest,
       }),
       webSockets: {
         clobMarket: new ClobMarketWebSocketManager({
-          url: config.environment.clobMarketWs,
+          headers: config.environment.clob.market.headers,
+          url: config.environment.clob.market.ws,
         }),
         clobUser: new ClobUserWebSocketManager({
           credentials: config.credentials,
-          url: config.environment.clobUserWs,
+          headers: config.environment.clob.user.headers,
+          url: config.environment.clob.user.ws,
         }),
         rfqQuoter: new RfqQuoterWebSocketManager({
           account: config.account,
           chainId: config.environment.chainId,
           credentials: config.credentials,
-          exchange: config.environment.exchangeV3,
-          headers: config.environment.rfqQuoterWsHeaders,
+          exchange: config.environment.contracts.exchangeV3,
+          headers: config.environment.rfq.headers,
           signer: config.signer,
-          url: config.environment.rfqQuoterWs,
+          url: config.environment.rfq.ws,
         }),
         sports: new SportsWebSocketManager({
-          url: config.environment.sportsWs,
+          headers: config.environment.sports.headers,
+          url: config.environment.sports.ws,
         }),
-        rtds: new RtdsWebSocketManager(config.environment.rtdsWs),
-        perpsSubscriptions: new PerpsSubscriptionManager(
-          config.environment.perpsWs,
-        ),
+        rtds: new RtdsWebSocketManager({
+          headers: config.environment.rtds.headers,
+          url: config.environment.rtds.ws,
+        }),
+        perpsSubscriptions: new PerpsSubscriptionManager({
+          headers: config.environment.perps.headers,
+          url: config.environment.perps.ws,
+        }),
         perpsSession: new PerpsSessionManager({
-          restUrl: config.environment.perpsApi,
           chainId: config.environment.chainId,
-          wsUrl: config.environment.perpsWs,
+          restHeaders: config.environment.perps.headers,
+          restUrl: config.environment.perps.rest,
+          wsHeaders: config.environment.perps.headers,
+          wsUrl: config.environment.perps.ws,
         }),
       },
     });

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -598,9 +598,8 @@ class BaseSecureClient<
         }),
         perpsSession: new PerpsSessionManager({
           chainId: config.environment.chainId,
-          restHeaders: config.environment.perps.headers,
+          headers: config.environment.perps.headers,
           restUrl: config.environment.perps.rest,
-          wsHeaders: config.environment.perps.headers,
           wsUrl: config.environment.perps.ws,
         }),
       },

--- a/packages/client/src/decorators/wallet.ts
+++ b/packages/client/src/decorators/wallet.ts
@@ -90,7 +90,7 @@ export type SecureWalletActions = {
    * const handle = await client.transferErc20({
    *   amount: 1n,
    *   recipientAddress: client.account.signer,
-   *   tokenAddress: client.environment.collateralToken,
+   *   tokenAddress: client.environment.contracts.collateralToken,
    * });
    *
    * const outcome = await handle.wait();

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -271,8 +271,8 @@ function forkHeaders(
 }
 
 /** @internal */
-export const staging = forkEnvironmentConfig({
-  name: 'staging',
+export const preproduction = forkEnvironmentConfig({
+  name: 'preproduction',
   clob: { rest: 'https://clob-preprod-int-v2.polymarket.com' },
   data: { rest: 'https://data-api-preprod-int.polymarket.com' },
   gamma: { rest: 'https://gamma-api-preprod-int.polymarket.com' },

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -11,6 +11,43 @@ export type WalletDerivationConfig = {
   safeInitCodeHash: Hex.Hex;
 };
 
+export type RestEndpoint = {
+  rest: string;
+  headers?: Record<string, string>;
+};
+
+export type WebSocketEndpoint = {
+  ws: string;
+  headers?: Record<string, string>;
+};
+
+export type ClobEndpoints = RestEndpoint & {
+  market: WebSocketEndpoint;
+  user: WebSocketEndpoint;
+};
+
+export type RfqEndpoints = RestEndpoint & WebSocketEndpoint;
+
+export type PerpsEndpoints = RestEndpoint & WebSocketEndpoint;
+
+export type EnvironmentContracts = {
+  collateralToken: EvmAddress;
+  conditionalTokens: EvmAddress;
+  negRiskAdapter: EvmAddress;
+  collateralAdapter: EvmAddress;
+  negRiskCollateralAdapter: EvmAddress;
+  standardExchange: EvmAddress;
+  negRiskExchange: EvmAddress;
+  exchangeV3: EvmAddress;
+  protocolV2Router: EvmAddress;
+  combinatorialModule: EvmAddress;
+  positionManager: EvmAddress;
+  autoRedeemOperator: EvmAddress;
+  safeMultisend: EvmAddress;
+  relayHub: EvmAddress;
+  perpsDepositContract: EvmAddress;
+};
+
 export type EnvironmentConfig = {
   name: string;
   chainId: number;
@@ -19,65 +56,50 @@ export type EnvironmentConfig = {
   /** @internal */
   walletDerivation: WalletDerivationConfig;
   /** @internal */
-  collateralToken: EvmAddress;
+  contracts: EnvironmentContracts;
   /** @internal */
-  conditionalTokens: EvmAddress;
+  clob: ClobEndpoints;
   /** @internal */
-  negRiskAdapter: EvmAddress;
+  relayer: RestEndpoint;
   /** @internal */
-  collateralAdapter: EvmAddress;
+  gamma: RestEndpoint;
   /** @internal */
-  negRiskCollateralAdapter: EvmAddress;
+  data: RestEndpoint;
   /** @internal */
-  standardExchange: EvmAddress;
+  rfq: RfqEndpoints;
   /** @internal */
-  negRiskExchange: EvmAddress;
+  perps: PerpsEndpoints;
   /** @internal */
-  exchangeV3: EvmAddress;
+  rtds: WebSocketEndpoint;
   /** @internal */
-  protocolV2Router: EvmAddress;
-  /** @internal */
-  combinatorialModule: EvmAddress;
-  /** @internal */
-  positionManager: EvmAddress;
-  /** @internal */
-  autoRedeemOperator: EvmAddress;
-  /** @internal */
-  safeMultisend: EvmAddress;
-  /** @internal */
-  relayHub: EvmAddress;
-  /** @internal */
-  perpsDepositContract: EvmAddress;
-  /** @internal */
-  clob: string;
-  /** @internal */
-  perpsApi: string;
-  /** @internal */
-  clobMarketWs: string;
-  /** @internal */
-  clobUserWs: string;
-  /** @internal */
-  perpsWs: string;
-  /** @internal */
-  relayer: string;
-  /** @internal */
-  gamma: string;
-  /** @internal */
-  data: string;
-  /** @internal */
-  rfq: string;
-  /** @internal */
-  rtdsWs: string;
-  /** @internal */
-  sportsWs: string;
-  /** @internal */
-  rfqQuoterWs: string;
-  /** @internal */
-  rfqQuoterWsHeaders?: Record<string, string>;
+  sports: WebSocketEndpoint;
   /** @internal */
   relayerMaxPolls: number;
   /** @internal */
   relayerPollFrequencyMs: number;
+};
+
+type EnvironmentConfigForkEndpoint = Partial<RestEndpoint & WebSocketEndpoint>;
+
+export type EnvironmentConfigFork = {
+  name: string;
+  chainId?: number;
+  rpc?: string;
+  walletDerivation?: Partial<WalletDerivationConfig>;
+  contracts?: Partial<EnvironmentContracts>;
+  clob?: Partial<RestEndpoint> & {
+    market?: Partial<WebSocketEndpoint>;
+    user?: Partial<WebSocketEndpoint>;
+  };
+  relayer?: Partial<RestEndpoint>;
+  gamma?: Partial<RestEndpoint>;
+  data?: Partial<RestEndpoint>;
+  rfq?: EnvironmentConfigForkEndpoint;
+  perps?: EnvironmentConfigForkEndpoint;
+  rtds?: Partial<WebSocketEndpoint>;
+  sports?: Partial<WebSocketEndpoint>;
+  relayerMaxPolls?: number;
+  relayerPollFrequencyMs?: number;
 };
 
 /**
@@ -107,67 +129,166 @@ export const production: EnvironmentConfig = {
     safeInitCodeHash:
       '0x2bce2127ff07fb632d16c8347c4ebf501f4841168bed00d9e6ef715ddb6fcecf',
   },
-  collateralToken: expectEvmAddress(
-    '0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB',
-  ),
-  conditionalTokens: expectEvmAddress(
-    '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045',
-  ),
-  negRiskAdapter: expectEvmAddress(
-    '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296',
-  ),
-  collateralAdapter: expectEvmAddress(
-    '0xAdA100Db00Ca00073811820692005400218FcE1f',
-  ),
-  negRiskCollateralAdapter: expectEvmAddress(
-    '0xadA2005600Dec949baf300f4C6120000bDB6eAab',
-  ),
-  standardExchange: expectEvmAddress(
-    '0xE111180000d2663C0091e4f400237545B87B996B',
-  ),
-  negRiskExchange: expectEvmAddress(
-    '0xe2222d279d744050d28e00520010520000310F59',
-  ),
-  exchangeV3: expectEvmAddress('0xe3333700cA9d93003F00f0F71f8515005F6c00Aa'),
-  protocolV2Router: expectEvmAddress(
-    '0x12121212006e4CD160D18e3f00711DA5c3372600',
-  ),
-  combinatorialModule: expectEvmAddress(
-    '0x30000034706c7d8e12009dab006be20000c031a8',
-  ),
-  positionManager: expectEvmAddress(
-    '0x006F54F7f9A22e0000CC2AB60031000000ae9fEF',
-  ),
-  autoRedeemOperator: expectEvmAddress(
-    '0xa1200000d0002264C9a1698e001292D00E1b00af',
-  ),
-  safeMultisend: expectEvmAddress('0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761'),
-  relayHub: expectEvmAddress('0xD216153c06E857cD7f72665E0aF1d7D82172F494'),
-  perpsDepositContract: expectEvmAddress(
-    '0xDCa4af75705dbB50f62437045afF9921947917d2',
-  ),
-  clob: 'https://clob.polymarket.com',
-  perpsApi: 'https://api.perpetuals.polymarket.com',
-  clobMarketWs: 'wss://ws-subscriptions-clob.polymarket.com/ws/market',
-  clobUserWs: 'wss://ws-subscriptions-clob.polymarket.com/ws/user',
-  perpsWs: 'wss://ws.perpetuals.polymarket.com/v1/ws',
-  relayer: 'https://relayer-v2.polymarket.com',
-  gamma: 'https://gamma-api.polymarket.com',
-  data: 'https://data-api.polymarket.com',
-  rfq: 'https://combos-rfq-api.polymarket.com',
-  rtdsWs: 'wss://ws-live-data.polymarket.com',
-  rfqQuoterWs: 'wss://combos-rfq-gateway-quoter.polymarket.com/ws/rfq',
-  sportsWs: 'wss://sports-api.polymarket.com/ws',
+  contracts: {
+    collateralToken: expectEvmAddress(
+      '0xC011a7E12a19f7B1f670d46F03B03f3342E82DFB',
+    ),
+    conditionalTokens: expectEvmAddress(
+      '0x4D97DCd97eC945f40cF65F87097ACe5EA0476045',
+    ),
+    negRiskAdapter: expectEvmAddress(
+      '0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296',
+    ),
+    collateralAdapter: expectEvmAddress(
+      '0xAdA100Db00Ca00073811820692005400218FcE1f',
+    ),
+    negRiskCollateralAdapter: expectEvmAddress(
+      '0xadA2005600Dec949baf300f4C6120000bDB6eAab',
+    ),
+    standardExchange: expectEvmAddress(
+      '0xE111180000d2663C0091e4f400237545B87B996B',
+    ),
+    negRiskExchange: expectEvmAddress(
+      '0xe2222d279d744050d28e00520010520000310F59',
+    ),
+    exchangeV3: expectEvmAddress('0xe3333700cA9d93003F00f0F71f8515005F6c00Aa'),
+    protocolV2Router: expectEvmAddress(
+      '0x12121212006e4CD160D18e3f00711DA5c3372600',
+    ),
+    combinatorialModule: expectEvmAddress(
+      '0x30000034706c7d8e12009dab006be20000c031a8',
+    ),
+    positionManager: expectEvmAddress(
+      '0x006F54F7f9A22e0000CC2AB60031000000ae9fEF',
+    ),
+    autoRedeemOperator: expectEvmAddress(
+      '0xa1200000d0002264C9a1698e001292D00E1b00af',
+    ),
+    safeMultisend: expectEvmAddress(
+      '0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761',
+    ),
+    relayHub: expectEvmAddress('0xD216153c06E857cD7f72665E0aF1d7D82172F494'),
+    perpsDepositContract: expectEvmAddress(
+      '0xDCa4af75705dbB50f62437045afF9921947917d2',
+    ),
+  },
+  clob: {
+    rest: 'https://clob.polymarket.com',
+    market: { ws: 'wss://ws-subscriptions-clob.polymarket.com/ws/market' },
+    user: { ws: 'wss://ws-subscriptions-clob.polymarket.com/ws/user' },
+  },
+  relayer: { rest: 'https://relayer-v2.polymarket.com' },
+  gamma: { rest: 'https://gamma-api.polymarket.com' },
+  data: { rest: 'https://data-api.polymarket.com' },
+  rfq: {
+    rest: 'https://combos-rfq-api.polymarket.com',
+    ws: 'wss://combos-rfq-gateway-quoter.polymarket.com/ws/rfq',
+  },
+  perps: {
+    rest: 'https://api.perpetuals.polymarket.com',
+    ws: 'wss://ws.perpetuals.polymarket.com/v1/ws',
+  },
+  rtds: { ws: 'wss://ws-live-data.polymarket.com' },
+  sports: { ws: 'wss://sports-api.polymarket.com/ws' },
   relayerMaxPolls: 100,
   relayerPollFrequencyMs: 2000,
 };
 
+/**
+ * Forks an environment config from production unless a different base is passed.
+ *
+ * @example
+ * ```ts
+ * const staging = forkEnvironmentConfig({
+ *   name: 'staging',
+ *   perps: {
+ *     rest: 'https://api-perpetuals-preprod.polymarket.com',
+ *     headers: {
+ *       'CF-Access-Client-Id': 'example-client-id',
+ *       'CF-Access-Client-Secret': 'example-client-secret',
+ *     },
+ *   },
+ *   rfq: {
+ *     ws: 'wss://combos-rfq-gateway-quoter-preprod.polymarket.com/ws/rfq',
+ *   },
+ * });
+ * ```
+ */
+export function forkEnvironmentConfig(
+  fork: EnvironmentConfigFork,
+  base: EnvironmentConfig = production,
+): EnvironmentConfig {
+  return {
+    ...base,
+    ...fork,
+    walletDerivation: {
+      ...base.walletDerivation,
+      ...fork.walletDerivation,
+    },
+    contracts: {
+      ...base.contracts,
+      ...fork.contracts,
+    },
+    clob: {
+      ...forkRestEndpoint(base.clob, fork.clob),
+      market: forkWebSocketEndpoint(base.clob.market, fork.clob?.market),
+      user: forkWebSocketEndpoint(base.clob.user, fork.clob?.user),
+    },
+    relayer: forkRestEndpoint(base.relayer, fork.relayer),
+    gamma: forkRestEndpoint(base.gamma, fork.gamma),
+    data: forkRestEndpoint(base.data, fork.data),
+    rfq: forkRestWebSocketEndpoint(base.rfq, fork.rfq),
+    perps: forkRestWebSocketEndpoint(base.perps, fork.perps),
+    rtds: forkWebSocketEndpoint(base.rtds, fork.rtds),
+    sports: forkWebSocketEndpoint(base.sports, fork.sports),
+  };
+}
+
+function forkRestEndpoint(
+  base: RestEndpoint,
+  fork: Partial<RestEndpoint> | undefined,
+): RestEndpoint {
+  return {
+    ...base,
+    ...fork,
+    headers: forkHeaders(base.headers, fork?.headers),
+  };
+}
+
+function forkWebSocketEndpoint(
+  base: WebSocketEndpoint,
+  fork: Partial<WebSocketEndpoint> | undefined,
+): WebSocketEndpoint {
+  return {
+    ...base,
+    ...fork,
+    headers: forkHeaders(base.headers, fork?.headers),
+  };
+}
+
+function forkRestWebSocketEndpoint<
+  TEndpoint extends RestEndpoint & WebSocketEndpoint,
+>(base: TEndpoint, fork: EnvironmentConfigForkEndpoint | undefined): TEndpoint {
+  return {
+    ...base,
+    ...fork,
+    headers: forkHeaders(base.headers, fork?.headers),
+  };
+}
+
+function forkHeaders(
+  base: Record<string, string> | undefined,
+  fork: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (base === undefined && fork === undefined) return undefined;
+  return { ...base, ...fork };
+}
+
 /** @internal */
-export const preproduction = {
-  ...production,
-  name: 'preproduction',
-  clob: 'https://clob-preprod-int-v2.polymarket.com',
-  data: 'https://data-api-preprod-int.polymarket.com',
-  gamma: 'https://gamma-api-preprod-int.polymarket.com',
-  relayer: 'https://relayer-v2-preprod-int.polymarket.com',
-};
+export const staging = forkEnvironmentConfig({
+  name: 'staging',
+  clob: { rest: 'https://clob-preprod-int-v2.polymarket.com' },
+  data: { rest: 'https://data-api-preprod-int.polymarket.com' },
+  gamma: { rest: 'https://gamma-api-preprod-int.polymarket.com' },
+  relayer: { rest: 'https://relayer-v2-preprod-int.polymarket.com' },
+});

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -197,22 +197,8 @@ export const production: EnvironmentConfig = {
 /**
  * Forks an environment config from production unless a different base is passed.
  *
- * @example
- * ```ts
- * const staging = forkEnvironmentConfig({
- *   name: 'staging',
- *   perps: {
- *     rest: 'https://api-perpetuals-preprod.polymarket.com',
- *     headers: {
- *       'CF-Access-Client-Id': 'example-client-id',
- *       'CF-Access-Client-Secret': 'example-client-secret',
- *     },
- *   },
- *   rfq: {
- *     ws: 'wss://combos-rfq-gateway-quoter-preprod.polymarket.com/ws/rfq',
- *   },
- * });
- * ```
+ * @experimental This helper is intended for advanced custom environment use,
+ * not general SDK usage. Its signature may change without notice.
  */
 export function forkEnvironmentConfig(
   fork: EnvironmentConfigFork,

--- a/packages/client/src/websockets/clob/market.test.ts
+++ b/packages/client/src/websockets/clob/market.test.ts
@@ -13,10 +13,10 @@ import { production } from '../../environments';
 import { captureConnection, collectFrames, waitForNextEvent } from '../testing';
 import { ClobMarketWebSocketManager } from './market';
 
-const clobMarket = ws.link(production.clobMarketWs);
+const clobMarket = ws.link(production.clob.market.ws);
 const server = setupServer();
 const manager = new ClobMarketWebSocketManager({
-  url: production.clobMarketWs,
+  url: production.clob.market.ws,
 });
 
 describe('ClobMarketWebSocketManager', () => {

--- a/packages/client/src/websockets/clob/market.ts
+++ b/packages/client/src/websockets/clob/market.ts
@@ -28,6 +28,7 @@ import {
 } from './protocol';
 
 export type ClobMarketWebSocketManagerOptions = {
+  headers?: Record<string, string>;
   url: string;
 };
 
@@ -40,6 +41,7 @@ export type ClobMarketWebSocketManagerOptions = {
 export class ClobMarketWebSocketManager
   implements WebSocketSubscriptionManager<MarketSubscription, MarketEvent>
 {
+  readonly #headers: Record<string, string> | undefined;
   readonly #url: string;
   #closing: Promise<void> | undefined;
   readonly #connection = new WebSocketConnection({
@@ -53,6 +55,7 @@ export class ClobMarketWebSocketManager
   >({ deriveServerState: deriveMarketServerSubscription });
 
   constructor(options: ClobMarketWebSocketManagerOptions) {
+    this.#headers = options.headers;
     this.#url = options.url;
   }
 
@@ -127,6 +130,7 @@ export class ClobMarketWebSocketManager
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: () => this.#onConnectionOpen(),
+      headers: this.#headers,
       url: this.#url,
     });
   }

--- a/packages/client/src/websockets/clob/user.test.ts
+++ b/packages/client/src/websockets/clob/user.test.ts
@@ -14,7 +14,7 @@ import { production } from '../../environments';
 import { captureConnection, collectFrames, waitForNextEvent } from '../testing';
 import { ClobUserWebSocketManager } from './user';
 
-const clobUser = ws.link(production.clobUserWs);
+const clobUser = ws.link(production.clob.user.ws);
 const server = setupServer();
 const credentials = ApiKeyCredsSchema.parse({
   apiKey: 'test-key',
@@ -23,7 +23,7 @@ const credentials = ApiKeyCredsSchema.parse({
 });
 const manager = new ClobUserWebSocketManager({
   credentials,
-  url: production.clobUserWs,
+  url: production.clob.user.ws,
 });
 
 describe('ClobUserWebSocketManager', () => {

--- a/packages/client/src/websockets/clob/user.ts
+++ b/packages/client/src/websockets/clob/user.ts
@@ -30,14 +30,16 @@ import {
 
 export type ClobUserWebSocketManagerOptions = {
   credentials: ApiKeyCreds;
+  headers?: Record<string, string>;
   url: string;
 };
 
 export class ClobUserWebSocketManager
   implements WebSocketSubscriptionManager<UserSubscription, UserEvent>
 {
-  readonly #url: string;
   readonly #credentials: ApiKeyCreds;
+  readonly #headers: Record<string, string> | undefined;
+  readonly #url: string;
   #closing: Promise<void> | undefined;
   readonly #connection = new WebSocketConnection({
     heartbeat: new ClobWebSocketHeartbeat(),
@@ -50,8 +52,9 @@ export class ClobUserWebSocketManager
   >({ deriveServerState: deriveUserServerSubscription });
 
   constructor(options: ClobUserWebSocketManagerOptions) {
-    this.#url = options.url;
     this.#credentials = options.credentials;
+    this.#headers = options.headers;
+    this.#url = options.url;
   }
 
   async subscribe(
@@ -126,6 +129,7 @@ export class ClobUserWebSocketManager
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: (credentials) => this.#onConnectionOpen(credentials),
       prepare: () => this.#credentials,
+      headers: this.#headers,
       url: this.#url,
     });
   }

--- a/packages/client/src/websockets/perps/manager.test.ts
+++ b/packages/client/src/websockets/perps/manager.test.ts
@@ -62,8 +62,8 @@ describe('PerpsSessionManager', () => {
     const connection = mockDelayedAuthSession();
     const manager = new PerpsSessionManager({
       chainId: production.chainId,
-      restUrl: production.perpsApi,
-      wsUrl: production.perpsWs,
+      restUrl: production.perps.rest,
+      wsUrl: production.perps.ws,
     });
 
     const connect = manager.connect(credentials);
@@ -83,8 +83,8 @@ describe('PerpsSessionManager', () => {
   it('rejects new sessions after manager close finishes', async () => {
     const manager = new PerpsSessionManager({
       chainId: production.chainId,
-      restUrl: production.perpsApi,
-      wsUrl: production.perpsWs,
+      restUrl: production.perps.rest,
+      wsUrl: production.perps.ws,
     });
 
     await manager.shutdown();

--- a/packages/client/src/websockets/perps/manager.test.ts
+++ b/packages/client/src/websockets/perps/manager.test.ts
@@ -14,7 +14,7 @@ import {
 import { production } from '../../environments';
 import { PerpsSessionManager } from './manager';
 
-const perps = ws.link(production.perpsWs);
+const perps = ws.link(production.perps.ws);
 const server = setupServer();
 
 const credentials = {
@@ -46,8 +46,8 @@ describe('PerpsSessionManager', () => {
   it('connects sessions through the manager lifecycle', async () => {
     const manager = new PerpsSessionManager({
       chainId: production.chainId,
-      restUrl: production.perpsApi,
-      wsUrl: production.perpsWs,
+      restUrl: production.perps.rest,
+      wsUrl: production.perps.ws,
     });
     const session = await manager.connect(credentials);
 

--- a/packages/client/src/websockets/perps/manager.ts
+++ b/packages/client/src/websockets/perps/manager.ts
@@ -4,17 +4,15 @@ import { PerpsSession } from './session';
 
 export type PerpsSessionManagerOptions = {
   chainId: number;
-  restHeaders?: Record<string, string>;
+  headers?: Record<string, string>;
   restUrl: string;
-  wsHeaders?: Record<string, string>;
   wsUrl: string;
 };
 
 export class PerpsSessionManager {
   readonly #chainId: number;
-  readonly #restHeaders: Record<string, string> | undefined;
+  readonly #headers: Record<string, string> | undefined;
   readonly #restUrl: string;
-  readonly #wsHeaders: Record<string, string> | undefined;
   readonly #wsUrl: string;
   readonly #sessions = new Set<PerpsSession>();
   readonly #connectingSessions = new Set<PerpsSession>();
@@ -23,9 +21,8 @@ export class PerpsSessionManager {
 
   constructor(options: PerpsSessionManagerOptions) {
     this.#chainId = options.chainId;
-    this.#restHeaders = options.restHeaders;
+    this.#headers = options.headers;
     this.#restUrl = options.restUrl;
-    this.#wsHeaders = options.wsHeaders;
     this.#wsUrl = options.wsUrl;
   }
 
@@ -39,10 +36,9 @@ export class PerpsSessionManager {
     const session = new PerpsSession({
       chainId: this.#chainId,
       credentials,
+      headers: this.#headers,
       onClose: (closedSession) => this.#clearSession(closedSession),
-      restHeaders: this.#restHeaders,
       restUrl: this.#restUrl,
-      wsHeaders: this.#wsHeaders,
       wsUrl: this.#wsUrl,
     });
     this.#connectingSessions.add(session);

--- a/packages/client/src/websockets/perps/manager.ts
+++ b/packages/client/src/websockets/perps/manager.ts
@@ -4,13 +4,17 @@ import { PerpsSession } from './session';
 
 export type PerpsSessionManagerOptions = {
   chainId: number;
+  restHeaders?: Record<string, string>;
   restUrl: string;
+  wsHeaders?: Record<string, string>;
   wsUrl: string;
 };
 
 export class PerpsSessionManager {
   readonly #chainId: number;
+  readonly #restHeaders: Record<string, string> | undefined;
   readonly #restUrl: string;
+  readonly #wsHeaders: Record<string, string> | undefined;
   readonly #wsUrl: string;
   readonly #sessions = new Set<PerpsSession>();
   readonly #connectingSessions = new Set<PerpsSession>();
@@ -19,7 +23,9 @@ export class PerpsSessionManager {
 
   constructor(options: PerpsSessionManagerOptions) {
     this.#chainId = options.chainId;
+    this.#restHeaders = options.restHeaders;
     this.#restUrl = options.restUrl;
+    this.#wsHeaders = options.wsHeaders;
     this.#wsUrl = options.wsUrl;
   }
 
@@ -34,7 +40,9 @@ export class PerpsSessionManager {
       chainId: this.#chainId,
       credentials,
       onClose: (closedSession) => this.#clearSession(closedSession),
+      restHeaders: this.#restHeaders,
       restUrl: this.#restUrl,
+      wsHeaders: this.#wsHeaders,
       wsUrl: this.#wsUrl,
     });
     this.#connectingSessions.add(session);

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -20,7 +20,7 @@ import { production } from '../../environments';
 import { captureConnection, waitForNextEvent } from '../testing';
 import { PerpsSession } from './session';
 
-const perps = ws.link(production.perpsWs);
+const perps = ws.link(production.perps.ws);
 const server = setupServer();
 
 const credentials = {
@@ -348,7 +348,7 @@ describe('PerpsSession', () => {
     it('sends session credentials as REST auth headers', async () => {
       server.use(
         http.get(
-          `${production.perpsApi}/v1/account/balances`,
+          `${production.perps.rest}/v1/account/balances`,
           ({ request }) => {
             expect(request.headers.get('polymarket-proxy')).toBe(
               credentials.proxy,
@@ -372,7 +372,7 @@ describe('PerpsSession', () => {
     it('overlaps and dedupes descending account history pages', async () => {
       const requests: URLSearchParams[] = [];
       server.use(
-        http.get(`${production.perpsApi}/v1/account/fills`, ({ request }) => {
+        http.get(`${production.perps.rest}/v1/account/fills`, ({ request }) => {
           const params = new URL(request.url).searchParams;
           requests.push(params);
 
@@ -451,25 +451,28 @@ describe('PerpsSession', () => {
     it('continues ascending interval account history pages', async () => {
       const requests: URLSearchParams[] = [];
       server.use(
-        http.get(`${production.perpsApi}/v1/account/equity`, ({ request }) => {
-          const params = new URL(request.url).searchParams;
-          requests.push(params);
+        http.get(
+          `${production.perps.rest}/v1/account/equity`,
+          ({ request }) => {
+            const params = new URL(request.url).searchParams;
+            requests.push(params);
 
-          if (params.get('start_timestamp') === '0') {
+            if (params.get('start_timestamp') === '0') {
+              return HttpResponse.json({
+                data: [
+                  [0, '10'],
+                  [3_600_000, '11'],
+                ],
+                more: true,
+              });
+            }
+
             return HttpResponse.json({
-              data: [
-                [0, '10'],
-                [3_600_000, '11'],
-              ],
-              more: true,
+              data: [[7_200_000, '12']],
+              more: false,
             });
-          }
-
-          return HttpResponse.json({
-            data: [[7_200_000, '12']],
-            more: false,
-          });
-        }),
+          },
+        ),
       );
       const session = createSession();
       const pages = session.listEquityHistory({
@@ -498,8 +501,8 @@ function createSession(): PerpsSession {
     chainId: production.chainId,
     credentials,
     onClose: () => undefined,
-    restUrl: production.perpsApi,
-    wsUrl: production.perpsWs,
+    restUrl: production.perps.rest,
+    wsUrl: production.perps.ws,
   });
 }
 

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -406,7 +406,7 @@ describe('PerpsSession', () => {
     it('continues descending account history after a fully deduped boundary page', async () => {
       const requests: URLSearchParams[] = [];
       server.use(
-        http.get(`${production.perpsApi}/v1/account/fills`, ({ request }) => {
+        http.get(`${production.perps.rest}/v1/account/fills`, ({ request }) => {
           const params = new URL(request.url).searchParams;
           requests.push(params);
 

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -130,10 +130,9 @@ export type {
 export type PerpsSessionOptions = {
   chainId: number;
   credentials: PerpsCredentials;
+  headers?: Record<string, string>;
   onClose: (session: PerpsSession) => void;
-  restHeaders?: Record<string, string>;
   restUrl: string;
-  wsHeaders?: Record<string, string>;
   wsUrl: string;
 };
 
@@ -141,8 +140,8 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   readonly credentials: PerpsCredentials;
   readonly #api: ServiceClient;
   readonly #chainId: number;
+  readonly #headers: Record<string, string> | undefined;
   readonly #onClose: (session: PerpsSession) => void;
-  readonly #wsHeaders: Record<string, string> | undefined;
   readonly #wsUrl: string;
   readonly #connection = new WebSocketConnection({
     heartbeat: new PerpsWebSocketHeartbeat(),
@@ -157,14 +156,14 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   constructor(options: PerpsSessionOptions) {
     this.#api = new ServiceClient({
-      headers: options.restHeaders,
+      headers: options.headers,
       resolveHeaders: async () => this.#authenticatedHeaders(),
       root: options.restUrl,
     });
     this.#chainId = options.chainId;
     this.credentials = options.credentials;
+    this.#headers = options.headers;
     this.#onClose = options.onClose;
-    this.#wsHeaders = options.wsHeaders;
     this.#wsUrl = options.wsUrl;
   }
 
@@ -301,7 +300,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
       onError: () => undefined,
       onMessage: (message) => this.#handleMessage(message),
       onOpen: () => undefined,
-      headers: this.#wsHeaders,
+      headers: this.#headers,
       url: this.#wsUrl,
     });
     await this.#authenticate();

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -131,7 +131,9 @@ export type PerpsSessionOptions = {
   chainId: number;
   credentials: PerpsCredentials;
   onClose: (session: PerpsSession) => void;
+  restHeaders?: Record<string, string>;
   restUrl: string;
+  wsHeaders?: Record<string, string>;
   wsUrl: string;
 };
 
@@ -140,6 +142,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   readonly #api: ServiceClient;
   readonly #chainId: number;
   readonly #onClose: (session: PerpsSession) => void;
+  readonly #wsHeaders: Record<string, string> | undefined;
   readonly #wsUrl: string;
   readonly #connection = new WebSocketConnection({
     heartbeat: new PerpsWebSocketHeartbeat(),
@@ -154,12 +157,14 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   constructor(options: PerpsSessionOptions) {
     this.#api = new ServiceClient({
+      headers: options.restHeaders,
       resolveHeaders: async () => this.#authenticatedHeaders(),
       root: options.restUrl,
     });
     this.#chainId = options.chainId;
     this.credentials = options.credentials;
     this.#onClose = options.onClose;
+    this.#wsHeaders = options.wsHeaders;
     this.#wsUrl = options.wsUrl;
   }
 
@@ -296,6 +301,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
       onError: () => undefined,
       onMessage: (message) => this.#handleMessage(message),
       onOpen: () => undefined,
+      headers: this.#wsHeaders,
       url: this.#wsUrl,
     });
     await this.#authenticate();

--- a/packages/client/src/websockets/perps/subscription.test.ts
+++ b/packages/client/src/websockets/perps/subscription.test.ts
@@ -14,9 +14,9 @@ import { production } from '../../environments';
 import { captureConnection, collectFrames, waitForNextEvent } from '../testing';
 import { PerpsSubscriptionManager } from './subscription';
 
-const perpsSubscriptions = ws.link(production.perpsWs);
+const perpsSubscriptions = ws.link(production.perps.ws);
 const server = setupServer();
-const manager = new PerpsSubscriptionManager(production.perpsWs);
+const manager = new PerpsSubscriptionManager({ url: production.perps.ws });
 
 describe('PerpsSubscriptionManager', () => {
   beforeAll(() => {

--- a/packages/client/src/websockets/perps/subscription.ts
+++ b/packages/client/src/websockets/perps/subscription.ts
@@ -28,6 +28,11 @@ type PerpsSubscriptionEntry = SubscriptionRegistryEntry<
 
 type PerpsSubscriptionServerState = Set<string>;
 
+export type PerpsSubscriptionManagerOptions = {
+  headers?: Record<string, string>;
+  url: string;
+};
+
 /**
  * Perps public subscription WebSocket manager.
  *
@@ -42,6 +47,7 @@ export class PerpsSubscriptionManager
       PerpsMarketDataEvent
     >
 {
+  readonly #headers: Record<string, string> | undefined;
   readonly #url: string;
   #closing: Promise<void> | undefined;
   #nextRequestId = 1;
@@ -55,8 +61,9 @@ export class PerpsSubscriptionManager
     PerpsSubscriptionServerState
   >({ deriveServerState: derivePerpsSubscriptionServerState });
 
-  constructor(url: string) {
-    this.#url = url;
+  constructor(options: PerpsSubscriptionManagerOptions) {
+    this.#headers = options.headers;
+    this.#url = options.url;
   }
 
   async subscribe(
@@ -120,6 +127,7 @@ export class PerpsSubscriptionManager
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: () => this.#onConnectionOpen(),
+      headers: this.#headers,
       url: this.#url,
     });
   }

--- a/packages/client/src/websockets/rtds.test.ts
+++ b/packages/client/src/websockets/rtds.test.ts
@@ -13,9 +13,9 @@ import { production } from '../environments';
 import { RtdsWebSocketManager } from './rtds';
 import { captureConnection, collectFrames, waitForNextEvent } from './testing';
 
-const rtds = ws.link(production.rtdsWs);
+const rtds = ws.link(production.rtds.ws);
 const server = setupServer();
-const manager = new RtdsWebSocketManager(production.rtdsWs);
+const manager = new RtdsWebSocketManager({ url: production.rtds.ws });
 
 describe('RtdsWebSocketManager', () => {
   beforeAll(() => {

--- a/packages/client/src/websockets/rtds.ts
+++ b/packages/client/src/websockets/rtds.ts
@@ -42,6 +42,11 @@ type RtdsServerSubscription = {
 
 type RtdsServerState = Map<string, RtdsServerSubscription>;
 
+export type RtdsWebSocketManagerOptions = {
+  headers?: Record<string, string>;
+  url: string;
+};
+
 /**
  * Realtime Data Service (RTDS) WebSocket manager.
  *
@@ -52,6 +57,7 @@ type RtdsServerState = Map<string, RtdsServerSubscription>;
 export class RtdsWebSocketManager
   implements WebSocketSubscriptionManager<RtdsSpec, RtdsEvent>
 {
+  readonly #headers: Record<string, string> | undefined;
   readonly #url: string;
   #closing: Promise<void> | undefined;
   readonly #connection = new WebSocketConnection({
@@ -64,8 +70,9 @@ export class RtdsWebSocketManager
     RtdsServerState
   >({ deriveServerState: deriveRtdsServerState });
 
-  constructor(url: string) {
-    this.#url = url;
+  constructor(options: RtdsWebSocketManagerOptions) {
+    this.#headers = options.headers;
+    this.#url = options.url;
   }
 
   async subscribe(
@@ -132,6 +139,7 @@ export class RtdsWebSocketManager
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: () => this.#onConnectionOpen(),
+      headers: this.#headers,
       url: this.#url,
     });
   }

--- a/packages/client/src/websockets/sports.test.ts
+++ b/packages/client/src/websockets/sports.test.ts
@@ -13,10 +13,10 @@ import { production } from '../environments';
 import { SportsWebSocketManager } from './sports';
 import { captureConnection, waitForNextEvent } from './testing';
 
-const sports = ws.link(production.sportsWs);
+const sports = ws.link(production.sports.ws);
 const server = setupServer();
 const manager = new SportsWebSocketManager({
-  url: production.sportsWs,
+  url: production.sports.ws,
 });
 
 describe('SportsWebSocketManager', () => {

--- a/packages/client/src/websockets/sports.ts
+++ b/packages/client/src/websockets/sports.ts
@@ -25,6 +25,7 @@ type SportsSubscriptionEntry = SubscriptionRegistryEntry<
 >;
 
 export type SportsWebSocketManagerOptions = {
+  headers?: Record<string, string>;
   url: string;
 };
 
@@ -38,6 +39,7 @@ export type SportsWebSocketManagerOptions = {
 export class SportsWebSocketManager
   implements WebSocketSubscriptionManager<SportsSubscription, SportsEvent>
 {
+  readonly #headers: Record<string, string> | undefined;
   readonly #url: string;
   #closing: Promise<void> | undefined;
   readonly #connection = new WebSocketConnection({
@@ -50,6 +52,7 @@ export class SportsWebSocketManager
   >();
 
   constructor(options: SportsWebSocketManagerOptions) {
+    this.#headers = options.headers;
     this.#url = options.url;
   }
 
@@ -107,6 +110,7 @@ export class SportsWebSocketManager
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: () => this.#onConnectionOpen(),
+      headers: this.#headers,
       url: this.#url,
     });
   }

--- a/packages/client/tests/integration/approvals.test.ts
+++ b/packages/client/tests/integration/approvals.test.ts
@@ -22,8 +22,8 @@ describe('Approvals', () => {
       expect(secureClient.account.walletType).toBe(WalletType.DEPOSIT_WALLET);
 
       const handle = await secureClient.approveErc20({
-        spenderAddress: secureClient.environment.standardExchange,
-        tokenAddress: secureClient.environment.collateralToken,
+        spenderAddress: secureClient.environment.contracts.standardExchange,
+        tokenAddress: secureClient.environment.contracts.collateralToken,
         amount: 'max',
       });
 
@@ -47,7 +47,7 @@ describe('Approvals', () => {
         secureClient.approveErc20({
           amount: 'max',
           spenderAddress: ZERO_ADDRESS,
-          tokenAddress: secureClient.environment.collateralToken,
+          tokenAddress: secureClient.environment.contracts.collateralToken,
         }),
       ).rejects.toBeInstanceOf(SigningError);
     });
@@ -68,8 +68,8 @@ describe('Approvals', () => {
       expect(secureClient.account.walletType).toBe(WalletType.DEPOSIT_WALLET);
 
       const handle = await secureClient.approveErc1155ForAll({
-        operatorAddress: secureClient.environment.standardExchange,
-        tokenAddress: secureClient.environment.conditionalTokens,
+        operatorAddress: secureClient.environment.contracts.standardExchange,
+        tokenAddress: secureClient.environment.contracts.conditionalTokens,
       });
 
       await expect(handle.wait()).resolves.toBeTruthy();

--- a/packages/client/tests/integration/gasless.test.ts
+++ b/packages/client/tests/integration/gasless.test.ts
@@ -163,8 +163,8 @@ describe('Gasless', () => {
 
 async function prepareAndSubmit(client: SecureClient, signer: Signer) {
   const call = erc20ApprovalCall(
-    client.environment.collateralToken,
-    client.environment.standardExchange,
+    client.environment.contracts.collateralToken,
+    client.environment.contracts.standardExchange,
     1n,
   );
   const workflow = await prepareGaslessTransaction(client, {

--- a/packages/client/tests/integration/perps.test.ts
+++ b/packages/client/tests/integration/perps.test.ts
@@ -9,8 +9,10 @@ describe('Perps integration', () => {
       const approval = await secureClientWithDepositWallet.approveErc20({
         amount: 'max',
         spenderAddress:
-          secureClientWithDepositWallet.environment.perpsDepositContract,
-        tokenAddress: secureClientWithDepositWallet.environment.collateralToken,
+          secureClientWithDepositWallet.environment.contracts
+            .perpsDepositContract,
+        tokenAddress:
+          secureClientWithDepositWallet.environment.contracts.collateralToken,
       });
       await approval.wait();
 

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -31,7 +31,7 @@ import {
   unknownRfqMessage,
 } from './rfq-frames';
 
-const rfq = ws.link(production.rfqQuoterWs);
+const rfq = ws.link(production.rfq.ws);
 const server = setupServer();
 let outboundFrames: OutboundFrame[] = [];
 let connectionCount = 0;

--- a/packages/client/tests/integration/transfers.test.ts
+++ b/packages/client/tests/integration/transfers.test.ts
@@ -20,7 +20,7 @@ describe('Transfers', () => {
       const handle = await secureClient.transferErc20({
         amount: 1n,
         recipientAddress: secureClient.account.signer,
-        tokenAddress: secureClient.environment.collateralToken,
+        tokenAddress: secureClient.environment.contracts.collateralToken,
       });
 
       await expect(handle.wait()).resolves.toBeTruthy();


### PR DESCRIPTION
## Summary
- Group environment REST and WebSocket URLs into endpoint config objects with optional headers.
- Add `forkEnvironmentConfig` for custom environment derivation while retaining the existing `preproduction` export.
- Move deployed protocol addresses under `environment.contracts` while keeping `walletDerivation` top-level.

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:client`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change to EnvironmentConfig shape affects all SDK consumers and every on-chain call path via contracts nesting; wrong forked URLs or headers could misroute traffic or auth.
> 
> **Overview**
> Restructures **`EnvironmentConfig`** so service URLs live under nested endpoint objects (`rest` / `ws`) with optional **`headers`**, and on-chain addresses move under **`environment.contracts`**. **`production`** and **`preproduction`** are updated accordingly; **`preproduction`** is now built via the new **`forkEnvironmentConfig`** helper for partial overrides (URLs, contracts, headers, etc.).
> 
> **`ServiceClient`** accepts optional default **`headers`** merged into every request (with per-request and resolver headers), enabling things like Cloudflare Access on forked environments. Public and secure clients wire each REST/WS client from the new endpoint shapes, including RFQ WS headers previously on a separate **`rfqQuoterWsHeaders`** field.
> 
> Trading, gasless, perps, positions, and related code paths are updated to read contract addresses from **`environment.contracts`** instead of top-level environment fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbe260dc87885c892df3ee5af58fe5400d301bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->