### PR TITLE
patch(client): Export PriceHistoryInterval from @polymarket/client DEV-338 

### DIFF
--- a/.changeset/dev-338-price-history-interval.md
+++ b/.changeset/dev-338-price-history-interval.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Export `PriceHistoryInterval` from `@polymarket/client`.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,7 +1,7 @@
 export type * from '@polymarket/bindings';
 export { OrderSide, OrderType } from '@polymarket/bindings';
 export type * from '@polymarket/bindings/clob';
-export { SignatureType } from '@polymarket/bindings/clob';
+export { PriceHistoryInterval, SignatureType } from '@polymarket/bindings/clob';
 export type * from '@polymarket/bindings/data';
 export { ActivityType } from '@polymarket/bindings/data';
 export type * from '@polymarket/bindings/gamma';


### PR DESCRIPTION
## Summary
- Export `PriceHistoryInterval` from `@polymarket/client` alongside `SignatureType`
- Enables callers to import and use `PriceHistoryInterval.ONE_DAY` directly from the client package

## Validation
- `PATH=/Users/dev/.nvm/versions/node/v24.5.0/bin:$PATH pnpm --filter @polymarket/client typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single re-export and changeset only; no runtime or API behavior changes.
> 
> **Overview**
> **Re-exports `PriceHistoryInterval`** from `@polymarket/client` (alongside existing `SignatureType` from `@polymarket/bindings/clob`), so consumers can pass values like `PriceHistoryInterval.ONE_DAY` to price-history APIs without importing from bindings directly.
> 
> Includes a **patch changeset** for `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382a464babf3e763e433bdf9b9961cbb75ad7c1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->