### PR TITLE
fix(client): align Perps order placement

### DIFF
--- a/.changeset/perps-command-signing.md
+++ b/.changeset/perps-command-signing.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Fix Perps session command signing to match backend MessagePack hashes and surface top-level WebSocket error acknowledgements as request rejections.

--- a/.changeset/perps-place-order-wait.md
+++ b/.changeset/perps-place-order-wait.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Make Perps session `placeOrder` wait for the first matching orders update, rename ack-only batch placement to `postOrders`, normalize Perps order entity ids as `id`, and type order statuses with `PerpsOrderStatus`.

--- a/packages/bindings/src/perps/orders.test.ts
+++ b/packages/bindings/src/perps/orders.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  PerpsOrderSchema,
+  PerpsOrderStatus,
   RawPerpsAccountFillSchema,
   RawPerpsCancelOrderAckSchema,
-  RawPerpsPlaceOrderAckSchema,
+  RawPerpsPostOrderAckSchema,
 } from './orders';
 
 const baseFill = {
@@ -33,15 +35,15 @@ describe('RawPerpsAccountFillSchema', () => {
   });
 });
 
-describe('RawPerpsPlaceOrderAckSchema', () => {
-  it('normalizes mixed place order acknowledgements', () => {
+describe('RawPerpsPostOrderAckSchema', () => {
+  it('normalizes mixed post order acknowledgements', () => {
     const acks = [
-      RawPerpsPlaceOrderAckSchema.parse({
+      RawPerpsPostOrderAckSchema.parse({
         coid: '0123456789abcdef0123456789abcdef',
         oid: 123,
         status: 'ok',
       }),
-      RawPerpsPlaceOrderAckSchema.parse({
+      RawPerpsPostOrderAckSchema.parse({
         coid: 'fedcba9876543210fedcba9876543210',
         error: 'insufficient_margin',
         status: 'err',
@@ -62,8 +64,30 @@ describe('RawPerpsPlaceOrderAckSchema', () => {
     ]);
   });
 
-  it('requires order id for accepted place order acknowledgements', () => {
-    expect(() => RawPerpsPlaceOrderAckSchema.parse({ status: 'ok' })).toThrow();
+  it('requires order id for accepted post order acknowledgements', () => {
+    expect(() => RawPerpsPostOrderAckSchema.parse({ status: 'ok' })).toThrow();
+  });
+});
+
+describe('PerpsOrderSchema', () => {
+  it('normalizes typed order statuses', () => {
+    const order = PerpsOrderSchema.parse({
+      buy: true,
+      created_timestamp: 1_700_000_000_000,
+      filled_quantity: '1',
+      instrument_id: 1,
+      order_id: 123,
+      post_only: false,
+      price: '100',
+      quantity: '2',
+      resting_quantity: '1',
+      status: 'partial',
+      tif: 'gtc',
+      updated_timestamp: 1_700_000_000_000,
+    });
+
+    expect(order.id).toBe(123);
+    expect(order.status).toBe(PerpsOrderStatus.Partial);
   });
 });
 

--- a/packages/bindings/src/perps/orders.ts
+++ b/packages/bindings/src/perps/orders.ts
@@ -16,23 +16,35 @@ import {
   RawPerpsTxHashSchema,
 } from './common';
 
-export const PerpsOrderSchema = z.object({
-  orderId: PerpsOrderIdSchema,
-  instrumentId: PerpsInstrumentIdSchema,
-  buy: z.boolean(),
-  price: DecimalStringSchema,
-  quantity: DecimalStringSchema,
-  timeInForce: PerpsTimeInForceSchema,
-  postOnly: z.boolean(),
-  status: z.string().min(1),
-  restingQuantity: DecimalStringSchema,
-  filledQuantity: DecimalStringSchema,
-  createdTimestamp: EpochMillisecondsSchema,
-  updatedTimestamp: EpochMillisecondsSchema,
-  clientOrderId: z.string().optional(),
-});
+export enum PerpsOrderStatus {
+  Accepted = 'accepted',
+  Open = 'open',
+  Partial = 'partial',
+  Filled = 'filled',
+  Cancelled = 'cancelled',
+  AutoCancelled = 'auto_cancelled',
+  PostOnlyRejected = 'post_only_rejected',
+  FokUnfilled = 'fok_unfilled',
+  IocNoFill = 'ioc_no_fill',
+  IocExpired = 'ioc_expired',
+  StpCancelled = 'stp_cancelled',
+  ZeroQuantity = 'zero_quantity',
+  DuplicateOrder = 'duplicate_order',
+  OrderNotFound = 'order_not_found',
+  ReduceOnlyInvalid = 'reduce_only_invalid',
+  ReduceOnlyExpired = 'reduce_only_expired',
+  OrderExpired = 'order_expired',
+  Untriggered = 'untriggered',
+  Armed = 'armed',
+  Triggered = 'triggered',
+  ParentCancelled = 'parent_cancelled',
+  PositionClosed = 'position_closed',
+  PositionFlipped = 'position_flipped',
+  ReduceOnlyInvalidAtTrigger = 'reduce_only_invalid_at_trigger',
+  Expired = 'expired',
+}
 
-export type PerpsOrder = z.infer<typeof PerpsOrderSchema>;
+export const PerpsOrderStatusSchema = z.enum(PerpsOrderStatus);
 
 export const PerpsCommandStatusSchema = z.enum(['ok', 'err']);
 
@@ -42,7 +54,7 @@ const PerpsAckErrorSchema = z
   .optional()
   .transform(perpsAckError);
 
-export const PerpsPlaceOrderAckSchema = z.discriminatedUnion('status', [
+export const PerpsPostOrderAckSchema = z.discriminatedUnion('status', [
   z.object({
     status: z.literal('ok'),
     orderId: PerpsOrderIdSchema,
@@ -55,7 +67,7 @@ export const PerpsPlaceOrderAckSchema = z.discriminatedUnion('status', [
   }),
 ]);
 
-export type PerpsPlaceOrderAck = z.infer<typeof PerpsPlaceOrderAckSchema>;
+export type PerpsPostOrderAck = z.infer<typeof PerpsPostOrderAckSchema>;
 
 export const PerpsModifyOrderAckSchema = z.discriminatedUnion('status', [
   z.object({ status: z.literal('ok') }),
@@ -93,14 +105,14 @@ export const PerpsCommandAckSchema = z.discriminatedUnion('status', [
 
 export type PerpsCommandAck = z.infer<typeof PerpsCommandAckSchema>;
 
-export const RawPerpsPlaceOrderAckSchema = z
+export const RawPerpsPostOrderAckSchema = z
   .object({
     status: PerpsCommandStatusSchema,
     oid: PerpsOrderIdSchema.optional(),
     coid: PerpsClientOrderIdSchema.optional(),
     error: z.string().optional(),
   })
-  .transform((ack, ctx): PerpsPlaceOrderAck => {
+  .transform((ack, ctx): PerpsPostOrderAck => {
     if (ack.status === 'err') {
       return {
         status: 'err',
@@ -165,7 +177,7 @@ function perpsAckError(error: string | undefined): string {
   return error ?? 'Perps command was rejected.';
 }
 
-export const RawPerpsOrderSchema = z
+export const PerpsOrderSchema = z
   .object({
     order_id: PerpsOrderIdSchema,
     instrument_id: PerpsInstrumentIdSchema,
@@ -174,7 +186,7 @@ export const RawPerpsOrderSchema = z
     quantity: DecimalStringSchema,
     tif: PerpsTimeInForceSchema,
     post_only: z.boolean(),
-    status: z.string().min(1),
+    status: PerpsOrderStatusSchema,
     resting_quantity: DecimalStringSchema,
     filled_quantity: DecimalStringSchema,
     created_timestamp: EpochMillisecondsSchema,
@@ -182,7 +194,7 @@ export const RawPerpsOrderSchema = z
     client_order_id: z.string().optional(),
   })
   .transform((order) => ({
-    orderId: order.order_id,
+    id: order.order_id,
     instrumentId: order.instrument_id,
     buy: order.buy,
     price: order.price,
@@ -197,9 +209,11 @@ export const RawPerpsOrderSchema = z
     clientOrderId: order.client_order_id,
   }));
 
-export const FetchPerpsOrdersResponseSchema = z.array(RawPerpsOrderSchema);
+export type PerpsOrder = z.infer<typeof PerpsOrderSchema>;
 
-export const FetchPerpsOpenOrdersResponseSchema = z.array(RawPerpsOrderSchema);
+export const FetchPerpsOrdersResponseSchema = z.array(PerpsOrderSchema);
+
+export const FetchPerpsOpenOrdersResponseSchema = z.array(PerpsOrderSchema);
 
 export const RawPerpsOrderUpdateSchema = z
   .object({
@@ -210,7 +224,7 @@ export const RawPerpsOrderUpdateSchema = z
     qty: DecimalStringSchema,
     tif: PerpsTimeInForceSchema,
     po: z.boolean(),
-    status: z.string().min(1),
+    status: PerpsOrderStatusSchema,
     rest: DecimalStringSchema,
     fill: DecimalStringSchema,
     cts: EpochMillisecondsSchema,
@@ -218,7 +232,7 @@ export const RawPerpsOrderUpdateSchema = z
     coid: z.string().optional(),
   })
   .transform((order) => ({
-    orderId: order.oid,
+    id: order.oid,
     instrumentId: order.iid,
     buy: order.buy,
     price: order.p,

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -99,11 +99,11 @@ export type {
   ModifyPerpsOrdersRequest,
   PerpsCancelOrderAck,
   PerpsModifyOrderAck,
-  PerpsPlaceOrderAck,
+  PerpsPostOrderAck,
   PerpsSession,
   PerpsSessionEvent,
   PlacePerpsOrderRequest,
-  PlacePerpsOrdersRequest,
+  PostPerpsOrdersRequest,
   UpdatePerpsLeverageRequest,
   UpdatePerpsMarginRequest,
 } from '../websockets/perps/session';

--- a/packages/client/src/decorators/perps.ts
+++ b/packages/client/src/decorators/perps.ts
@@ -45,7 +45,7 @@ import type { TransactionHandle } from '../types';
 export type {
   PerpsCancelOrderAck,
   PerpsModifyOrderAck,
-  PerpsPlaceOrderAck,
+  PerpsPostOrderAck,
   PerpsSession,
   PerpsSessionEvent,
 } from '../actions';

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -13,6 +13,7 @@ export {
   PerpsInstrumentType,
   PerpsInternalTransferDirection,
   PerpsKlineInterval,
+  PerpsOrderStatus,
   PerpsSide,
   PerpsTimeInForce,
   PerpsWithdrawalStatus,

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -32,7 +32,7 @@ import {
   UserInputError,
 } from '../../../errors';
 import { parseUserInput } from '../../../input';
-import type { PerpsSignedOp } from '../signing';
+import type { PerpsSignableValue, PerpsSignedOp } from '../signing';
 
 type RawPerpsOrderInput = readonly [
   PerpsInstrumentId,
@@ -62,7 +62,7 @@ export type PerpsSignedWsCommandRequest<T> = {
 };
 
 export type PerpsSignedHttpCommandRequest = {
-  bodyOp: unknown;
+  bodyOp: PerpsSignableValue;
   op: PerpsSignedOp;
 };
 
@@ -327,11 +327,11 @@ export async function updatePerpsMargin(
   const ack = await transport.sendSignedHttpCommand('/v1/trade/margin', {
     op: ['updateMargin', [params.instrumentId, amount]],
     bodyOp: {
+      type: 'updateMargin',
       args: {
         amt: amount,
         iid: params.instrumentId,
       },
-      type: 'updateMargin',
     },
   });
   if (ack.status === 'err') {
@@ -361,22 +361,22 @@ export function toPerpsCommandBodyOp(op: PerpsSignedOp) {
   switch (type) {
     case 'createOrders':
       return {
-        args: (args as RawPerpsOrderInput[]).map(toPerpsOrderBody),
         type,
+        args: (args as RawPerpsOrderInput[]).map(toPerpsOrderBody),
       };
     case 'modifyOrders':
       return {
+        type,
         args: (args as Array<readonly [PerpsOrderId, RawPerpsOrderInput]>).map(
           ([orderId, order]) => ({
             oid: orderId,
             order: toPerpsOrderBody(order),
           }),
         ),
-        type,
       };
     case 'cancelOrders':
     case 'cancelOrdersCOID':
-      return { args, type };
+      return { type, args };
     case 'updateLeverage': {
       const [instrumentId, leverage, crossMargin] = args as readonly [
         PerpsInstrumentId,
@@ -384,12 +384,12 @@ export function toPerpsCommandBodyOp(op: PerpsSignedOp) {
         boolean,
       ];
       return {
+        type,
         args: {
           cross: crossMargin,
           iid: instrumentId,
           lev: leverage,
         },
-        type,
       };
     }
     default:
@@ -399,13 +399,13 @@ export function toPerpsCommandBodyOp(op: PerpsSignedOp) {
 
 function toPerpsOrderBody(order: RawPerpsOrderInput) {
   const body: Record<string, unknown> = {
-    buy: order[1],
     iid: order[0],
-    po: order[5],
-    qty: order[3],
-    tif: order[4],
+    buy: order[1],
   };
   if (order[2] !== undefined) body.p = order[2];
+  body.qty = order[3];
+  if (order[4] !== undefined) body.tif = order[4];
+  body.po = order[5];
   if (order[6] !== undefined) body.c = order[6];
   return body;
 }

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -14,12 +14,12 @@ import {
   type PerpsModifyOrderAck,
   type PerpsOrderId,
   PerpsOrderIdSchema,
-  type PerpsPlaceOrderAck,
+  type PerpsPostOrderAck,
   type PerpsTimeInForce,
   PerpsTimeInForceSchema,
   RawPerpsCancelOrderAckSchema,
   RawPerpsModifyOrderAckSchema,
-  RawPerpsPlaceOrderAckSchema,
+  RawPerpsPostOrderAckSchema,
 } from '@polymarket/bindings/perps';
 import { expectPresent, invariant } from '@polymarket/types';
 import { z } from 'zod';
@@ -80,32 +80,24 @@ export type PlacePerpsOrderRequest = z.input<
   typeof PlacePerpsOrderRequestSchema
 >;
 
-export async function placePerpsOrder(
-  transport: PerpsTradingTransport,
-  request: PlacePerpsOrderRequest,
-): Promise<PerpsPlaceOrderAck> {
-  const [ack] = await placePerpsOrders(transport, { orders: [request] });
-  return expectPresent(ack, 'Expected Perps place order acknowledgement.');
-}
-
-const PlacePerpsOrdersRequestSchema = z.object({
+const PostPerpsOrdersRequestSchema = z.object({
   orders: z.array(PerpsOrderInputSchema).min(1),
   expiresAt: z.number().int().positive().optional(),
 });
 
-export type PlacePerpsOrdersRequest = z.input<
-  typeof PlacePerpsOrdersRequestSchema
+export type PostPerpsOrdersRequest = z.input<
+  typeof PostPerpsOrdersRequestSchema
 >;
 
-export async function placePerpsOrders(
+export async function postPerpsOrders(
   transport: PerpsTradingTransport,
-  request: PlacePerpsOrdersRequest,
-): Promise<PerpsPlaceOrderAck[]> {
-  const params = parseUserInput(request, PlacePerpsOrdersRequestSchema);
+  request: PostPerpsOrdersRequest,
+): Promise<PerpsPostOrderAck[]> {
+  const params = parseUserInput(request, PostPerpsOrdersRequestSchema);
   return await transport.sendSignedWsCommand({
     op: ['createOrders', params.orders.map(toRawPerpsOrder)],
-    responseSchema: z.array(RawPerpsPlaceOrderAckSchema),
-    timeoutMessage: 'Perps place order acknowledgement timed out.',
+    responseSchema: z.array(RawPerpsPostOrderAckSchema),
+    timeoutMessage: 'Perps post order acknowledgement timed out.',
     expiresAt: params.expiresAt,
   });
 }

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -328,6 +328,35 @@ describe('PerpsSession', () => {
       }
     });
 
+    it('rejects request-level order errors', async () => {
+      mockCommandSession((frame) => {
+        if (frame.op?.type === 'createOrders') {
+          return {
+            error: 'price exceeds allowed precision',
+            status: 'err',
+          };
+        }
+
+        return responseForFrame(frame);
+      });
+      const session = createSession();
+      await session.connect();
+
+      try {
+        await expect(
+          session.placeOrder({
+            instrumentId: 1,
+            price: '100.123',
+            quantity: '1',
+            side: OrderSide.BUY,
+            timeInForce: PerpsTimeInForce.Gtc,
+          }),
+        ).rejects.toThrow(RequestRejectedError);
+      } finally {
+        await session.close();
+      }
+    });
+
     it('returns mixed batch order acknowledgements', async () => {
       mockCommandSession((frame) => {
         if (frame.op?.type === 'createOrders') {

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -247,7 +247,7 @@ describe('PerpsSession', () => {
       const session = createSession();
       await session.connect();
 
-      const [ack] = await session.placeOrders({
+      const [ack] = await session.postOrders({
         orders: [
           {
             clientOrderId: '0123456789abcdef0123456789abcdef',
@@ -291,7 +291,106 @@ describe('PerpsSession', () => {
       await session.close();
     });
 
-    it('returns rejected order acknowledgements', async () => {
+    it('waits for the matching private order update', async () => {
+      const frames = mockOrderPlacementSession({ status: 'open' });
+      const session = createSession();
+      await session.connect();
+
+      const nextEvent = waitForNextEvent(session);
+      await expect(
+        session.placeOrder({
+          clientOrderId: '0123456789abcdef0123456789abcdef',
+          instrumentId: 1,
+          postOnly: false,
+          price: '100.00',
+          quantity: '1.5',
+          side: OrderSide.BUY,
+          timeInForce: PerpsTimeInForce.Gtc,
+        }),
+      ).resolves.toMatchObject({
+        clientOrderId: '0123456789abcdef0123456789abcdef',
+        id: 123,
+        restingQuantity: '1.5',
+        status: 'open',
+      });
+      expect(frames[2]).toMatchObject({
+        op: { type: 'createOrders' },
+        req: 'post',
+      });
+      await expect(nextEvent).resolves.toMatchObject({
+        done: false,
+        value: {
+          payload: {
+            id: 123,
+            status: 'open',
+          },
+          type: 'order',
+        },
+      });
+
+      await session.close();
+    });
+
+    it('returns terminal placement updates after the ack', async () => {
+      mockOrderPlacementSession({
+        status: 'post_only_rejected',
+      });
+      const session = createSession();
+      await session.connect();
+
+      try {
+        await expect(
+          session.placeOrder({
+            clientOrderId: '0123456789abcdef0123456789abcdef',
+            instrumentId: 1,
+            postOnly: true,
+            price: '100.00',
+            quantity: '1.5',
+            side: OrderSide.BUY,
+            timeInForce: PerpsTimeInForce.Gtc,
+          }),
+        ).resolves.toMatchObject({
+          clientOrderId: '0123456789abcdef0123456789abcdef',
+          id: 123,
+          status: 'post_only_rejected',
+        });
+      } finally {
+        await session.close();
+      }
+    });
+
+    it('throws when place order receives a rejected order acknowledgement', async () => {
+      mockCommandSession((frame) => {
+        if (frame.op?.type === 'createOrders') {
+          return [
+            {
+              error: 'insufficient margin',
+              status: 'err',
+            },
+          ];
+        }
+
+        return responseForFrame(frame);
+      });
+      const session = createSession();
+      await session.connect();
+
+      try {
+        await expect(
+          session.placeOrder({
+            instrumentId: 1,
+            price: '100',
+            quantity: '1',
+            side: OrderSide.BUY,
+            timeInForce: PerpsTimeInForce.Ioc,
+          }),
+        ).rejects.toBeInstanceOf(RequestRejectedError);
+      } finally {
+        await session.close();
+      }
+    });
+
+    it('returns rejected post order acknowledgements', async () => {
       mockCommandSession((frame) => {
         if (frame.op?.type === 'createOrders') {
           return [
@@ -310,19 +409,25 @@ describe('PerpsSession', () => {
 
       try {
         await expect(
-          session.placeOrder({
-            clientOrderId: '0123456789abcdef0123456789abcdef',
-            instrumentId: 1,
-            price: '100',
-            quantity: '1',
-            side: OrderSide.BUY,
-            timeInForce: PerpsTimeInForce.Ioc,
+          session.postOrders({
+            orders: [
+              {
+                clientOrderId: '0123456789abcdef0123456789abcdef',
+                instrumentId: 1,
+                price: '100',
+                quantity: '1',
+                side: OrderSide.BUY,
+                timeInForce: PerpsTimeInForce.Ioc,
+              },
+            ],
           }),
-        ).resolves.toEqual({
-          clientOrderId: '0123456789abcdef0123456789abcdef',
-          status: 'err',
-          error: 'order would cross post-only book',
-        });
+        ).resolves.toEqual([
+          {
+            clientOrderId: '0123456789abcdef0123456789abcdef',
+            status: 'err',
+            error: 'order would cross post-only book',
+          },
+        ]);
       } finally {
         await session.close();
       }
@@ -379,7 +484,7 @@ describe('PerpsSession', () => {
 
       try {
         await expect(
-          session.placeOrders({
+          session.postOrders({
             orders: [
               {
                 instrumentId: 1,
@@ -705,6 +810,40 @@ function mockCommandSession(
   return frames;
 }
 
+function mockOrderPlacementSession(request: { status: string }): unknown[] {
+  const frames: unknown[] = [];
+
+  server.use(
+    perps.addEventListener('connection', ({ client }) => {
+      client.addEventListener('message', (event) => {
+        const frame = JSON.parse(String(event.data));
+        frames.push(frame);
+
+        if (frame.op?.type === 'createOrders') {
+          const update = orderUpdate(request.status);
+          client.send(
+            JSON.stringify({
+              id: frame.id,
+              data: responseForFrame(frame),
+            }),
+          );
+          setTimeout(() => client.send(JSON.stringify(update)), 0);
+          return;
+        }
+
+        client.send(
+          JSON.stringify({
+            id: frame.id,
+            data: responseForFrame(frame),
+          }),
+        );
+      });
+    }),
+  );
+
+  return frames;
+}
+
 function responseForFrame(frame: { op?: { type?: string }; req?: string }) {
   if (frame.req === 'sub') return [{ status: 'ok' }];
   switch (frame.op?.type) {
@@ -796,6 +935,30 @@ function balanceUpdate(request: { balance: string; sequence: number }) {
       value: request.balance,
     },
     sq: request.sequence,
+    ts: 1_700_000_000_000,
+  };
+}
+
+function orderUpdate(status: string) {
+  return {
+    ch: 'orders',
+    data: {
+      buy: true,
+      coid: '0123456789abcdef0123456789abcdef',
+      cts: 1_700_000_000_000,
+      fill: status === 'filled' ? '1.5' : '0',
+      iid: 1,
+      oid: 123,
+      p: '100.00',
+      po: false,
+      qty: '1.5',
+      rest: status === 'filled' ? '0' : '1.5',
+      ro: false,
+      status,
+      tif: 'gtc',
+      uts: 1_700_000_000_000,
+    },
+    sq: 1,
     ts: 1_700_000_000_000,
   };
 }

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -11,21 +11,28 @@ import {
   type PerpsEquityPoint,
   type PerpsModifyOrderAck,
   type PerpsOrder,
-  type PerpsPlaceOrderAck,
   type PerpsPnlPoint,
   type PerpsPortfolio,
+  type PerpsPostOrderAck,
   type PerpsWithdrawal,
 } from '@polymarket/bindings/perps';
 import {
+  type PerpsOrderUpdateEvent,
   type PerpsSessionEvent,
   PerpsSessionUpdateEventSchema,
 } from '@polymarket/bindings/subscriptions';
-import { invariant, setNonBlockingTimeout, unwrap } from '@polymarket/types';
+import {
+  expectNonEmptyArray,
+  invariant,
+  setNonBlockingTimeout,
+  unwrap,
+} from '@polymarket/types';
 import { type Pushable, pushable } from 'it-pushable';
 import { z } from 'zod';
 import {
   RequestRejectedError,
   SigningError,
+  TimeoutError,
   TransportError,
 } from '../../errors';
 import type { Paginated } from '../../pagination';
@@ -68,9 +75,8 @@ import {
   type PerpsSignedWsCommandRequest,
   type PerpsTradingTransport,
   type PlacePerpsOrderRequest,
-  type PlacePerpsOrdersRequest,
-  placePerpsOrder,
-  placePerpsOrders,
+  type PostPerpsOrdersRequest,
+  postPerpsOrders,
   toPerpsCommandBodyOp,
   type UpdatePerpsLeverageRequest,
   type UpdatePerpsMarginRequest,
@@ -81,6 +87,8 @@ import { type PerpsSignableValue, signPerpsOp } from './signing';
 
 const AUTH_TIMEOUT_MS = 30_000;
 const ACK_TIMEOUT_MS = 30_000;
+// Purposefully generous: backend order updates are expected in the ~100ms range.
+const ORDER_PLACEMENT_UPDATE_TIMEOUT_MS = 500;
 const PERPS_SESSION_CHANNELS = [
   'balances',
   'portfolio',
@@ -112,10 +120,17 @@ type PendingResponse = {
   schema: z.ZodType;
 };
 
+type EventWaiter = {
+  predicate(event: PerpsSessionEvent): boolean;
+  reject(error: Error): void;
+  resolve(event: PerpsSessionEvent): void;
+  timeout: ReturnType<typeof setNonBlockingTimeout>;
+};
+
 export type {
   PerpsCancelOrderAck,
   PerpsModifyOrderAck,
-  PerpsPlaceOrderAck,
+  PerpsPostOrderAck,
 } from '@polymarket/bindings/perps';
 export type { PerpsSessionEvent } from '@polymarket/bindings/subscriptions';
 export type {
@@ -135,7 +150,7 @@ export type {
   ModifyPerpsOrderRequest,
   ModifyPerpsOrdersRequest,
   PlacePerpsOrderRequest,
-  PlacePerpsOrdersRequest,
+  PostPerpsOrdersRequest,
   UpdatePerpsLeverageRequest,
   UpdatePerpsMarginRequest,
 } from './actions/trading';
@@ -165,6 +180,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   });
   readonly #queue: Pushable<PerpsSessionEvent> = pushable({ objectMode: true });
   readonly #pending = new Map<number, PendingResponse>();
+  readonly #eventWaiters = new Set<EventWaiter>();
   readonly #reconnectScheduler = new ReconnectScheduler();
   readonly #sequences = new Map<string, number>();
   readonly #lastDedupedPayload = new Map<string, string>();
@@ -263,16 +279,38 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     return listPerpsPnlHistory(this.#api, request);
   }
 
-  async placeOrder(
-    request: PlacePerpsOrderRequest,
-  ): Promise<PerpsPlaceOrderAck> {
-    return await placePerpsOrder(this.#tradingTransport(), request);
+  /**
+   * Places one Perps order and resolves with the first matching orders update.
+   *
+   * @throws Thrown on failure.
+   */
+  async placeOrder(request: PlacePerpsOrderRequest): Promise<PerpsOrder> {
+    const [acknowledgement] = await postPerpsOrders(this.#tradingTransport(), {
+      orders: [request],
+    }).then(expectNonEmptyArray);
+
+    if (acknowledgement.status === 'err') {
+      throw new RequestRejectedError(acknowledgement.error, { status: 200 });
+    }
+
+    const update = await this.#waitForEvent(
+      (event): event is PerpsOrderUpdateEvent =>
+        event.type === 'order' && event.payload.id === acknowledgement.orderId,
+      ORDER_PLACEMENT_UPDATE_TIMEOUT_MS,
+    );
+    return update.payload;
   }
 
-  async placeOrders(
-    request: PlacePerpsOrdersRequest,
-  ): Promise<PerpsPlaceOrderAck[]> {
-    return await placePerpsOrders(this.#tradingTransport(), request);
+  /**
+   * Posts one or more Perps orders and returns queue-entry acknowledgements.
+   *
+   * @remarks
+   * This is a low-level method. Most SDK consumers should prefer `placeOrder`.
+   */
+  async postOrders(
+    request: PostPerpsOrdersRequest,
+  ): Promise<PerpsPostOrderAck[]> {
+    return await postPerpsOrders(this.#tradingTransport(), request);
   }
 
   async modifyOrder(
@@ -466,6 +504,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async #shutdown(): Promise<void> {
     this.#reconnectScheduler.stop();
     this.#rejectPending(new TransportError('Perps session closed.'));
+    this.#rejectEventWaiters(new TransportError('Perps session closed.'));
     this.#queue.end();
     await this.#connection.close();
     this.#onClose(this);
@@ -481,7 +520,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     const shouldSkipDedupedTick = this.#shouldSkipDedupedTick(event);
     this.#pushSequenceGapIfNeeded(event);
     if (shouldSkipDedupedTick) return;
-    this.#queue.push(event);
+    this.#emitEvent(event);
   }
 
   #handleResponse(rawMessage: unknown): boolean {
@@ -516,6 +555,9 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   #handleClose(): void {
     this.#rejectPending(new TransportError('Perps session connection closed.'));
+    this.#rejectEventWaiters(
+      new TransportError('Perps session connection closed.'),
+    );
     if (this.#closing !== undefined) return;
 
     this.#reconnectScheduler.schedule({
@@ -556,13 +598,68 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
       return;
     }
 
-    this.#queue.push({
+    this.#emitEvent({
       channel: event.channel,
       previousSequence,
       reason: 'sequence_gap',
       sequence: event.sequence,
       type: 'resync',
     });
+  }
+
+  #emitEvent(event: PerpsSessionEvent): void {
+    this.#resolveEventWaiters(event);
+    this.#queue.push(event);
+  }
+
+  #waitForEvent<TEvent extends PerpsSessionEvent>(
+    predicate: (event: PerpsSessionEvent) => event is TEvent,
+    timeoutMs: number,
+  ): Promise<TEvent> {
+    return this.#createEventWaiter(predicate, timeoutMs).then(
+      (event) => event as TEvent,
+    );
+  }
+
+  #createEventWaiter(
+    predicate: (event: PerpsSessionEvent) => boolean,
+    timeoutMs: number,
+  ): Promise<PerpsSessionEvent> {
+    let waiter!: EventWaiter;
+    const promise = new Promise<PerpsSessionEvent>((resolve, reject) => {
+      waiter = {
+        predicate,
+        reject,
+        resolve,
+        timeout: setNonBlockingTimeout(() => {
+          this.#removeEventWaiter(waiter);
+          reject(new TimeoutError('Perps event wait timed out.'));
+        }, timeoutMs),
+      };
+    });
+    this.#eventWaiters.add(waiter);
+    return promise;
+  }
+
+  #resolveEventWaiters(event: PerpsSessionEvent): void {
+    for (const waiter of Array.from(this.#eventWaiters)) {
+      if (waiter.predicate(event)) {
+        this.#removeEventWaiter(waiter);
+        waiter.resolve(event);
+      }
+    }
+  }
+
+  #removeEventWaiter(waiter: EventWaiter): void {
+    if (!this.#eventWaiters.delete(waiter)) return;
+    clearTimeout(waiter.timeout);
+  }
+
+  #rejectEventWaiters(error: Error): void {
+    for (const waiter of Array.from(this.#eventWaiters)) {
+      this.#removeEventWaiter(waiter);
+      waiter.reject(error);
+    }
   }
 }
 

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -77,7 +77,7 @@ import {
   updatePerpsLeverage,
   updatePerpsMargin,
 } from './actions/trading';
-import { type PerpsSignedOp, signPerpsOp } from './signing';
+import { type PerpsSignableValue, signPerpsOp } from './signing';
 
 const AUTH_TIMEOUT_MS = 30_000;
 const ACK_TIMEOUT_MS = 30_000;
@@ -91,10 +91,12 @@ const PERPS_SESSION_CHANNELS = [
   'withdrawals',
 ] as const;
 
-const PerpsResponseEnvelopeSchema = z.object({
-  id: z.number().int().positive().optional(),
-  data: z.unknown(),
-});
+const PerpsResponseEnvelopeSchema = z
+  .object({
+    id: z.number().int().positive().optional(),
+    data: z.unknown().optional(),
+  })
+  .passthrough();
 
 const PerpsSessionAckSchema = z
   .union([PerpsCommandAckSchema, z.array(PerpsCommandAckSchema)])
@@ -378,12 +380,13 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async #sendSignedWsCommand<T>(
     request: PerpsSignedWsCommandRequest<T>,
   ): Promise<T> {
+    const bodyOp = toPerpsCommandBodyOp(request.op);
     const command = this.#createSignedCommand(request.op, request.expiresAt);
     return await this.#sendRequest(
       {
         ...command,
         id: this.#nextRequestId++,
-        op: toPerpsCommandBodyOp(request.op),
+        op: bodyOp,
         req: 'post',
       },
       request.responseSchema,
@@ -409,7 +412,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     );
   }
 
-  #createSignedCommand(op: PerpsSignedOp, expiresAt?: number) {
+  #createSignedCommand(op: PerpsSignableValue, expiresAt?: number) {
     const salt = randomUint32();
     const timestamp = Date.now();
     let signature: string;
@@ -490,7 +493,14 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
     const data = pending.schema.safeParse(parsed.data.data);
     if (!data.success) {
-      pending.reject(new TransportError('Perps session empty response.'));
+      const ack = errorAckFrom(parsed.data.data ?? parsed.data);
+      if (ack !== undefined) {
+        pending.reject(new RequestRejectedError(ack.error, { status: 200 }));
+      } else {
+        pending.reject(
+          new TransportError('Perps session unexpected response.'),
+        );
+      }
       return true;
     }
 
@@ -572,13 +582,20 @@ function createPendingResponse<T>(
 function isRejectedPerpsAck(
   value: unknown,
 ): value is Extract<PerpsCommandAck, { status: 'err' }> {
-  return (
-    !Array.isArray(value) &&
-    typeof value === 'object' &&
-    value !== null &&
-    'status' in value &&
-    value.status === 'err'
-  );
+  return errorAckFrom(value) !== undefined;
+}
+
+function errorAckFrom(value: unknown): { error: string } | undefined {
+  if (Array.isArray(value) || typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+
+  const ack = value as { error?: unknown; status?: unknown };
+  if (ack.status !== 'err') return undefined;
+
+  return {
+    error: typeof ack.error === 'string' ? ack.error : 'Perps command failed.',
+  };
 }
 
 function randomUint32(): number {

--- a/packages/client/src/websockets/perps/signing.ts
+++ b/packages/client/src/websockets/perps/signing.ts
@@ -9,13 +9,15 @@ type MsgpackValue =
   | number
   | string
   | readonly MsgpackValue[]
+  | { readonly [key: string]: MsgpackValue }
   | undefined;
 
 export type PerpsSignedOp = readonly MsgpackValue[];
+export type PerpsSignableValue = MsgpackValue;
 
 export type SignPerpsOpRequest = {
   chainId: number;
-  op: PerpsSignedOp;
+  op: PerpsSignableValue;
   privateKey: PrivateKey;
   salt: number;
   timestamp: number;
@@ -47,7 +49,9 @@ export function createPerpsOpTypedDataPayload(
       version: '1',
     },
     message: {
-      data: Hash.keccak256(encode(request.op), { as: 'Hex' }),
+      data: Hash.keccak256(encode(compactSignableValue(request.op)), {
+        as: 'Hex',
+      }),
       salt: BigInt(request.salt),
       ts: BigInt(request.timestamp),
     },
@@ -60,4 +64,12 @@ export function createPerpsOpTypedDataPayload(
       ],
     },
   };
+}
+
+function compactSignableValue(value: PerpsSignableValue): PerpsSignableValue {
+  if (Array.isArray(value)) {
+    return value.filter((item) => item !== undefined).map(compactSignableValue);
+  }
+
+  return value;
 }

--- a/packages/client/tests/integration/perps.test.ts
+++ b/packages/client/tests/integration/perps.test.ts
@@ -108,10 +108,6 @@ describe('Perps integration', () => {
 
         orderId = ack.orderId;
         expect(orderId).toEqual(expect.any(Number));
-
-        console.log(
-          await session.fetchOpenOrders({ instrumentId: instrument.id }),
-        );
       } finally {
         try {
           if (orderId !== undefined) {

--- a/packages/client/tests/integration/perps.test.ts
+++ b/packages/client/tests/integration/perps.test.ts
@@ -92,9 +92,8 @@ describe('Perps integration', () => {
       const session = await secureClientWithDepositWallet.openPerpsSession();
       const price = Number(ticker.markPrice) / 2; // ensure the order is not immediately filled
 
-      let orderId: number | undefined;
       try {
-        const ack = await session.placeOrder({
+        const order = await session.placeOrder({
           instrumentId: instrument.id,
           price: price.toFixed(instrument.priceDecimals),
           quantity: minimalPerpsOrderQuantity(instrument, price),
@@ -102,21 +101,10 @@ describe('Perps integration', () => {
           timeInForce: PerpsTimeInForce.Gtc,
         });
 
-        if (ack.status === 'err') {
-          throw new Error(`Failed to place Perps order: ${ack.error}`);
-        }
-
-        orderId = ack.orderId;
-        expect(orderId).toEqual(expect.any(Number));
+        const cancelAck = await session.cancelOrder({ orderId: order.id });
+        expect(cancelAck.status).toBe('ok');
       } finally {
-        try {
-          if (orderId !== undefined) {
-            const cancelAck = await session.cancelOrder({ orderId });
-            expect(cancelAck.status).toBe('ok');
-          }
-        } finally {
-          await session.close();
-        }
+        await session.close();
       }
     },
     6 * 60_000,

--- a/packages/client/tests/integration/perps.test.ts
+++ b/packages/client/tests/integration/perps.test.ts
@@ -1,5 +1,15 @@
-import type { PerpsSession, TxHash } from '@polymarket/client';
-import { RequestRejectedError } from '@polymarket/client';
+import type {
+  DecimalString,
+  PerpsInstrument,
+  PerpsSession,
+  TxHash,
+} from '@polymarket/client';
+import {
+  OrderSide,
+  PerpsTimeInForce,
+  RequestRejectedError,
+} from '@polymarket/client';
+import { expectNonEmptyArray } from '@polymarket/types';
 import { describe, expect, it, runMeteredTests } from './fixtures';
 
 const DEFAULT_PERPS_CREDENTIAL_EXPIRES_IN = 7 * 24 * 60 * 60 * 1000;
@@ -67,6 +77,53 @@ describe('Perps integration', () => {
 
       await session.close();
     },
+  );
+
+  it.runIf(runMeteredTests)(
+    'places and cancels one Perps order',
+    async ({ secureClientWithDepositWallet }) => {
+      const [instrument] = await secureClientWithDepositWallet
+        .fetchPerpsInstruments()
+        .then(expectNonEmptyArray);
+
+      const ticker = await secureClientWithDepositWallet.fetchPerpsTicker({
+        instrumentId: instrument.id,
+      });
+      const session = await secureClientWithDepositWallet.openPerpsSession();
+      const price = Number(ticker.markPrice) / 2; // ensure the order is not immediately filled
+
+      let orderId: number | undefined;
+      try {
+        const ack = await session.placeOrder({
+          instrumentId: instrument.id,
+          price: price.toFixed(instrument.priceDecimals),
+          quantity: minimalPerpsOrderQuantity(instrument, price),
+          side: OrderSide.BUY,
+          timeInForce: PerpsTimeInForce.Gtc,
+        });
+
+        if (ack.status === 'err') {
+          throw new Error(`Failed to place Perps order: ${ack.error}`);
+        }
+
+        orderId = ack.orderId;
+        expect(orderId).toEqual(expect.any(Number));
+
+        console.log(
+          await session.fetchOpenOrders({ instrumentId: instrument.id }),
+        );
+      } finally {
+        try {
+          if (orderId !== undefined) {
+            const cancelAck = await session.cancelOrder({ orderId });
+            expect(cancelAck.status).toBe('ok');
+          }
+        } finally {
+          await session.close();
+        }
+      }
+    },
+    6 * 60_000,
   );
 
   it.runIf(runMeteredTests)(
@@ -159,4 +216,18 @@ async function waitForConfirmedDeposit(
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function minimalPerpsOrderQuantity(
+  instrument: PerpsInstrument,
+  price: number,
+): DecimalString {
+  const quantity =
+    Math.ceil(
+      (Number(instrument.minNotional) / Number(price)) *
+        10 ** instrument.quantityDecimals,
+    ) /
+    10 ** instrument.quantityDecimals;
+
+  return quantity.toFixed(instrument.quantityDecimals) as DecimalString;
 }


### PR DESCRIPTION
## Summary
- align Perps command signing with backend MessagePack hashing by compacting undefined tuple fields
- map top-level Perps WebSocket error acknowledgements to RequestRejectedError
- make `session.placeOrder` wait for the first matching private `orders` update and return `PerpsOrder`
- rename the ack-only batch placement helper to `session.postOrders`
- normalize Perps order entity ids as `id` and type statuses with `PerpsOrderStatus`

## Verification
- `pnpm exec vitest run --project bindings packages/bindings/src/perps/orders.test.ts`
- `pnpm --filter @polymarket/bindings build`
- `pnpm exec vitest run --project client packages/client/src/websockets/perps/session.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

## Not Run
- Live metered Perps integration, because metered tests were not enabled locally.