### PR TITLE
fix(bindings): normalize perps order side

### DIFF
--- a/.changeset/perps-order-side.md
+++ b/.changeset/perps-order-side.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Normalize Perps order reads to expose `side: OrderSide` instead of upstream `buy`.

--- a/packages/bindings/src/perps/orders.test.ts
+++ b/packages/bindings/src/perps/orders.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { OrderSide } from '../shared';
 import {
   PerpsAccountFillSchema,
   PerpsCancelOrderResultSchema,
   PerpsOrderSchema,
   PerpsOrderStatus,
+  PerpsOrderUpdateSchema,
   PerpsPostOrderAckSchema,
 } from './orders';
 
@@ -70,7 +72,7 @@ describe('PerpsPostOrderAckSchema', () => {
 });
 
 describe('PerpsOrderSchema', () => {
-  it('normalizes typed order statuses', () => {
+  it('normalizes order status and side', () => {
     const order = PerpsOrderSchema.parse({
       buy: true,
       created_timestamp: 1_700_000_000_000,
@@ -87,7 +89,30 @@ describe('PerpsOrderSchema', () => {
     });
 
     expect(order.id).toBe(123);
+    expect(order.side).toBe(OrderSide.BUY);
     expect(order.status).toBe(PerpsOrderStatus.Partial);
+  });
+});
+
+describe('PerpsOrderUpdateSchema', () => {
+  it('normalizes order update side', () => {
+    const order = PerpsOrderUpdateSchema.parse({
+      buy: false,
+      coid: '0123456789abcdef0123456789abcdef',
+      cts: 1_700_000_000_000,
+      fill: '0',
+      iid: 1,
+      oid: 123,
+      p: '100',
+      po: false,
+      qty: '2',
+      rest: '2',
+      status: 'open',
+      tif: 'gtc',
+      uts: 1_700_000_000_000,
+    });
+
+    expect(order.side).toBe(OrderSide.SELL);
   });
 });
 

--- a/packages/bindings/src/perps/orders.ts
+++ b/packages/bindings/src/perps/orders.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import { DecimalStringSchema, EpochMillisecondsSchema } from '../shared';
+import {
+  DecimalStringSchema,
+  EpochMillisecondsSchema,
+  OrderSide,
+} from '../shared';
 import {
   PerpsAssetSchema,
   PerpsClientOrderIdSchema,
@@ -144,7 +148,7 @@ export const PerpsOrderSchema = z
   .transform((order) => ({
     id: order.order_id,
     instrumentId: order.instrument_id,
-    buy: order.buy,
+    side: order.buy ? OrderSide.BUY : OrderSide.SELL,
     price: order.price,
     quantity: order.quantity,
     timeInForce: order.tif,
@@ -182,7 +186,7 @@ export const PerpsOrderUpdateSchema = z
   .transform((order) => ({
     id: order.oid,
     instrumentId: order.iid,
-    buy: order.buy,
+    side: order.buy ? OrderSide.BUY : OrderSide.SELL,
     price: order.p,
     quantity: order.qty,
     timeInForce: order.tif,


### PR DESCRIPTION
## Summary
- normalize Perps order reads and order update events from upstream `buy` into SDK `side: OrderSide`
- add binding coverage for HTTP order reads and websocket order updates
- add a patch changeset for `@polymarket/bindings` and `@polymarket/client`

## Verification
- `pnpm test:bindings -- packages/bindings/src/perps/orders.test.ts`
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking shape change for any code reading `buy` on `PerpsOrder` or order updates; downstream client usage must switch to `side`.
> 
> **Overview**
> Perps **HTTP order reads** (`PerpsOrderSchema`) and **websocket order updates** (`PerpsOrderUpdateSchema`) no longer expose upstream `buy: boolean` on parsed objects. Both schemas now map `buy` to **`side: OrderSide`** (`BUY` / `SELL`) during Zod transforms, aligning perps orders with the shared SDK order-side type.
> 
> Tests assert `side` for REST-shaped orders and compact WS update payloads. A patch changeset covers `@polymarket/bindings` and `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91c9e6381fb1d5aab09aebd89aeb65e6539d7e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->