### PR TITLE
fix(client): align perps leverage result

### DIFF
--- a/.changeset/perps-leverage-result.md
+++ b/.changeset/perps-leverage-result.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/client": patch
+"@polymarket/bindings": patch
+---
+
+Remove unsupported Perps margin updates and return the leverage update result.

--- a/packages/bindings/src/perps/orders.ts
+++ b/packages/bindings/src/perps/orders.ts
@@ -125,6 +125,24 @@ export type PerpsCancelOrderResult = z.infer<
   typeof PerpsCancelOrderResultSchema
 >;
 
+export const PerpsUpdateLeverageResultSchema = z
+  .object({
+    status: z.literal('ok'),
+    instrument_id: PerpsInstrumentIdSchema,
+    leverage: z.number().int().positive(),
+    cross: z.boolean(),
+  })
+  .transform((result) => ({
+    status: result.status,
+    instrumentId: result.instrument_id,
+    leverage: result.leverage,
+    crossMargin: result.cross,
+  }));
+
+export type PerpsUpdateLeverageResult = z.infer<
+  typeof PerpsUpdateLeverageResultSchema
+>;
+
 function perpsAckError(error: string | undefined): string {
   return error ?? 'Perps command was rejected.';
 }

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -102,15 +102,12 @@ export type {
   PerpsPostOrderAck,
   PerpsSession,
   PerpsSessionEvent,
+  PerpsUpdateLeverageResult,
   PlacePerpsOrderRequest,
   PostPerpsOrdersRequest,
   UpdatePerpsLeverageRequest,
-  UpdatePerpsMarginRequest,
 } from '../websockets/perps/session';
-export {
-  UpdatePerpsLeverageError,
-  UpdatePerpsMarginError,
-} from '../websockets/perps/session';
+export { UpdatePerpsLeverageError } from '../websockets/perps/session';
 
 import { snakeCase, toSearchParams } from './params';
 

--- a/packages/client/src/decorators/perps.ts
+++ b/packages/client/src/decorators/perps.ts
@@ -47,8 +47,9 @@ export type {
   PerpsPostOrderAck,
   PerpsSession,
   PerpsSessionEvent,
+  PerpsUpdateLeverageResult,
 } from '../actions';
