### PR TITLE
refactor(bindings): clean up Perps raw schemas

### DIFF
--- a/.changeset/perps-raw-schema-cleanup.md
+++ b/.changeset/perps-raw-schema-cleanup.md
@@ -2,4 +2,4 @@
 "@polymarket/bindings": patch
 ---
 
-Rename duplicate Perps raw model schemas to the public schema names.
+Rename duplicate Perps raw model and response schemas to the public schema names.

--- a/.changeset/perps-raw-schema-cleanup.md
+++ b/.changeset/perps-raw-schema-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/bindings": patch
+---
+
+Rename duplicate Perps raw model schemas to the public schema names.

--- a/packages/bindings/src/perps/account.ts
+++ b/packages/bindings/src/perps/account.ts
@@ -191,15 +191,7 @@ const RawPerpsProxyExpirySchema = z
   )
   .pipe(EpochMillisecondsSchema);
 
-export const PerpsProxyKeySchema = z.object({
-  proxy: EvmAddressSchema,
-  label: z.string().optional(),
-  expiresAt: EpochMillisecondsSchema,
-});
-
-export type PerpsProxyKey = z.infer<typeof PerpsProxyKeySchema>;
-
-export const RawPerpsProxyKeySchema = z
+export const PerpsProxyKeySchema = z
   .object({
     proxy: EvmAddressSchema,
     label: z.string().optional(),
@@ -211,21 +203,23 @@ export const RawPerpsProxyKeySchema = z
     expiresAt: key.expiry,
   }));
 
-export const RawPerpsCredentialsResponseSchema = z
+export type PerpsProxyKey = z.infer<typeof PerpsProxyKeySchema>;
+
+export const PerpsCredentialsResponseSchema = z
   .object({
     address: EvmAddressSchema,
-    keys: z.array(RawPerpsProxyKeySchema),
+    keys: z.array(PerpsProxyKeySchema),
   })
   .transform((credentials) => ({
     address: credentials.address,
     keys: credentials.keys,
   }));
 
-export const RawPerpsCreateProxyResponseSchema = z.object({
+export const PerpsCreateProxyResponseSchema = z.object({
   secret: z.string().min(1),
 });
 
-export const RawPerpsDeleteProxyResponseSchema = z.object({
+export const PerpsDeleteProxyResponseSchema = z.object({
   status: z.enum(['ok', 'err']),
   error: z.string().optional(),
 });

--- a/packages/bindings/src/perps/account.ts
+++ b/packages/bindings/src/perps/account.ts
@@ -20,27 +20,7 @@ export type PerpsBalance = z.infer<typeof PerpsBalanceSchema>;
 
 export const FetchPerpsBalancesResponseSchema = z.array(PerpsBalanceSchema);
 
-export const PerpsPortfolioPositionSchema = z.object({
-  instrumentId: PerpsInstrumentIdSchema,
-  symbol: z.string().min(1),
-  size: DecimalStringSchema,
-  entryPrice: DecimalStringSchema,
-  leverage: z.number().int().positive(),
-  cross: z.boolean(),
-  initialMargin: DecimalStringSchema,
-  maintenanceMargin: DecimalStringSchema,
-  positionValue: DecimalStringSchema,
-  liquidationPrice: DecimalStringSchema,
-  unrealizedPnl: DecimalStringSchema,
-  returnOnEquity: DecimalStringSchema,
-  cumulativeFunding: DecimalStringSchema,
-});
-
-export type PerpsPortfolioPosition = z.infer<
-  typeof PerpsPortfolioPositionSchema
->;
-
-export const RawPerpsPortfolioPositionSchema = z
+export const PerpsPortfolioPositionSchema = z
   .object({
     instrument_id: PerpsInstrumentIdSchema,
     symbol: z.string().min(1),
@@ -72,6 +52,10 @@ export const RawPerpsPortfolioPositionSchema = z
     cumulativeFunding: position.cumulative_funding,
   }));
 
+export type PerpsPortfolioPosition = z.infer<
+  typeof PerpsPortfolioPositionSchema
+>;
+
 export const PerpsMarginSummarySchema = z.object({
   totalAccountValue: DecimalStringSchema,
   totalInitialMargin: DecimalStringSchema,
@@ -95,19 +79,9 @@ const RawPerpsMarginSummarySchema = z
     totalPositionValue: margin.total_position_value,
   }));
 
-export const PerpsPortfolioSchema = z.object({
-  positions: z.array(PerpsPortfolioPositionSchema),
-  margin: PerpsMarginSummarySchema,
-  withdrawable: DecimalStringSchema,
-  inLiquidation: z.boolean(),
-  timestamp: EpochMillisecondsSchema,
-});
-
-export type PerpsPortfolio = z.infer<typeof PerpsPortfolioSchema>;
-
-export const RawPerpsPortfolioSchema = z
+export const PerpsPortfolioSchema = z
   .object({
-    positions: z.array(RawPerpsPortfolioPositionSchema),
+    positions: z.array(PerpsPortfolioPositionSchema),
     margin: RawPerpsMarginSummarySchema,
     withdrawable: DecimalStringSchema,
     in_liquidation: z.boolean(),
@@ -121,22 +95,11 @@ export const RawPerpsPortfolioSchema = z
     timestamp: portfolio.timestamp,
   }));
 
-export const FetchPerpsPortfolioResponseSchema = RawPerpsPortfolioSchema;
+export type PerpsPortfolio = z.infer<typeof PerpsPortfolioSchema>;
 
-export const PerpsAccountFundingPaymentSchema = z.object({
-  instrumentId: PerpsInstrumentIdSchema,
-  size: DecimalStringSchema,
-  fundingRate: DecimalStringSchema,
-  fundingAsset: PerpsAssetSchema,
-  funding: DecimalStringSchema,
-  timestamp: EpochMillisecondsSchema,
-});
+export const FetchPerpsPortfolioResponseSchema = PerpsPortfolioSchema;
 
-export type PerpsAccountFundingPayment = z.infer<
-  typeof PerpsAccountFundingPaymentSchema
->;
-
-export const RawPerpsAccountFundingPaymentSchema = z
+export const PerpsAccountFundingPaymentSchema = z
   .object({
     instrument_id: PerpsInstrumentIdSchema,
     size: DecimalStringSchema,
@@ -154,8 +117,12 @@ export const RawPerpsAccountFundingPaymentSchema = z
     timestamp: funding.timestamp,
   }));
 
