### PR TITLE
Add changeset for client beta import fix

### DIFF
--- a/.changeset/dev-337-client-beta-types-pin.md
+++ b/.changeset/dev-337-client-beta-types-pin.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/types": patch
+"@polymarket/client": patch
+---
+
+Publish `expectPrivateKey` from `@polymarket/types` and republish the client against the corrected types package.


### PR DESCRIPTION
## Summary

Adds a changeset for [DEV-337](https://linear.app/polymarket/issue/DEV-337/bug-current-polymarketclientbeta-010-beta8-broken-due-missing) so the next beta release republishes `@polymarket/types` with `expectPrivateKey` and republishes `@polymarket/client` against the corrected package set.

## Root Cause

`@polymarket/client@0.1.0-beta.8` imports `expectPrivateKey` from `@polymarket/types`, but the pinned published `@polymarket/types@0.1.0-beta.3` artifact does not export that runtime symbol. The client therefore fails at ESM import time.

## Validation

- `pnpm changeset status --since=main` using Node 24.5.0
- Previously smoke-tested the simulated release locally: build, typecheck, tests, pack, fresh consumer import, and publish dry-run all passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only; no runtime or security-sensitive code changes in the diff.
> 
> **Overview**
> Adds a **changeset** only—no application code in this diff. It schedules **patch** releases for `@polymarket/types` and `@polymarket/client` so the next release ships types that **export** `expectPrivateKey` and a client build that depends on that corrected types artifact.
> 
> This addresses broken `@polymarket/client` beta imports where the client references `expectPrivateKey` from `@polymarket/types` but the previously published types package did not expose that symbol at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 700acc9a130328ca7e6633ce03661df1e5c83905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->