### PR TITLE
fix(gamma): preserve market group item title

### DIFF
--- a/.changeset/dev-316-group-item-title.md
+++ b/.changeset/dev-316-group-item-title.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Preserve `groupItemTitle` on normalized market responses.

--- a/packages/bindings/src/gamma/market.test.ts
+++ b/packages/bindings/src/gamma/market.test.ts
@@ -7,6 +7,7 @@ import {
 
 const rawBinaryMarket = {
   id: '1',
+  groupItemTitle: 'New Rihanna Album',
   marketMakerAddress: '0x0000000000000000000000000000000000000000',
   outcomes: '["Yes", "No"]',
   outcomePrices: '["0.4", "0.6"]',
@@ -28,6 +29,7 @@ describe('MarketSchema', () => {
       yes: { label: 'Yes', tokenId: null, price: '0.4' },
       no: { label: 'No', tokenId: null, price: '0.6' },
     });
+    expect(market.groupItemTitle).toBe('New Rihanna Album');
   });
 
   it('fails validation instead of throwing for multi-outcome markets', () => {

--- a/packages/bindings/src/gamma/market.test.ts
+++ b/packages/bindings/src/gamma/market.test.ts
@@ -7,7 +7,6 @@ import {
 
 const rawBinaryMarket = {
   id: '1',
-  groupItemTitle: 'New Rihanna Album',
   marketMakerAddress: '0x0000000000000000000000000000000000000000',
   outcomes: '["Yes", "No"]',
   outcomePrices: '["0.4", "0.6"]',
@@ -29,7 +28,6 @@ describe('MarketSchema', () => {
       yes: { label: 'Yes', tokenId: null, price: '0.4' },
       no: { label: 'No', tokenId: null, price: '0.6' },
     });
-    expect(market.groupItemTitle).toBe('New Rihanna Album');
   });
 
   it('fails validation instead of throwing for multi-outcome markets', () => {

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -169,6 +169,7 @@ export type Market = {
   slug?: string | null;
   conditionId: CtfConditionId | null;
   question?: string | null;
+  groupItemTitle?: string | null;
   description?: string | null;
   category?: string | null;
   image?: string | null;
@@ -420,6 +421,7 @@ export function normalizeMarket(market: GammaMarket): Market {
     slug: market.slug,
     conditionId: market.conditionId,
     question: market.question,
+    groupItemTitle: market.groupItemTitle,
     description: market.description,
     category: market.category,
     image: market.image,


### PR DESCRIPTION
## Summary
- add groupItemTitle to the normalized Market model
- preserve groupItemTitle during market normalization
- cover the field in the existing market schema test

## Verification
- pnpm test:bindings -- packages/bindings/src/gamma/market.test.ts
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive field on bindings normalization with no auth or trading logic changes; consumers may start seeing a new optional property.
> 
> **Overview**
> Normalized Gamma **market** objects now expose **`groupItemTitle`**, so grouped-market labels from the API are no longer dropped when responses pass through **`normalizeMarket`**.
> 
> The **`Market`** type and **`normalizeMarket`** mapping were updated to copy **`groupItemTitle`** from the existing raw **`GammaMarket`** payload (the field was already parsed on ingest).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96e935c5a907894c72ef313e37f8e1af34b1aafc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->