### PR TITLE
fix(bindings): normalize Perps deposit update hashes

### DIFF
--- a/.changeset/perps-deposit-placeholder-hashes.md
+++ b/.changeset/perps-deposit-placeholder-hashes.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/bindings": patch
+---
+
+Normalize placeholder Perps deposit update hashes to `undefined`.

--- a/packages/bindings/src/perps/funds.test.ts
+++ b/packages/bindings/src/perps/funds.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  RawPerpsDepositUpdateSchema,
   RawPerpsWithdrawalSchema,
   RawPerpsWithdrawalUpdateSchema,
 } from './funds';
@@ -15,6 +16,19 @@ const baseWithdrawal = {
   required_confirmations: 10,
   created_timestamp: 1_700_000_000_000,
 };
+
+describe('RawPerpsDepositUpdateSchema', () => {
+  it.each(['', '0x'])('normalizes %s pending hashes to undefined', (hash) => {
+    const deposit = RawPerpsDepositUpdateSchema.parse({
+      hash,
+      asset: 'USDC',
+      amount: '1000000',
+      status: 'pending',
+    });
+
+    expect(deposit.hash).toBeUndefined();
+  });
+});
 
 describe('RawPerpsWithdrawalSchema', () => {
   it('normalizes empty pending hashes to undefined', () => {

--- a/packages/bindings/src/perps/funds.ts
+++ b/packages/bindings/src/perps/funds.ts
@@ -64,7 +64,7 @@ export const ListPerpsDepositsResponseSchema = PerpsDataResponseSchema(
 
 export const RawPerpsDepositUpdateSchema = z
   .object({
-    hash: TxHashSchema,
+    hash: RawPerpsTxHashSchema,
     asset: PerpsAssetSchema,
     amount: BaseUnitsSchema,
     status: PerpsDepositStatusSchema,


### PR DESCRIPTION
## Summary
- Normalize Perps deposit update placeholder hashes (`""` / `"0x"`) to `undefined`
- Add regression coverage for pending deposit update payloads
- Add a patch changeset for `@polymarket/bindings`

## Verification
- `pnpm test:bindings packages/bindings/src/perps/funds.test.ts`
- `pnpm --filter @polymarket/bindings build`
- `pnpm test:client packages/client/src/websockets/perps/session.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:bindings`
- `pnpm test:client`
- `pnpm --filter @polymarket/client build`
- `git diff --check`

Metered live integration tests were not rerun locally.