### PR TITLE
fix(client): type search sort fields

### DIFF
--- a/.changeset/search-sort-types.md
+++ b/.changeset/search-sort-types.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Add a typed `SearchSort` enum for supported search sort fields and reject unsupported search sort values.

--- a/packages/client/src/actions/search.ts
+++ b/packages/client/src/actions/search.ts
@@ -27,6 +27,16 @@ import {
 import { validateWith } from '../response';
 import { snakeCase, toSearchParams } from './params';
 
+export enum SearchSort {
+  Volume = 'volume',
+  Volume24Hr = 'volume_24hr',
+  Liquidity = 'liquidity',
+  Competitive = 'competitive',
+  ClosedTime = 'closed_time',
+  StartDate = 'start_date',
+  EndDate = 'end_date',
+}
+
 const SearchRequestSchema = z.object({
   q: z.string().trim().min(1),
   ascending: z.boolean().optional(),
@@ -42,7 +52,7 @@ const SearchRequestSchema = z.object({
   recurrence: z.enum(['daily', 'weekly', 'monthly']).optional(),
   searchProfiles: z.boolean().optional(),
   searchTags: z.boolean().optional(),
-  sort: z.string().min(1).optional(),
+  sort: z.enum(SearchSort).optional(),
 });
 
 export type SearchRequest = z.input<typeof SearchRequestSchema>;
@@ -79,6 +89,8 @@ export const SearchError = makeErrorGuard(
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ * `keepClosedMarkets` is an hour window for including recently closed markets
+ * when searching active events.
  *
  * @throws {@link SearchError}
  * Thrown on failure.

--- a/packages/client/src/decorators/discovery.ts
+++ b/packages/client/src/decorators/discovery.ts
@@ -401,6 +401,9 @@ export type DiscoveryActions = {
   /**
    * Runs a public full-text search.
    *
+   * `keepClosedMarkets` is an hour window for including recently closed markets
+   * when searching active events.
+   *
    * @throws {@link SearchError}
    * Thrown on failure.
    *

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -19,6 +19,7 @@ export {
 } from '@polymarket/bindings/perps';
 export type * from '@polymarket/bindings/relayer';
 export * from './abis';
+export { SearchSort } from './actions';
 export type {
   RelayerApiKeyConfig,
   RemoteBuilderSigningConfig,

--- a/packages/client/tests/integration/search.test.ts
+++ b/packages/client/tests/integration/search.test.ts
@@ -1,4 +1,4 @@
-import { UserInputError } from '@polymarket/client';
+import { SearchSort, UserInputError } from '@polymarket/client';
 import { describe, expect, it } from './fixtures';
 
 describe('Search', () => {
@@ -9,6 +9,7 @@ describe('Search', () => {
         pageSize: 1,
         searchProfiles: true,
         searchTags: true,
+        sort: SearchSort.Volume,
       });
       const firstPage = await paginator.firstPage();
 
@@ -38,6 +39,12 @@ describe('Search', () => {
 
     it('rejects whitespace-only queries', ({ publicClient }) => {
       expect(() => publicClient.search({ q: '   ' })).toThrow(UserInputError);
+    });
+
+    it('rejects unsupported sort fields', ({ publicClient }) => {
+      expect(() =>
+        publicClient.search({ q: 'trump', sort: 'recent' as SearchSort }),
+      ).toThrow(UserInputError);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add a public `SearchSort` enum for supported search sort fields
- validate search sort input against the supported enum
- clarify that `keepClosedMarkets` is an hour window, not a boolean
- add a patch changeset

## Verification
- `pnpm exec vitest --project client-integration packages/client/tests/integration/search.test.ts`
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrower client-side validation and documentation only; no auth, data, or server behavior changes beyond rejecting bad sort strings earlier.
> 
> **Overview**
> Search **`sort`** is now constrained to a public **`SearchSort`** enum instead of any non-empty string, so invalid values fail at input validation with **`UserInputError`** instead of reaching the API.
> 
> **`SearchSort`** is re-exported from **`@polymarket/client`**. JSDoc on **`search`** / **`client.search`** clarifies that **`keepClosedMarkets`** is an hour window for recently closed markets when searching active events. Integration coverage uses a typed sort and asserts rejection of unsupported sort values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d37bde4401612115d7071e837482c19617b2e2a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->