### PR TITLE
fix(client): default perps credential expiry

### DIFF
--- a/.changeset/default-perps-session-expiry.md
+++ b/.changeset/default-perps-session-expiry.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Default new Perps sessions to a one-week credential expiry when no custom `expiresIn` is provided.

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -751,12 +751,18 @@ const PerpsCredentialsSchema = z.object({
   expiresAt: z.number().int().positive(),
 });
 
-const CreatePerpsSessionRequestSchema = z.object({
-  expiresIn: z.number().int().positive(),
+const DEFAULT_PERPS_CREDENTIAL_EXPIRES_IN = 7 * 24 * 60 * 60 * 1000;
+
+const CreatePerpsSessionRequestSchema = z.strictObject({
+  expiresIn: z
+    .number()
+    .int()
+    .positive()
+    .default(DEFAULT_PERPS_CREDENTIAL_EXPIRES_IN),
   label: z.string().min(1).optional(),
 });
 
-const ResumePerpsSessionRequestSchema = z.object({
+const ResumePerpsSessionRequestSchema = z.strictObject({
   credentials: PerpsCredentialsSchema,
 });
 
@@ -770,6 +776,9 @@ const RevokePerpsCredentialsRequestSchema = z.object({
 });
 
 export type CreatePerpsSessionRequest = z.input<
+  typeof CreatePerpsSessionRequestSchema
+>;
+type ParsedCreatePerpsSessionRequest = z.output<
   typeof CreatePerpsSessionRequestSchema
 >;
 
@@ -885,15 +894,17 @@ export const WithdrawFromPerpsError = makeErrorGuard(
  * Opens a Perps account session.
  *
  * @remarks
- * Pass `expiresIn` to create new delegated Perps credentials, or pass existing
- * credentials to validate and resume a previous session.
+ * Omit `expiresIn` to create new delegated Perps credentials that expire after
+ * one week. Pass `expiresIn` as a duration in milliseconds to use a shorter or
+ * longer credential lifetime, or pass existing credentials to validate and
+ * resume a previous session.
  *
  * @throws {@link OpenPerpsSessionError}
  * Thrown on failure.
  */
 export async function openPerpsSession(
   client: BaseSecureClient,
-  request: OpenPerpsSessionRequest,
+  request: OpenPerpsSessionRequest = {},
 ): Promise<PerpsSession> {
   const params = parseUserInput(request, OpenPerpsSessionRequestSchema);
   const credentials =
@@ -1075,7 +1086,7 @@ export async function withdrawFromPerps(
 
 async function createPerpsCredentials(
   client: BaseSecureClient,
-  request: CreatePerpsSessionRequest,
+  request: ParsedCreatePerpsSessionRequest,
 ): Promise<PerpsCredentials> {
   const privateKey = createPerpsProxyPrivateKey();
   const proxy = addressFromPrivateKey(privateKey);

--- a/packages/client/src/decorators/perps.ts
+++ b/packages/client/src/decorators/perps.ts
@@ -129,13 +129,15 @@ export type SecurePerpsActions = PublicPerpsActions & {
    * Opens a Perps account session.
    *
    * @remarks
-   * Pass `expiresIn` to create new delegated Perps credentials, or pass existing
-   * credentials to validate and resume a previous session.
+   * Omit `expiresIn` to create new delegated Perps credentials that expire after
+   * one week. Pass `expiresIn` as a duration in milliseconds to use a shorter or
+   * longer credential lifetime, or pass existing credentials to validate and
+   * resume a previous session.
    *
    * @throws {@link OpenPerpsSessionError}
    * Thrown on failure.
    */
-  openPerpsSession(request: OpenPerpsSessionRequest): Promise<PerpsSession>;
+  openPerpsSession(request?: OpenPerpsSessionRequest): Promise<PerpsSession>;
 
   /**
    * Revokes delegated Perps credentials by proxy address.

--- a/packages/client/tests/integration/perps.test.ts
+++ b/packages/client/tests/integration/perps.test.ts
@@ -2,6 +2,8 @@ import type { PerpsSession, TxHash } from '@polymarket/client';
 import { RequestRejectedError } from '@polymarket/client';
 import { describe, expect, it, runMeteredTests } from './fixtures';
 
+const DEFAULT_PERPS_CREDENTIAL_EXPIRES_IN = 7 * 24 * 60 * 60 * 1000;
+
 describe('Perps integration', () => {
   it.runIf(runMeteredTests)(
     'deposits and withdraws the same Perps amount',
@@ -48,16 +50,20 @@ describe('Perps integration', () => {
   );
 
   it.runIf(runMeteredTests)(
-    'creates delegated Perps credentials',
+    'creates delegated Perps credentials with the default expiry',
     async ({ secureClientWithDepositWallet }) => {
-      const session = await secureClientWithDepositWallet.openPerpsSession({
-        expiresIn: 30 * 60_000,
-      });
+      const startedAt = Date.now();
+      const session = await secureClientWithDepositWallet.openPerpsSession();
 
       expect(session.credentials.proxy).toMatch(/^0x[0-9a-f]{40}$/i);
       expect(session.credentials.privateKey).toMatch(/^0x[0-9a-f]{64}$/i);
       expect(session.credentials.secret).toEqual(expect.any(String));
-      expect(session.credentials.expiresAt).toBeGreaterThan(Date.now());
+      expect(session.credentials.expiresAt).toBeGreaterThanOrEqual(
+        startedAt + DEFAULT_PERPS_CREDENTIAL_EXPIRES_IN,
+      );
+      expect(session.credentials.expiresAt).toBeLessThanOrEqual(
+        Date.now() + DEFAULT_PERPS_CREDENTIAL_EXPIRES_IN,
+      );
 
       await session.close();
     },


### PR DESCRIPTION
## Summary
- default new Perps credentials to a one-week expiry when expiresIn is omitted
- allow openPerpsSession() without a request object
- document expiresIn as a duration in milliseconds and cover the default in Perps integration tests

## Verification
- pnpm lint
- pnpm typecheck

Linear: DEV-304

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small public API and default-lifetime change in the client SDK; credential creation and resume paths are unchanged aside from the new default and optional request.
> 
> **Overview**
> New Perps sessions now get **one-week delegated credential lifetime** when `expiresIn` is omitted, via `DEFAULT_PERPS_CREDENTIAL_EXPIRES_IN` and a Zod default on the create-session schema. **`openPerpsSession()`** accepts no arguments (and the decorator signature marks the request optional), so callers can open a session without passing `{}` or an explicit duration.
> 
> Create/resume request schemas use **`z.strictObject`**, and internal credential creation uses the parsed output type so the default `expiresIn` is applied before `expiresAt` is computed. Docs now describe `expiresIn` as **milliseconds** and the omit-one-week behavior; the integration test calls `openPerpsSession()` with no args and asserts `expiresAt` falls within the one-week window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 638bcc97a7779305d08e0ef81aa7c66eae77f952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->