### PR TITLE
fix(client): emit repeated Perps session ticks

### DIFF
--- a/.changeset/perps-session-periodic-ticks.md
+++ b/.changeset/perps-session-periodic-ticks.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Forward repeated Perps balance and portfolio ticks instead of deduplicating unchanged payloads.

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -90,7 +90,7 @@ describe('PerpsSession', () => {
       await session.close();
     });
 
-    it('emits balance ticks and resync on sequence gaps', async () => {
+    it('emits resync on sequence gaps', async () => {
       const connection = captureConnection(server, perps);
       const session = createSession();
 
@@ -109,25 +109,15 @@ describe('PerpsSession', () => {
       });
 
       const nextEvent = waitForNextEvent(session);
-      await connection.send(balanceUpdate({ balance: '1', sequence: 2 }));
-      await connection.send(balanceUpdate({ balance: '2', sequence: 4 }));
+      await connection.send(balanceUpdate({ balance: '2', sequence: 3 }));
 
       await expect(nextEvent).resolves.toMatchObject({
         done: false,
         value: {
           channel: 'balances',
-          payload: { asset: 'USDC', balance: '1', value: '1' },
-          sequence: 2,
-          type: 'balance',
-        },
-      });
-      await expect(waitForNextEvent(session)).resolves.toMatchObject({
-        done: false,
-        value: {
-          channel: 'balances',
-          previousSequence: 2,
+          previousSequence: 1,
           reason: 'sequence_gap',
-          sequence: 4,
+          sequence: 3,
           type: 'resync',
         },
       });
@@ -136,40 +126,7 @@ describe('PerpsSession', () => {
         value: {
           channel: 'balances',
           payload: { asset: 'USDC', balance: '2', value: '2' },
-          sequence: 4,
-          type: 'balance',
-        },
-      });
-
-      await session.close();
-    });
-
-    it('emits repeated balance ticks', async () => {
-      const connection = captureConnection(server, perps);
-      const session = createSession();
-
-      await session.connect();
-
-      const firstEvent = waitForNextEvent(session);
-      await connection.send(balanceUpdate({ balance: '1', sequence: 1 }));
-      await expect(firstEvent).resolves.toMatchObject({
-        done: false,
-        value: {
-          channel: 'balances',
-          sequence: 1,
-          type: 'balance',
-        },
-      });
-
-      const nextEvent = waitForNextEvent(session);
-      await connection.send(balanceUpdate({ balance: '1', sequence: 2 }));
-
-      await expect(nextEvent).resolves.toMatchObject({
-        done: false,
-        value: {
-          channel: 'balances',
-          payload: { asset: 'USDC', balance: '1', value: '1' },
-          sequence: 2,
+          sequence: 3,
           type: 'balance',
         },
       });

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -90,7 +90,7 @@ describe('PerpsSession', () => {
       await session.close();
     });
 
-    it('deduplicates balance ticks and emits resync on sequence gaps', async () => {
+    it('emits balance ticks and resync on sequence gaps', async () => {
       const connection = captureConnection(server, perps);
       const session = createSession();
 
@@ -116,6 +116,15 @@ describe('PerpsSession', () => {
         done: false,
         value: {
           channel: 'balances',
+          payload: { asset: 'USDC', balance: '1', value: '1' },
+          sequence: 2,
+          type: 'balance',
+        },
+      });
+      await expect(waitForNextEvent(session)).resolves.toMatchObject({
+        done: false,
+        value: {
+          channel: 'balances',
           previousSequence: 2,
           reason: 'sequence_gap',
           sequence: 4,
@@ -135,7 +144,7 @@ describe('PerpsSession', () => {
       await session.close();
     });
 
-    it('advances sequence tracking when skipping deduped balance ticks', async () => {
+    it('emits repeated balance ticks', async () => {
       const connection = captureConnection(server, perps);
       const session = createSession();
 
@@ -154,14 +163,13 @@ describe('PerpsSession', () => {
 
       const nextEvent = waitForNextEvent(session);
       await connection.send(balanceUpdate({ balance: '1', sequence: 2 }));
-      await connection.send(balanceUpdate({ balance: '2', sequence: 3 }));
 
       await expect(nextEvent).resolves.toMatchObject({
         done: false,
         value: {
           channel: 'balances',
-          payload: { asset: 'USDC', balance: '2', value: '2' },
-          sequence: 3,
+          payload: { asset: 'USDC', balance: '1', value: '1' },
+          sequence: 2,
           type: 'balance',
         },
       });

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -183,7 +183,6 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   readonly #eventWaiters = new Set<EventWaiter>();
   readonly #reconnectScheduler = new ReconnectScheduler();
   readonly #sequences = new Map<string, number>();
-  readonly #lastDedupedPayload = new Map<string, string>();
   #nextRequestId = 1;
   #closing: Promise<void> | undefined;
 
@@ -360,7 +359,6 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     this.#reconnectScheduler.resetBackoff();
     if (emitResync) {
       this.#sequences.clear();
-      this.#lastDedupedPayload.clear();
       this.#queue.push({
         reason: 'reconnect',
         type: 'resync',
@@ -517,9 +515,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     if (!parsed.success) return;
 
     const event = parsed.data;
-    const shouldSkipDedupedTick = this.#shouldSkipDedupedTick(event);
     this.#pushSequenceGapIfNeeded(event);
-    if (shouldSkipDedupedTick) return;
     this.#emitEvent(event);
   }
 
@@ -571,20 +567,6 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
       pending.reject(error);
     }
     this.#pending.clear();
-  }
-
-  #shouldSkipDedupedTick(event: {
-    channel: string;
-    payload: unknown;
-  }): boolean {
-    if (event.channel !== 'balances' && event.channel !== 'portfolio') {
-      return false;
-    }
-
-    const payload = JSON.stringify(event.payload);
-    const previousPayload = this.#lastDedupedPayload.get(event.channel);
-    this.#lastDedupedPayload.set(event.channel, payload);
-    return payload === previousPayload;
   }
 
   #pushSequenceGapIfNeeded(event: { channel: string; sequence: number }): void {


### PR DESCRIPTION
## Summary
- remove Perps session payload deduplication for repeated balance and portfolio ticks
- keep sequence-gap detection independent of payload changes
- keep session tests focused on sequence-gap behavior without asserting absence of dedupe logic

## Verification
- `pnpm exec vitest run --project client packages/client/src/websockets/perps/session.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in WebSocket event forwarding; no auth, signing, or REST paths touched.
> 
> **Overview**
> **Perps WebSocket session** no longer drops **balance** and **portfolio** updates when the payload is identical to the previous tick. Every server message on those channels is emitted to the async iterator after sequence handling.
> 
> **Sequence-gap `resync` events** are unchanged: they still use per-channel sequence numbers only, not payload comparison. Reconnect still clears sequence state (dedup payload cache removal is part of that cleanup).
> 
> Tests were trimmed to focus on gap detection without asserting dedup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a890d38707b99337891cfaa3bc5c335c1bf7ed99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->