+export type PerpsAccountFundingPayment = z.infer<
+  typeof PerpsAccountFundingPaymentSchema
+>;
+
 export const ListPerpsFundingPaymentsResponseSchema = PerpsDataResponseSchema(
-  RawPerpsAccountFundingPaymentSchema,
+  PerpsAccountFundingPaymentSchema,
 );
 
 export const RawPerpsAccountFundingPaymentEntrySchema = z
@@ -176,15 +143,7 @@ export const RawPerpsAccountFundingPaymentEntrySchema = z
     timestamp: funding.ts,
   }));
 
-export const PerpsAccountConfigSchema = z.object({
-  instrumentId: PerpsInstrumentIdSchema,
-  leverage: z.number().int().positive(),
-  cross: z.boolean(),
-});
-
-export type PerpsAccountConfig = z.infer<typeof PerpsAccountConfigSchema>;
-
-export const RawPerpsAccountConfigSchema = z
+export const PerpsAccountConfigSchema = z
   .object({
     instrument_id: PerpsInstrumentIdSchema,
     leverage: z.number().int().positive(),
@@ -196,8 +155,10 @@ export const RawPerpsAccountConfigSchema = z
     cross: config.cross,
   }));
 
+export type PerpsAccountConfig = z.infer<typeof PerpsAccountConfigSchema>;
+
 export const FetchPerpsAccountConfigResponseSchema = z.array(
-  RawPerpsAccountConfigSchema,
+  PerpsAccountConfigSchema,
 );
 
 export const PerpsEquityPointSchema = z

--- a/packages/bindings/src/perps/common.ts
+++ b/packages/bindings/src/perps/common.ts
@@ -139,7 +139,7 @@ export const PerpsPnlIntervalSchema = z.enum(PerpsPnlInterval);
 
 export const PerpsAssetSchema = z.string().min(1);
 
-export const RawPerpsTxHashSchema = z.preprocess(
+export const PerpsTxHashSchema = z.preprocess(
   (hash) => (hash === '0x' || hash === '' ? undefined : hash),
   TxHashSchema.optional(),
 );

--- a/packages/bindings/src/perps/funds.test.ts
+++ b/packages/bindings/src/perps/funds.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  PerpsWithdrawalSchema,
   RawPerpsDepositUpdateSchema,
-  RawPerpsWithdrawalSchema,
   RawPerpsWithdrawalUpdateSchema,
 } from './funds';
 
@@ -30,9 +30,9 @@ describe('RawPerpsDepositUpdateSchema', () => {
   });
 });
 
