### PR TITLE
chore: require conventional commits in agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 
 ## Required workflow
 
+- Commit messages are mandatory to follow the [Conventional Commits](https://www.conventionalcommits.org/) specification. Use the `type(scope): subject` format, such as `fix(client): handle empty markets`.
 - Before finishing, run:
   - `pnpm lint`
   - `pnpm typecheck`


### PR DESCRIPTION
Adds a required workflow note to `AGENTS.md` stating that commit messages must follow the Conventional Commits specification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor/agent guidance with no runtime or API impact.
> 
> **Overview**
> **Agent workflow docs** now require commit messages to follow [Conventional Commits](https://www.conventionalcommits.org/), using `type(scope): subject` (e.g. `fix(client): handle empty markets`).
> 
> The new bullet is the first item under **Required workflow** in `AGENTS.md`, before lint/typecheck steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ea782eb6c0c28adfbc0b6b8e96c7c2e33cf5e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->