### PR TITLE
fix(client): clean up deposit wallet deployment

### DIFF
--- a/.changeset/legacy-deposit-wallet-default.md
+++ b/.changeset/legacy-deposit-wallet-default.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/client': patch
+---
+
+Clean up Deposit Wallet deployment after the beacon factory upgrade by preserving deployed legacy UUPS wallets and defaulting new deployments to beacon wallets.

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -93,9 +93,15 @@ describe('secure client gasless wallet setup', () => {
       signerAddress,
       environment.walletDerivation,
     );
+    const legacyWallet = deriveUupsDepositWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
     mockApiKeys();
-    mockBeaconFactory();
-    mockUndeployedWallet(expectedWallet);
+    mockDepositWalletDeployments([
+      { wallet: legacyWallet, deployed: false },
+      { wallet: expectedWallet, deployed: false },
+    ]);
     const submit = mockDeployDepositWallet();
 
     const client = await createSecureClient({
@@ -113,14 +119,42 @@ describe('secure client gasless wallet setup', () => {
     });
   });
 
-  it('defaults createSecureClient without a wallet to the deterministic deposit wallet', async () => {
+  it('defaults createSecureClient without a wallet param to the beacon deposit wallet', async () => {
     const expectedWallet = deriveBeaconDepositWalletAddress(
       signerAddress,
       environment.walletDerivation,
     );
+    const legacyWallet = deriveUupsDepositWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
     mockApiKeys();
-    mockBeaconFactory();
-    mockDeployedWallet(expectedWallet);
+    mockDepositWalletDeployments([
+      { wallet: legacyWallet, deployed: false },
+      { wallet: expectedWallet, deployed: true },
+    ]);
+
+    const client = await createSecureClient({
+      apiKey,
+      credentials,
+      environment,
+      signer,
+    });
+
+    expect(client.account).toEqual({
+      signer: signerAddress,
+      wallet: expectedWallet,
+      walletType: WalletType.DEPOSIT_WALLET,
+    });
+  });
+
+  it('defaults createSecureClient without a wallet param to an existing legacy deposit wallet', async () => {
+    const expectedWallet = deriveUupsDepositWalletAddress(
+      signerAddress,
+      environment.walletDerivation,
+    );
+    mockApiKeys();
+    mockDepositWalletDeployments([{ wallet: expectedWallet, deployed: true }]);
 
     const client = await createSecureClient({
       apiKey,
@@ -291,7 +325,6 @@ describe('secure client gasless wallet setup', () => {
       environment.walletDerivation,
     );
     mockApiKeys();
-    mockBeaconFactory();
     mockUndeployedWallet(legacyWallet);
 
     await expect(
@@ -305,22 +338,6 @@ describe('secure client gasless wallet setup', () => {
     ).rejects.toMatchObject({
       message: `Wallet ${legacyWallet} does not match the expected Deposit Wallet ${currentWallet} for this signer, nor a deployed wallet address.`,
       name: 'UserInputError',
-    });
-  });
-
-  it('does not silently fall back when default deposit wallet detection fails generically', async () => {
-    mockFactoryRpcError();
-
-    await expect(
-      createSecureClient({
-        apiKey,
-        credentials,
-        environment,
-        signer,
-      }),
-    ).rejects.toMatchObject({
-      message: 'JSON-RPC eth_call failed: upstream unavailable',
-      name: 'RequestRejectedError',
     });
   });
 
@@ -368,30 +385,6 @@ describe('secure client gasless wallet setup', () => {
   });
 });
 
-function mockBeaconFactory() {
-  server.use(
-    http.post(rpcRoot, () =>
-      HttpResponse.json({
-        jsonrpc: '2.0',
-        id: 1,
-        result: `0x000000000000000000000000${environment.walletDerivation.depositWalletBeacon.slice(2)}`,
-      }),
-    ),
-  );
-}
-
-function mockFactoryRpcError() {
-  server.use(
-    http.post(rpcRoot, () =>
-      HttpResponse.json({
-        jsonrpc: '2.0',
-        id: 1,
-        error: { code: -32_603, message: 'upstream unavailable' },
-      }),
-    ),
-  );
-}
-
 function mockApiKeys() {
   server.use(
     http.get(`${clobRoot}/auth/api-keys`, () =>
@@ -421,6 +414,25 @@ function mockUndeployedWallet(expectedWallet: EvmAddress) {
       expect(url.searchParams.get('type')).toBe('WALLET');
 
       return HttpResponse.json({ deployed: false });
+    }),
+  );
+}
+
+function mockDepositWalletDeployments(
+  deployments: Array<{ wallet: EvmAddress; deployed: boolean }>,
+) {
+  server.use(
+    http.get(`${relayerRoot}/deployed`, ({ request }) => {
+      const url = new URL(request.url);
+      const address = expectEvmAddress(url.searchParams.get('address') ?? '');
+      const deployment = deployments.find(
+        ({ wallet }) => wallet.toLowerCase() === address.toLowerCase(),
+      );
+
+      expect(url.searchParams.get('type')).toBe('WALLET');
+      expect(deployment).toBeDefined();
+
+      return HttpResponse.json({ deployed: deployment?.deployed ?? false });
     }),
   );
 }

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -48,7 +48,8 @@ import { ServiceClient } from './ServiceClient';
 import type { ApiKeyAuthorization, Signer } from './types';
 import type { AccountIdentity } from './wallet';
 import {
-  deriveCurrentDepositWalletAddress,
+  deriveBeaconDepositWalletAddress,
+  deriveUupsDepositWalletAddress,
   resolveAccountIdentity,
 } from './wallet';
 import {
@@ -984,10 +985,7 @@ export async function createSecureClient(
   );
 }
 
-/**
- * Resolves the wallet address to authenticate as. Defaults to the signer's
- * current deterministic Deposit Wallet when no wallet is provided.
- */
+/** Resolves the wallet address to authenticate as. */
 async function resolveRequestedWallet(
   client: BasePublicClient,
   options: SecureClientOptions,
@@ -997,25 +995,35 @@ async function resolveRequestedWallet(
   }
 
   const signerAddress = expectEvmAddress(await options.signer.getAddress());
+  const legacyDepositWallet = deriveUupsDepositWalletAddress(
+    signerAddress,
+    client.environment.walletDerivation,
+  );
 
-  return deriveCurrentDepositWalletAddress(
-    client.rpc,
+  if (
+    await isWalletDeployed(client, {
+      wallet: legacyDepositWallet,
+      type: WalletType.DEPOSIT_WALLET,
+    })
+  ) {
+    return legacyDepositWallet;
+  }
+
+  return deriveBeaconDepositWalletAddress(
     signerAddress,
     client.environment.walletDerivation,
   );
 }
 
 /**
- * Deploys the signer's current deterministic Deposit Wallet for the secure
- * client. Only the current Deposit Wallet can be deployed: a provided Deposit
- * Wallet that does not match the current deterministic address would deploy a
- * different wallet than the client is bound to, so it is rejected.
+ * Deploys the signer's beacon Deposit Wallet for the secure client. The current
+ * factory only deploys beacon wallets, so legacy UUPS wallets must already be
+ * deployed and cannot be created through this path.
  */
 async function deployDefaultDepositWallet(
   secureClient: SecureClient<PublicActions, SecureActions>,
 ): Promise<void> {
-  const currentDepositWallet = await deriveCurrentDepositWalletAddress(
-    secureClient.rpc,
+  const currentDepositWallet = deriveBeaconDepositWalletAddress(
     secureClient.account.signer,
     secureClient.environment.walletDerivation,
   );


### PR DESCRIPTION
## Summary
- Clean up secure client Deposit Wallet resolution after the beacon factory upgrade
- Preserve deployed legacy UUPS Deposit Wallets when wallet is omitted
- Default new Deposit Wallet deployments to beacon wallets without runtime factory probing
- Add a patch changeset for @polymarket/client

## Verification
- pnpm vitest --project client packages/client/src/clients.test.ts --run
- pnpm vitest --project client-integration packages/client/tests/integration/clients.test.ts -t "defaults omitted wallet to the current Deposit Wallet" --run
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which on-chain wallet secure clients bind to for gasless deposit flows, which can mis-route funds or auth if deployment checks are wrong; scope is limited to client resolution/deploy logic with updated unit tests.
> 
> **Overview**
> Updates **omitted-wallet** resolution in `createSecureClient` so users with an **already-deployed legacy UUPS** deposit wallet keep that address, while **new** users get the **beacon** deterministic address without probing the on-chain factory via RPC.
> 
> **Deployment** path now always targets the beacon wallet (`deriveBeaconDepositWalletAddress`) and documents that legacy UUPS wallets cannot be created through auto-deploy; explicit undeployed legacy wallets still fail with the same mismatch error.
> 
> Tests mock relayer `/deployed` for both wallet variants and drop JSON-RPC factory mocks plus the case that expected RPC failure during default wallet detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5fa4fda05295dbe50ed0bf22b849ca4c5907f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->