-describe('RawPerpsWithdrawalSchema', () => {
+describe('PerpsWithdrawalSchema', () => {
   it('normalizes empty pending hashes to undefined', () => {
-    const withdrawal = RawPerpsWithdrawalSchema.parse({
+    const withdrawal = PerpsWithdrawalSchema.parse({
       ...baseWithdrawal,
       hash: '',
     });

--- a/packages/bindings/src/perps/funds.ts
+++ b/packages/bindings/src/perps/funds.ts
@@ -12,9 +12,9 @@ import {
   PerpsDepositStatusSchema,
   PerpsInternalTransferDirectionSchema,
   PerpsInternalTransferIdSchema,
+  PerpsTxHashSchema,
   PerpsWithdrawalIdSchema,
   PerpsWithdrawalStatusSchema,
-  RawPerpsTxHashSchema,
 } from './common';
 
 export const PerpsDepositSchema = z
@@ -50,7 +50,7 @@ export const ListPerpsDepositsResponseSchema =
 
 export const RawPerpsDepositUpdateSchema = z
   .object({
-    hash: RawPerpsTxHashSchema,
+    hash: PerpsTxHashSchema,
     asset: PerpsAssetSchema,
     amount: BaseUnitsSchema,
     status: PerpsDepositStatusSchema,
@@ -70,7 +70,7 @@ export const PerpsWithdrawalSchema = z
     fee: DecimalStringSchema,
     status: PerpsWithdrawalStatusSchema,
     to: EvmAddressSchema,
-    hash: RawPerpsTxHashSchema,
+    hash: PerpsTxHashSchema,
     confirmations: z.number().int().nonnegative(),
     required_confirmations: z.number().int().nonnegative(),
     created_timestamp: EpochMillisecondsSchema,
@@ -96,7 +96,7 @@ export const ListPerpsWithdrawalsResponseSchema = PerpsDataResponseSchema(
   PerpsWithdrawalSchema,
 );
 
-export const RawPerpsWithdrawResponseSchema = z
+export const PerpsWithdrawResponseSchema = z
   .object({
     status: z.enum(['ok', 'err']),
     withdraw_id: PerpsWithdrawalIdSchema.optional(),
@@ -116,7 +116,7 @@ export const RawPerpsWithdrawalUpdateSchema = z
     fee: DecimalStringSchema,
     status: PerpsWithdrawalStatusSchema,
     to: EvmAddressSchema,
-    hash: RawPerpsTxHashSchema,
+    hash: PerpsTxHashSchema,
   })
   .transform((withdrawal) => ({
     withdrawalId: withdrawal.withdraw_id,

--- a/packages/bindings/src/perps/funds.ts
+++ b/packages/bindings/src/perps/funds.ts
@@ -17,22 +17,7 @@ import {
   RawPerpsTxHashSchema,
 } from './common';
 
-export const PerpsDepositSchema = z.object({
-  hash: TxHashSchema,
-  asset: PerpsAssetSchema,
-  amount: BaseUnitsSchema,
-  status: PerpsDepositStatusSchema,
-  from: EvmAddressSchema,
-  to: EvmAddressSchema,
-  confirmations: z.number().int().nonnegative(),
-  requiredConfirmations: z.number().int().nonnegative(),
-  createdTimestamp: EpochMillisecondsSchema,
-  confirmedTimestamp: EpochMillisecondsSchema.optional(),
-});
-
-export type PerpsDeposit = z.infer<typeof PerpsDepositSchema>;
-
-export const RawPerpsDepositSchema = z
+export const PerpsDepositSchema = z
   .object({
     hash: TxHashSchema,
     asset: PerpsAssetSchema,
@@ -58,9 +43,10 @@ export const RawPerpsDepositSchema = z
     confirmedTimestamp: deposit.confirmed_timestamp,
   }));
 
-export const ListPerpsDepositsResponseSchema = PerpsDataResponseSchema(
-  RawPerpsDepositSchema,
-);
+export type PerpsDeposit = z.infer<typeof PerpsDepositSchema>;
+
+export const ListPerpsDepositsResponseSchema =
+  PerpsDataResponseSchema(PerpsDepositSchema);
 
 export const RawPerpsDepositUpdateSchema = z
   .object({
@@ -76,23 +62,7 @@ export const RawPerpsDepositUpdateSchema = z
     status: deposit.status,
   }));
 
-export const PerpsWithdrawalSchema = z.object({
-  withdrawalId: PerpsWithdrawalIdSchema,
-  asset: PerpsAssetSchema,
-  amount: BaseUnitsSchema,
-  fee: DecimalStringSchema,
-  status: PerpsWithdrawalStatusSchema,
-  to: EvmAddressSchema,
-  hash: TxHashSchema.optional(),
-  confirmations: z.number().int().nonnegative(),
-  requiredConfirmations: z.number().int().nonnegative(),
-  createdTimestamp: EpochMillisecondsSchema,
-  confirmedTimestamp: EpochMillisecondsSchema.optional(),
-});
-
-export type PerpsWithdrawal = z.infer<typeof PerpsWithdrawalSchema>;
-
-export const RawPerpsWithdrawalSchema = z
+export const PerpsWithdrawalSchema = z
   .object({
     withdraw_id: PerpsWithdrawalIdSchema,
     asset: PerpsAssetSchema,
@@ -120,8 +90,10 @@ export const RawPerpsWithdrawalSchema = z
     confirmedTimestamp: withdrawal.confirmed_timestamp,
   }));
 
+export type PerpsWithdrawal = z.infer<typeof PerpsWithdrawalSchema>;
+
 export const ListPerpsWithdrawalsResponseSchema = PerpsDataResponseSchema(
-  RawPerpsWithdrawalSchema,
+  PerpsWithdrawalSchema,
 );
 
 export const RawPerpsWithdrawResponseSchema = z
@@ -167,23 +139,3 @@ export const PerpsInternalTransferSchema = z.object({
 });
 
 export type PerpsInternalTransfer = z.infer<typeof PerpsInternalTransferSchema>;
-
-export const RawPerpsInternalTransferSchema = z
-  .object({
-    transfer_id: PerpsInternalTransferIdSchema,
-    asset: PerpsAssetSchema,
-    amount: BaseUnitsSchema,
-    direction: PerpsInternalTransferDirectionSchema,
-    counterparty: EvmAddressSchema,
-    label: z.string().optional(),
-    created_timestamp: EpochMillisecondsSchema,
-  })
-  .transform((transfer) => ({
-    transferId: transfer.transfer_id,
-    asset: transfer.asset,
-    amount: transfer.amount,
-    direction: transfer.direction,
-    counterparty: transfer.counterparty,
-    label: transfer.label,
-    createdTimestamp: transfer.created_timestamp,
-  }));

--- a/packages/bindings/src/perps/market.test.ts
+++ b/packages/bindings/src/perps/market.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   PerpsFundingIntervalSchema,
-  RawPerpsInstrumentSchema,
+  PerpsInstrumentSchema,
+  PerpsPublicTradeSchema,
   RawPerpsPublicTradeResponseSchema,
-  RawPerpsPublicTradeSchema,
 } from './market';
 
 const txHash = `0x${'1'.repeat(64)}`;
@@ -21,9 +21,9 @@ describe('PerpsFundingIntervalSchema', () => {
   });
 });
 
-describe('RawPerpsInstrumentSchema', () => {
+describe('PerpsInstrumentSchema', () => {
   it('normalizes instrument identifiers without exposing instrument type', () => {
-    const instrument = RawPerpsInstrumentSchema.parse({
+    const instrument = PerpsInstrumentSchema.parse({
       base_asset: 'BTC',
       category: 'crypto',
       funding_interval: '1h',
@@ -53,9 +53,9 @@ describe('RawPerpsInstrumentSchema', () => {
   });
 });
 
-describe('RawPerpsPublicTradeSchema', () => {
+describe('PerpsPublicTradeSchema', () => {
   it('normalizes placeholder hashes to undefined', () => {
-    const trade = RawPerpsPublicTradeSchema.parse({
+    const trade = PerpsPublicTradeSchema.parse({
       trade_id: 1,
       instrument_id: 6,
       side: 'long',
@@ -69,7 +69,7 @@ describe('RawPerpsPublicTradeSchema', () => {
   });
 
   it('preserves valid transaction hashes', () => {
-    const trade = RawPerpsPublicTradeSchema.parse({
+    const trade = PerpsPublicTradeSchema.parse({
       trade_id: 1,
       instrument_id: 6,
       side: 'long',

--- a/packages/bindings/src/perps/market.ts
+++ b/packages/bindings/src/perps/market.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import {
+  type DecimalString,
   DecimalStringSchema,
   EpochMillisecondsSchema,
-  TxHashSchema,
 } from '../shared';
 import {
   PerpsAssetSchema,
@@ -38,28 +38,7 @@ const RawPerpsRiskTierSchema = z
 
 export type PerpsRiskTier = z.infer<typeof PerpsRiskTierSchema>;
 
-export const PerpsInstrumentSchema = z.object({
-  id: PerpsInstrumentIdSchema,
-  category: PerpsInstrumentCategorySchema,
-  symbol: z.string().min(1),
-  baseAsset: PerpsAssetSchema,
-  quoteAsset: PerpsAssetSchema,
-  fundingInterval: PerpsFundingIntervalSchema,
-  quantityDecimals: z.number().int().nonnegative(),
-  priceDecimals: z.number().int().nonnegative(),
-  priceBounds: DecimalStringSchema,
-  liquidationFee: DecimalStringSchema,
-  maxOrderCount: z.number().int().positive(),
-  minNotional: DecimalStringSchema,
-  maxMarketNotional: DecimalStringSchema,
-  maxLimitNotional: DecimalStringSchema,
-  maxLeverage: z.number().int().positive(),
-  riskTiers: z.array(PerpsRiskTierSchema),
-});
-
-export type PerpsInstrument = z.infer<typeof PerpsInstrumentSchema>;
-
-export const RawPerpsInstrumentSchema = z
+export const PerpsInstrumentSchema = z
   .object({
     instrument_id: PerpsInstrumentIdSchema,
     instrument_type: PerpsInstrumentTypeSchema,
@@ -98,28 +77,13 @@ export const RawPerpsInstrumentSchema = z
     riskTiers: instrument.risk_tiers,
   }));
 
+export type PerpsInstrument = z.infer<typeof PerpsInstrumentSchema>;
+
 export const FetchPerpsInstrumentsResponseSchema = z.array(
-  RawPerpsInstrumentSchema,
+  PerpsInstrumentSchema,
 );
 
-export const PerpsTickerSchema = z.object({
-  instrumentId: PerpsInstrumentIdSchema,
-  symbol: z.string().min(1),
-  indexPrice: DecimalStringSchema,
-  markPrice: DecimalStringSchema,
-  lastPrice: DecimalStringSchema,
-  midPrice: DecimalStringSchema,
-  openInterest: DecimalStringSchema,
-  fundingRate: DecimalStringSchema,
-  nextFunding: EpochMillisecondsSchema,
-  volume24h: DecimalStringSchema.optional(),
-  openPrice: DecimalStringSchema.optional(),
-  timestamp: EpochMillisecondsSchema.optional(),
-});
-
-export type PerpsTicker = z.infer<typeof PerpsTickerSchema>;
-
-export const RawPerpsTickerSchema = z
+export const PerpsTickerSchema = z
   .object({
     instrument_id: PerpsInstrumentIdSchema,
     symbol: z.string().min(1),
@@ -145,7 +109,12 @@ export const RawPerpsTickerSchema = z
     timestamp: ticker.timestamp,
   }));
 
-export const FetchPerpsTickersResponseSchema = z.array(RawPerpsTickerSchema);
+export type PerpsTicker = z.infer<typeof PerpsTickerSchema> & {
+  openPrice?: DecimalString;
+  volume24h?: DecimalString;
+};
+
+export const FetchPerpsTickersResponseSchema = z.array(PerpsTickerSchema);
 
 export const RawPerpsTickerEntrySchema = z
   .object({
@@ -191,17 +160,7 @@ export const PerpsCandleSchema = z
 
 export type PerpsCandle = z.infer<typeof PerpsCandleSchema>;
 
-export const PerpsStatisticSchema = z.object({
-  instrumentId: PerpsInstrumentIdSchema,
-  symbol: z.string().min(1).optional(),
-  volume: DecimalStringSchema,
-  openPrice: DecimalStringSchema,
-  klines: z.array(PerpsCandleSchema),
-});
-
-export type PerpsStatistic = z.infer<typeof PerpsStatisticSchema>;
-
-export const RawPerpsStatisticSchema = z
+export const PerpsStatisticSchema = z
   .object({
     instrument_id: PerpsInstrumentIdSchema,
     symbol: z.string().min(1).optional(),
@@ -217,9 +176,9 @@ export const RawPerpsStatisticSchema = z
     klines: statistic.klines,
   }));
 
-export const FetchPerpsStatisticsResponseSchema = z.array(
-  RawPerpsStatisticSchema,
-);
+export type PerpsStatistic = z.infer<typeof PerpsStatisticSchema>;
+
+export const FetchPerpsStatisticsResponseSchema = z.array(PerpsStatisticSchema);
 
 export const RawPerpsStatisticDataSchema = z
   .object({
@@ -241,17 +200,7 @@ export const PerpsBookLevelSchema = z
 
 export type PerpsBookLevel = z.infer<typeof PerpsBookLevelSchema>;
 
-export const PerpsBookSchema = z.object({
-  instrumentId: PerpsInstrumentIdSchema,
-  bids: z.array(PerpsBookLevelSchema),
-  asks: z.array(PerpsBookLevelSchema),
-  timestamp: EpochMillisecondsSchema,
-  sequence: z.number().int().nonnegative(),
-});
-
-export type PerpsBook = z.infer<typeof PerpsBookSchema>;
-
-export const RawPerpsBookSchema = z
+export const PerpsBookSchema = z
   .object({
     instrument_id: PerpsInstrumentIdSchema,
     bids: z.array(PerpsBookLevelSchema),
@@ -266,6 +215,8 @@ export const RawPerpsBookSchema = z
     timestamp: book.timestamp,
     sequence: book.sequence,
   }));
+
+export type PerpsBook = z.infer<typeof PerpsBookSchema>;
 
 export const RawPerpsBookUpdateSchema = z
   .object({
@@ -288,24 +239,6 @@ export const PerpsBboSchema = z.object({
 
 export type PerpsBbo = z.infer<typeof PerpsBboSchema>;
 
-export const RawPerpsBboSchema = z
-  .object({
-    instrument_id: PerpsInstrumentIdSchema,
-    bid_price: DecimalStringSchema,
-    bid_quantity: DecimalStringSchema,
-    ask_price: DecimalStringSchema,
-    ask_quantity: DecimalStringSchema,
-    timestamp: EpochMillisecondsSchema.optional(),
-  })
-  .transform((bbo) => ({
-    instrumentId: bbo.instrument_id,
-    bidPrice: bbo.bid_price,
-    bidQuantity: bbo.bid_quantity,
-    askPrice: bbo.ask_price,
-    askQuantity: bbo.ask_quantity,
-    timestamp: bbo.timestamp,
-  }));
-
 export const RawPerpsBboDataSchema = z
   .object({
     iid: PerpsInstrumentIdSchema,
@@ -322,19 +255,7 @@ export const RawPerpsBboDataSchema = z
     askQuantity: bbo.aq,
   }));
 
-export const PerpsPublicTradeSchema = z.object({
-  tradeId: PerpsTradeIdSchema,
-  instrumentId: PerpsInstrumentIdSchema,
-  side: PerpsSideSchema,
-  price: DecimalStringSchema,
-  quantity: DecimalStringSchema,
-  timestamp: EpochMillisecondsSchema,
-  hash: TxHashSchema.optional(),
-});
-
-export type PerpsPublicTrade = z.infer<typeof PerpsPublicTradeSchema>;
-
-export const RawPerpsPublicTradeSchema = z
+export const PerpsPublicTradeSchema = z
   .object({
     trade_id: PerpsTradeIdSchema,
     instrument_id: PerpsInstrumentIdSchema,
@@ -353,6 +274,8 @@ export const RawPerpsPublicTradeSchema = z
     timestamp: trade.timestamp,
     hash: trade.hash,
   }));
+
+export type PerpsPublicTrade = z.infer<typeof PerpsPublicTradeSchema>;
 
 export const RawPerpsPublicTradeResponseSchema = z
   .object({
@@ -375,17 +298,10 @@ export const RawPerpsPublicTradeResponseSchema = z
   }));
 
 export const FetchPerpsTradesResponseSchema = PerpsDataResponseSchema(
-  RawPerpsPublicTradeSchema,
+  PerpsPublicTradeSchema,
 );
 
-export const PerpsFundingRateSchema = z.object({
-  fundingRate: DecimalStringSchema,
-  timestamp: EpochMillisecondsSchema,
-});
-
-export type PerpsFundingRate = z.infer<typeof PerpsFundingRateSchema>;
-
-export const RawPerpsFundingRateSchema = z
+export const PerpsFundingRateSchema = z
   .object({
     funding_rate: DecimalStringSchema,
     timestamp: EpochMillisecondsSchema,
@@ -395,19 +311,13 @@ export const RawPerpsFundingRateSchema = z
     timestamp: funding.timestamp,
   }));
 
+export type PerpsFundingRate = z.infer<typeof PerpsFundingRateSchema>;
+
 export const FetchPerpsFundingHistoryResponseSchema = PerpsDataResponseSchema(
-  RawPerpsFundingRateSchema,
+  PerpsFundingRateSchema,
 );
 
-export const PerpsFeeScheduleEntrySchema = z.object({
-  category: PerpsInstrumentCategorySchema,
-  takerFeeRate: DecimalStringSchema,
-  makerFeeRate: DecimalStringSchema,
-});
-
-export type PerpsFeeScheduleEntry = z.infer<typeof PerpsFeeScheduleEntrySchema>;
-
-export const RawPerpsFeeScheduleEntrySchema = z
+export const PerpsFeeScheduleEntrySchema = z
   .object({
     instrument_type: PerpsInstrumentTypeSchema,
     category: PerpsInstrumentCategorySchema,
@@ -420,19 +330,19 @@ export const RawPerpsFeeScheduleEntrySchema = z
     makerFeeRate: fee.maker_fee_rate,
   }));
 
-export const PerpsFeesInfoSchema = z.object({
-  feeSchedule: z.array(PerpsFeeScheduleEntrySchema),
-});
+export type PerpsFeeScheduleEntry = z.infer<typeof PerpsFeeScheduleEntrySchema>;
 
-export type PerpsFeesInfo = z.infer<typeof PerpsFeesInfoSchema>;
-
-export const FetchPerpsFeesResponseSchema = z
+export const PerpsFeesInfoSchema = z
   .object({
-    fee_schedule: z.array(RawPerpsFeeScheduleEntrySchema),
+    fee_schedule: z.array(PerpsFeeScheduleEntrySchema),
   })
   .transform((fees) => ({
     feeSchedule: fees.fee_schedule,
   }));
+
+export type PerpsFeesInfo = z.infer<typeof PerpsFeesInfoSchema>;
+
+export const FetchPerpsFeesResponseSchema = PerpsFeesInfoSchema;
 
 export const FetchPerpsCandlesResponseSchema =
   PerpsDataResponseSchema(PerpsCandleSchema);

--- a/packages/bindings/src/perps/market.ts
+++ b/packages/bindings/src/perps/market.ts
@@ -13,7 +13,7 @@ import {
   PerpsInstrumentTypeSchema,
   PerpsSideSchema,
   PerpsTradeIdSchema,
-  RawPerpsTxHashSchema,
+  PerpsTxHashSchema,
 } from './common';
 
 export {
@@ -263,7 +263,7 @@ export const PerpsPublicTradeSchema = z
     price: DecimalStringSchema,
     quantity: DecimalStringSchema,
     timestamp: EpochMillisecondsSchema,
-    hash: RawPerpsTxHashSchema,
+    hash: PerpsTxHashSchema,
   })
   .transform((trade) => ({
     tradeId: trade.trade_id,
@@ -285,7 +285,7 @@ export const RawPerpsPublicTradeResponseSchema = z
     p: DecimalStringSchema,
     qty: DecimalStringSchema,
     ts: EpochMillisecondsSchema,
-    hash: RawPerpsTxHashSchema,
+    hash: PerpsTxHashSchema,
   })
   .transform((trade) => ({
     tradeId: trade.tid,

--- a/packages/bindings/src/perps/orders.test.ts
+++ b/packages/bindings/src/perps/orders.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
+  PerpsAccountFillSchema,
   PerpsOrderSchema,
   PerpsOrderStatus,
-  RawPerpsAccountFillSchema,
   RawPerpsCancelOrderAckSchema,
   RawPerpsPostOrderAckSchema,
 } from './orders';
@@ -24,9 +24,9 @@ const baseFill = {
   timestamp: 1_700_000_000_000,
 };
 
-describe('RawPerpsAccountFillSchema', () => {
+describe('PerpsAccountFillSchema', () => {
   it('normalizes placeholder hashes to undefined', () => {
-    const fill = RawPerpsAccountFillSchema.parse({
+    const fill = PerpsAccountFillSchema.parse({
       ...baseFill,
       hash: '0x',
     });

--- a/packages/bindings/src/perps/orders.ts
+++ b/packages/bindings/src/perps/orders.ts
@@ -1,9 +1,5 @@
 import { z } from 'zod';
-import {
-  DecimalStringSchema,
-  EpochMillisecondsSchema,
-  TxHashSchema,
-} from '../shared';
+import { DecimalStringSchema, EpochMillisecondsSchema } from '../shared';
 import {
   PerpsAssetSchema,
   PerpsClientOrderIdSchema,
@@ -247,28 +243,7 @@ export const RawPerpsOrderUpdateSchema = z
     clientOrderId: order.coid,
   }));
 
-export const PerpsAccountFillSchema = z.object({
-  tradeId: PerpsTradeIdSchema,
-  orderId: PerpsOrderIdSchema,
-  instrumentId: PerpsInstrumentIdSchema,
-  side: PerpsSideSchema,
-  price: DecimalStringSchema,
-  quantity: DecimalStringSchema,
-  taker: z.boolean(),
-  fee: DecimalStringSchema,
-  feeAsset: PerpsAssetSchema,
-  previousSize: DecimalStringSchema,
-  previousEntryPrice: DecimalStringSchema,
-  pnl: DecimalStringSchema,
-  liquidation: z.boolean(),
-  timestamp: EpochMillisecondsSchema,
-  hash: TxHashSchema.optional(),
-  clientOrderId: z.string().optional(),
-});
-
-export type PerpsAccountFill = z.infer<typeof PerpsAccountFillSchema>;
-
-export const RawPerpsAccountFillSchema = z
+export const PerpsAccountFillSchema = z
   .object({
     trade_id: PerpsTradeIdSchema,
     order_id: PerpsOrderIdSchema,
@@ -304,8 +279,10 @@ export const RawPerpsAccountFillSchema = z
     hash: fill.hash,
   }));
 
+export type PerpsAccountFill = z.infer<typeof PerpsAccountFillSchema>;
+
 export const ListPerpsFillsResponseSchema = PerpsDataResponseSchema(
-  RawPerpsAccountFillSchema,
+  PerpsAccountFillSchema,
 );
 
 export const RawPerpsAccountFillUpdateSchema = z

--- a/packages/bindings/src/perps/orders.ts
+++ b/packages/bindings/src/perps/orders.ts
@@ -9,7 +9,7 @@ import {
   PerpsSideSchema,
   PerpsTimeInForceSchema,
   PerpsTradeIdSchema,
-  RawPerpsTxHashSchema,
+  PerpsTxHashSchema,
 } from './common';
 
 export enum PerpsOrderStatus {
@@ -259,7 +259,7 @@ export const PerpsAccountFillSchema = z
     pnl: DecimalStringSchema,
     liquidation: z.boolean(),
     timestamp: EpochMillisecondsSchema,
-    hash: RawPerpsTxHashSchema,
+    hash: PerpsTxHashSchema,
   })
   .transform((fill) => ({
     tradeId: fill.trade_id,

--- a/packages/bindings/src/subscriptions/perps.ts
+++ b/packages/bindings/src/subscriptions/perps.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 import {
   PerpsBalanceSchema,
+  PerpsPortfolioSchema,
   RawPerpsAccountFundingPaymentEntrySchema,
-  RawPerpsPortfolioSchema,
 } from '../perps/account';
 import {
   PerpsInstrumentIdSchema,
@@ -195,7 +195,7 @@ export type PerpsBalanceUpdateEvent = z.infer<
 export const PerpsPortfolioUpdateEventSchema = perpsSessionEventSchema(
   'portfolio',
   'portfolio',
-  RawPerpsPortfolioSchema,
+  PerpsPortfolioSchema,
 );
 export type PerpsPortfolioUpdateEvent = z.infer<
   typeof PerpsPortfolioUpdateEventSchema

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -13,6 +13,7 @@ import {
   FetchPerpsTickersResponseSchema,
   FetchPerpsTradesResponseSchema,
   type PerpsBook,
+  PerpsBookSchema,
   type PerpsCandle,
   type PerpsCredentials,
   type PerpsFeeScheduleEntry,
@@ -27,7 +28,6 @@ import {
   type PerpsTicker,
   PerpsTradeIdSchema,
   type PerpsWithdrawalId,
-  RawPerpsBookSchema,
   RawPerpsCreateProxyResponseSchema,
   RawPerpsCredentialsResponseSchema,
   RawPerpsDeleteProxyResponseSchema,
@@ -314,7 +314,7 @@ export async function fetchPerpsBook(
       .get('/v1/info/book', {
         params: toSearchParams(params, snakeCase()),
       })
-      .andThen(validateWith(RawPerpsBookSchema)),
+      .andThen(validateWith(PerpsBookSchema)),
   );
 }
 

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -15,7 +15,10 @@ import {
   type PerpsBook,
   PerpsBookSchema,
   type PerpsCandle,
+  PerpsCreateProxyResponseSchema,
   type PerpsCredentials,
+  PerpsCredentialsResponseSchema,
+  PerpsDeleteProxyResponseSchema,
   type PerpsFeeScheduleEntry,
   type PerpsFundingRate,
   type PerpsInstrument,
@@ -28,10 +31,7 @@ import {
   type PerpsTicker,
   PerpsTradeIdSchema,
   type PerpsWithdrawalId,
-  RawPerpsCreateProxyResponseSchema,
-  RawPerpsCredentialsResponseSchema,
-  RawPerpsDeleteProxyResponseSchema,
-  RawPerpsWithdrawResponseSchema,
+  PerpsWithdrawResponseSchema,
 } from '@polymarket/bindings/perps';
 import {
   type EvmAddress,
@@ -971,7 +971,7 @@ export async function revokePerpsCredentials(
           ts: timestamp,
         },
       })
-      .andThen(validateWith(RawPerpsDeleteProxyResponseSchema)),
+      .andThen(validateWith(PerpsDeleteProxyResponseSchema)),
   );
 
   if (response.status === 'err') {
@@ -1079,7 +1079,7 @@ export async function withdrawFromPerps(
           ts: timestamp,
         },
       })
-      .andThen(validateWith(RawPerpsWithdrawResponseSchema)),
+      .andThen(validateWith(PerpsWithdrawResponseSchema)),
   );
 
   if (response.status === 'err') {
@@ -1133,7 +1133,7 @@ async function createPerpsCredentials(
   const response = await unwrap(
     client.perps
       .post('/v1/account/proxy', { json: body })
-      .andThen(validateWith(RawPerpsCreateProxyResponseSchema)),
+      .andThen(validateWith(PerpsCreateProxyResponseSchema)),
   );
   const credentials = {
     expiresAt,
@@ -1162,7 +1162,7 @@ async function validatePerpsCredentials(
       .get('/v1/account/credentials', {
         headers: perpsCredentialHeaders(credentials),
       })
-      .andThen(validateWith(RawPerpsCredentialsResponseSchema)),
+      .andThen(validateWith(PerpsCredentialsResponseSchema)),
   );
 
   if (!isSameEvmAddress(response.address, client.account.signer)) {


### PR DESCRIPTION
## Summary
- Rename duplicate Perps REST model raw schema exports to the public schema names.
- Rename Perps response/hash boundary schemas that do not need the raw suffix.
- Keep compact websocket/update payload parsers and command acknowledgement raw parsers intact.
- Update schema consumers, tests, and add a bindings changeset.

## Verification
- pnpm exec vitest run --project bindings packages/bindings/src/perps/market.test.ts packages/bindings/src/perps/funds.test.ts packages/bindings/src/perps/orders.test.ts
- pnpm --filter @polymarket/types build
- pnpm --filter @polymarket/bindings build
- pnpm lint
- pnpm typecheck
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bindings export renames can break downstream imports of removed `RawPerps*` REST symbols, though validation logic is largely unchanged.
> 
> **Overview**
> **Collapses duplicate Perps REST models** so the exported `Perps*Schema` names are the snake_case wire parsers with camelCase transforms, instead of maintaining parallel “public object” and `RawPerps*` pairs.
> 
> **Renames** `RawPerpsTxHashSchema` to `PerpsTxHashSchema` and applies it across deposits, withdrawals, trades, and fills. Response helpers such as `FetchPerpsPortfolioResponseSchema`, `PerpsWithdrawResponseSchema`, and `PerpsCredentialsResponseSchema` now alias the unified schemas. **Removes** the unused `RawPerpsInternalTransferSchema` path in funds.
> 
> **Leaves `RawPerps*` in place** for compact websocket payloads and command acks (order updates, deposit/withdrawal updates, post/cancel acks, ticker/book/trade entry shapes). **Updates** `@polymarket/client` perps actions and portfolio subscription wiring to import the new names, plus bindings tests and a patch changeset.
> 
> **Note for consumers:** any code importing former `RawPerps*` REST/response schema symbols must switch to the matching `Perps*` export; parsing behavior is intended to stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53174043630a630e6113ec222912d300c6c8074a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->