### PR TITLE
fix(client): support new CLOB tick sizes

### DIFF
--- a/.changeset/clob-new-tick-sizes.md
+++ b/.changeset/clob-new-tick-sizes.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Support CLOB order tick sizes `0.005` and `0.0025`.

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -352,6 +352,8 @@ export const EventIdSchema = z
 export const TickSizeValueSchema = z.union([
   z.literal(0.1),
   z.literal(0.01),
+  z.literal(0.005),
+  z.literal(0.0025),
   z.literal(0.001),
   z.literal(0.0001),
 ]);

--- a/packages/client/src/actions/orders/context.test.ts
+++ b/packages/client/src/actions/orders/context.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRoundingConfig } from './context';
+
+describe('resolveRoundingConfig', () => {
+  it('supports all current tick sizes', () => {
+    expect(resolveRoundingConfig(0.1)).toEqual({
+      amount: 3,
+      price: 1,
+      size: 2,
+    });
+    expect(resolveRoundingConfig(0.01)).toEqual({
+      amount: 4,
+      price: 2,
+      size: 2,
+    });
+    expect(resolveRoundingConfig(0.005)).toEqual({
+      amount: 5,
+      price: 3,
+      size: 2,
+    });
+    expect(resolveRoundingConfig(0.0025)).toEqual({
+      amount: 6,
+      price: 4,
+      size: 2,
+    });
+    expect(resolveRoundingConfig(0.001)).toEqual({
+      amount: 5,
+      price: 3,
+      size: 2,
+    });
+    expect(resolveRoundingConfig(0.0001)).toEqual({
+      amount: 6,
+      price: 4,
+      size: 2,
+    });
+  });
+});

--- a/packages/client/src/actions/orders/context.ts
+++ b/packages/client/src/actions/orders/context.ts
@@ -15,6 +15,10 @@ export function resolveRoundingConfig(tickSize: TickSizeValue): RoundingConfig {
       return { amount: 3, price: 1, size: 2 };
     case 0.01:
       return { amount: 4, price: 2, size: 2 };
+    case 0.005:
+      return { amount: 5, price: 3, size: 2 };
+    case 0.0025:
+      return { amount: 6, price: 4, size: 2 };
     case 0.001:
       return { amount: 5, price: 3, size: 2 };
     case 0.0001:


### PR DESCRIPTION
## Summary
- accept 0.005 and 0.0025 tick sizes in the shared tick-size schema
- add order rounding config coverage for the new tick sizes
- align with Polymarket/clob-client-v2#84

## Verification
- pnpm exec vitest run packages/client/src/actions/orders/context.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test:client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive validation and rounding changes for order formatting; covered by unit tests and aligned with existing tick-size handling.
> 
> **Overview**
> Adds support for CLOB minimum tick sizes **`0.005`** and **`0.0025`**, matching upstream CLOB behavior.
> 
> **`TickSizeValueSchema`** in `@polymarket/bindings` now accepts the two new literals, so tick-size API responses and market metadata (e.g. `minimum_tick_size`, `orderPriceMinTickSize`) can validate without failing.
> 
> **`resolveRoundingConfig`** in the client order context maps those tick sizes to rounding decimals (same pattern as existing sizes: finer ticks get more `amount`/`price` precision). A new **`context.test.ts`** locks in expected rounding for every supported tick size.
> 
> Patch changesets are included for bindings and client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e091ef4a63dbf37273637c67ab6be2b5ab325ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->