### PR TITLE
fix(bindings): tolerate non-standard gamma market tick size (don't reject the page)

### DIFF
--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -251,7 +251,7 @@ export const GammaMarketSchema = z.object({
     .transform(nullishToNull),
   umaEndDate: MixedDateTimeStringSchema.nullish(),
   enableOrderBook: z.boolean().nullish(),
-  orderPriceMinTickSize: TickSizeValueSchema.nullish(),
+  orderPriceMinTickSize: TickSizeValueSchema.nullish().catch(null),
   orderMinSize: DecimalishSchema.nullish(),
   umaResolutionStatus: z
     .preprocess(emptyStringToNull, UmaResolutionStatusSchema.nullish())


### PR DESCRIPTION
A gamma market with an off-enum `orderPriceMinTickSize` (e.g. `0.0025` seen on staging) makes the strict `TickSizeValueSchema` reject the **entire** `/markets/keyset` response, so `listMarkets()` throws (`Received an incompatible API response`).

Scope a tolerant fallback to the **gamma market-list field only**:
```
orderPriceMinTickSize: TickSizeValueSchema.nullish().catch(null)
```
An off-enum tick parses to `null` instead of nuking the page. `clob/tick-size.ts` (`minimum_tick_size`, order-placement rounding) stays strict.

Draft — needs a changeset + review. Mirrors a temporary bun-patch carried in the e2e-defi test harness; once this lands in a canary we drop that patch.