-export { UpdatePerpsLeverageError, UpdatePerpsMarginError } from '../actions';
+export { UpdatePerpsLeverageError } from '../actions';
 
 export type PublicPerpsActions = {
   /**

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -7,8 +7,6 @@ import {
   type PerpsCancelOrderResult,
   PerpsCancelOrderResultSchema,
   PerpsClientOrderIdSchema,
-  type PerpsCommandAck,
-  PerpsCommandAckSchema,
   type PerpsDecimalInput,
   PerpsDecimalInputSchema,
   type PerpsInstrumentId,
@@ -17,6 +15,8 @@ import {
   type PerpsPostOrderAck,
   PerpsPostOrderAckSchema,
   PerpsTimeInForce,
+  type PerpsUpdateLeverageResult,
+  PerpsUpdateLeverageResultSchema,
 } from '@polymarket/bindings/perps';
 import { expectPresent, invariant } from '@polymarket/types';
 import { z } from 'zod';
@@ -25,11 +25,10 @@ import {
   RequestRejectedError,
   SigningError,
   TransportError,
-  UnexpectedResponseError,
   UserInputError,
 } from '../../../errors';
 import { parseUserInput } from '../../../input';
-import type { PerpsSignableValue, PerpsSignedOp } from '../signing';
+import type { PerpsSignedOp } from '../signing';
 
 const PerpsOrderBaseInputSchema = z.object({
   instrumentId: PerpsInstrumentIdSchema,
@@ -135,17 +134,8 @@ export type PerpsSignedWsCommandRequest<T> = {
   expiresAt?: number;
 };
 
-export type PerpsSignedHttpCommandRequest = {
-  bodyOp: PerpsSignableValue;
-  op: PerpsSignedOp;
-};
-
 export type PerpsTradingTransport = {
   sendSignedWsCommand<T>(request: PerpsSignedWsCommandRequest<T>): Promise<T>;
-  sendSignedHttpCommand(
-    path: string,
-    request: PerpsSignedHttpCommandRequest,
-  ): Promise<PerpsCommandAck>;
 };
 
 /** Request parameters for posting one or more Perps orders. */
@@ -278,75 +268,16 @@ export const UpdatePerpsLeverageError = makeErrorGuard(
 export async function updatePerpsLeverage(
   transport: PerpsTradingTransport,
   request: UpdatePerpsLeverageRequest,
-): Promise<void> {
+): Promise<PerpsUpdateLeverageResult> {
   const params = parseUserInput(request, UpdatePerpsLeverageRequestSchema);
-  const ack = await transport.sendSignedWsCommand({
+  return await transport.sendSignedWsCommand({
     op: [
       'updateLeverage',
       [params.instrumentId, params.leverage, params.crossMargin],
     ],
-    responseSchema: PerpsCommandAckSchema,
-    timeoutMessage: 'Perps update leverage acknowledgement timed out.',
+    responseSchema: PerpsUpdateLeverageResultSchema,
+    timeoutMessage: 'Perps update leverage response timed out.',
   });
-  if (ack.status === 'err') {
-    throw new RequestRejectedError(
-      ack.error ?? 'Perps update leverage command was rejected.',
-      { status: 200 },
-    );
-  }
-}
-
-const UpdatePerpsMarginRequestSchema = z.object({
-  instrumentId: PerpsInstrumentIdSchema,
-  amount: PerpsDecimalInputSchema,
-});
-
-export type UpdatePerpsMarginRequest = z.input<
-  typeof UpdatePerpsMarginRequestSchema
->;
-
-export type UpdatePerpsMarginError =
-  | RequestRejectedError
-  | SigningError
-  | TransportError
-  | UnexpectedResponseError
-  | UserInputError;
-export const UpdatePerpsMarginError = makeErrorGuard(
-  RequestRejectedError,
-  SigningError,
-  TransportError,
-  UnexpectedResponseError,
-  UserInputError,
-);
-
-/**
- * Updates isolated margin for an instrument position.
- *
- * @throws {@link UpdatePerpsMarginError}
- * Thrown on failure.
- */
-export async function updatePerpsMargin(
-  transport: PerpsTradingTransport,
-  request: UpdatePerpsMarginRequest,
-): Promise<void> {
-  const params = parseUserInput(request, UpdatePerpsMarginRequestSchema);
-  const amount = toDecimalString(params.amount);
-  const ack = await transport.sendSignedHttpCommand('/v1/trade/margin', {
-    op: ['updateMargin', [params.instrumentId, amount]],
-    bodyOp: {
-      type: 'updateMargin',
-      args: {
-        amt: amount,
-        iid: params.instrumentId,
-      },
-    },
-  });
-  if (ack.status === 'err') {
-    throw new RequestRejectedError(
-      ack.error ?? 'Perps update margin command was rejected.',
-      { status: 200 },
-    );
-  }
 }
 
 type RawPerpsOrderInput = readonly [

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -498,7 +498,12 @@ describe('PerpsSession', () => {
           instrumentId: 1,
           leverage: 5,
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toEqual({
+        crossMargin: false,
+        instrumentId: 1,
+        leverage: 5,
+        status: 'ok',
+      });
       expect(frames[2]).toMatchObject({
         id: 3,
         op: {
@@ -600,22 +605,6 @@ describe('PerpsSession', () => {
       } finally {
         await session.close();
       }
-    });
-
-    it('throws when margin update is rejected', async () => {
-      server.use(
-        http.patch(`${production.perps.rest}/v1/trade/margin`, () => {
-          return HttpResponse.json({
-            status: 'err',
-            error: 'invalid margin',
-          });
-        }),
-      );
-      const session = createSession();
-
-      await expect(
-        session.updateMargin({ amount: '1', instrumentId: 1 }),
-      ).rejects.toBeInstanceOf(RequestRejectedError);
     });
   });
 
@@ -855,7 +844,7 @@ function responseForFrame(frame: { op?: { type?: string }; req?: string }) {
         },
       ];
     case 'updateLeverage':
-      return { status: 'ok' };
+      return { status: 'ok', instrument_id: 1, leverage: 5, cross: false };
     case 'cancelOrdersCOID':
       return [
         {

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -13,6 +13,7 @@ import {
   type PerpsPnlPoint,
   type PerpsPortfolio,
   type PerpsPostOrderAck,
+  type PerpsUpdateLeverageResult,
   type PerpsWithdrawal,
 } from '@polymarket/bindings/perps';
 import {
@@ -24,7 +25,6 @@ import {
   expectNonEmptyArray,
   invariant,
   setNonBlockingTimeout,
-  unwrap,
 } from '@polymarket/types';
 import { type Pushable, pushable } from 'it-pushable';
 import { z } from 'zod';
@@ -35,7 +35,6 @@ import {
   TransportError,
 } from '../../errors';
 import type { Paginated } from '../../pagination';
-import { validateWith } from '../../response';
 import { ServiceClient } from '../../ServiceClient';
 import { PerpsWebSocketHeartbeat } from '../heartbeat';
 import { ReconnectScheduler, WebSocketConnection } from '../lifecycle';
@@ -66,7 +65,6 @@ import {
   type CancelPerpsOrdersRequest,
   cancelPerpsOrder,
   cancelPerpsOrders,
-  type PerpsSignedHttpCommandRequest,
   type PerpsSignedWsCommandRequest,
   type PerpsTradingTransport,
   type PlacePerpsOrderRequest,
@@ -74,9 +72,7 @@ import {
   postPerpsOrders,
   toPerpsCommandBodyOp,
   type UpdatePerpsLeverageRequest,
-  type UpdatePerpsMarginRequest,
   updatePerpsLeverage,
-  updatePerpsMargin,
 } from './actions/trading';
 import { type PerpsSignableValue, signPerpsOp } from './signing';
 
@@ -125,6 +121,7 @@ type EventWaiter = {
 export type {
   PerpsCancelOrderResult,
   PerpsPostOrderAck,
+  PerpsUpdateLeverageResult,
 } from '@polymarket/bindings/perps';
 export type { PerpsSessionEvent } from '@polymarket/bindings/subscriptions';
 export type {
@@ -147,12 +144,8 @@ export type {
   PlacePerpsOrderRequest,
   PostPerpsOrdersRequest,
   UpdatePerpsLeverageRequest,
-  UpdatePerpsMarginRequest,
 } from './actions/trading';
-export {
-  UpdatePerpsLeverageError,
-  UpdatePerpsMarginError,
-} from './actions/trading';
+export { UpdatePerpsLeverageError } from './actions/trading';
 
 export type PerpsSessionOptions = {
   chainId: number;
@@ -331,12 +324,10 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     return await cancelPerpsOrders(this.#tradingTransport(), request);
   }
 
-  async updateLeverage(request: UpdatePerpsLeverageRequest): Promise<void> {
+  async updateLeverage(
+    request: UpdatePerpsLeverageRequest,
+  ): Promise<PerpsUpdateLeverageResult> {
     return await updatePerpsLeverage(this.#tradingTransport(), request);
-  }
-
-  async updateMargin(request: UpdatePerpsMarginRequest): Promise<void> {
-    return await updatePerpsMargin(this.#tradingTransport(), request);
   }
 
   async #connect(emitResync: boolean): Promise<void> {
@@ -403,8 +394,6 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   #tradingTransport(): PerpsTradingTransport {
     return {
       sendSignedWsCommand: (request) => this.#sendSignedWsCommand(request),
-      sendSignedHttpCommand: (path, request) =>
-        this.#sendSignedHttpCommand(path, request),
     };
   }
 
@@ -423,23 +412,6 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
       request.responseSchema,
       ACK_TIMEOUT_MS,
       request.timeoutMessage,
-    );
-  }
-
-  async #sendSignedHttpCommand(
-    path: string,
-    request: PerpsSignedHttpCommandRequest,
-  ): Promise<PerpsCommandAck> {
-    const command = this.#createSignedCommand(request.op);
-    return await unwrap(
-      this.#api
-        .patch(path, {
-          json: {
-            ...command,
-            op: request.bodyOp,
-          },
-        })
-        .andThen(validateWith(PerpsCommandAckSchema)),
     );
   }
 


### PR DESCRIPTION
## Summary
- remove unsupported Perps margin update APIs from the client/session surface
- parse and return the backend leverage update result as `PerpsUpdateLeverageResult`
- add a changeset for the client and bindings packages

## Verification
- `pnpm --filter @polymarket/types build`
- `pnpm --filter @polymarket/bindings build`
- `pnpm exec vitest run --project client packages/client/src/websockets/perps/session.test.ts`
- `pnpm exec vitest run --project bindings packages/bindings/src/perps/orders.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`