### PR TITLE
feat(client): add listMarketClarifications

### DIFF
--- a/.changeset/dev-342-market-clarifications.md
+++ b/.changeset/dev-342-market-clarifications.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Add `listMarketClarifications` for reading market clarification text, with SDK-owned offset pagination and market/event/state/question/tx filters.

--- a/packages/bindings/src/gamma/index.ts
+++ b/packages/bindings/src/gamma/index.ts
@@ -2,6 +2,7 @@ export * from './comment';
 export * from './common';
 export * from './event';
 export * from './market';
+export * from './market-clarification';
 export * from './pagination';
 export * from './profile';
 export * from './search';

--- a/packages/bindings/src/gamma/market-clarification.test.ts
+++ b/packages/bindings/src/gamma/market-clarification.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MarketClarificationSchema,
+  MarketClarificationState,
+} from './market-clarification';
+
+const QUESTION_ID = `0x${'1'.repeat(64)}`;
+const TX_HASH = `0x${'a'.repeat(64)}`;
+const ADAPTER_ADDRESS = `0x${'b'.repeat(40)}`;
+
+describe('MarketClarificationSchema', () => {
+  it('normalizes a full clarification record', () => {
+    const result = MarketClarificationSchema.parse({
+      id: 123,
+      marketId: 512038,
+      eventId: 20001,
+      questionId: QUESTION_ID,
+      content: 'Resolves YES if the price is at or above the strike.',
+      state: 'success',
+      clearBook: false,
+      notifyDiscord: true,
+      showInFrontend: true,
+      adapterAddress: ADAPTER_ADDRESS,
+      negRiskRequestId: 'req-1',
+      txHash: TX_HASH,
+      createdAt: '2025-06-01T00:00:00Z',
+      queuedAt: '2025-06-01T00:01:00Z',
+      scheduledFor: '2025-06-01T00:05:00Z',
+      txTimestamp: '2025-06-01T00:06:00Z',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 123,
+        // numeric upstream ids are branded as strings
+        marketId: '512038',
+        eventId: '20001',
+        questionId: QUESTION_ID,
+        state: MarketClarificationState.Success,
+        adapterAddress: ADAPTER_ADDRESS,
+        txHash: TX_HASH,
+        createdAt: '2025-06-01T00:00:00Z',
+        txTimestamp: '2025-06-01T00:06:00Z',
+      }),
+    );
+  });
+
+  it('accepts a sparse record with nullish optional fields', () => {
+    const result = MarketClarificationSchema.parse({
+      id: 7,
+      marketId: '900',
+      content: null,
+      state: null,
+      clearBook: null,
+    });
+
+    expect(result.id).toBe(7);
+    expect(result.marketId).toBe('900');
+    expect(result.state).toBeNull();
+  });
+});

--- a/packages/bindings/src/gamma/market-clarification.ts
+++ b/packages/bindings/src/gamma/market-clarification.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import {
+  EventIdSchema,
+  EvmAddressSchema,
+  IsoDateTimeStringSchema,
+  QuestionIdSchema,
+  TxHashSchema,
+  toMarketId,
+} from '../shared';
+
+/** Lifecycle state of a clarification as it is scheduled and posted on-chain. */
+export enum MarketClarificationState {
+  Pending = 'pending',
+  Queued = 'queued',
+  Success = 'success',
+  Failed = 'failed',
+  Cancelled = 'cancelled',
+}
+
+// The upstream payload returns `marketId` as a JSON number, but the `MarketId`
+// brand is string-valued, so accept number-or-string here (mirrors `EventIdSchema`).
+const MarketIdFromWireSchema = z
+  .union([z.string(), z.number().int().transform(String)])
+  .transform(toMarketId);
+
+export const MarketClarificationSchema = z.object({
+  id: z.number().int(),
+  marketId: MarketIdFromWireSchema.nullish(),
+  eventId: EventIdSchema.nullish(),
+  questionId: QuestionIdSchema.nullish(),
+  content: z.string().nullish(),
+  state: z.enum(MarketClarificationState).nullish(),
+  clearBook: z.boolean().nullish(),
+  notifyDiscord: z.boolean().nullish(),
+  showInFrontend: z.boolean().nullish(),
+  adapterAddress: EvmAddressSchema.nullish(),
+  negRiskRequestId: z.string().nullish(),
+  txHash: TxHashSchema.nullish(),
+  createdAt: IsoDateTimeStringSchema.nullish(),
+  queuedAt: IsoDateTimeStringSchema.nullish(),
+  scheduledFor: IsoDateTimeStringSchema.nullish(),
+  txTimestamp: IsoDateTimeStringSchema.nullish(),
+});
+
+export const ListMarketClarificationsResponseSchema = z.array(
+  MarketClarificationSchema,
+);
+
+export type MarketClarification = z.infer<typeof MarketClarificationSchema>;
+export type ListMarketClarificationsResponse = z.infer<
+  typeof ListMarketClarificationsResponseSchema
+>;

--- a/packages/client/src/actions/index.ts
+++ b/packages/client/src/actions/index.ts
@@ -8,6 +8,7 @@ export * from './comments';
 export * from './events';
 export * from './gasless';
 export * from './leaderboards';
+export * from './market-clarifications';
 export * from './markets';
 export * from './orders';
 export * from './perps';

--- a/packages/client/src/actions/market-clarifications.ts
+++ b/packages/client/src/actions/market-clarifications.ts
@@ -1,0 +1,141 @@
+import { PaginationCursorSchema } from '@polymarket/bindings';
+import {
+  ListMarketClarificationsResponseSchema,
+  type MarketClarification,
+  MarketClarificationState,
+} from '@polymarket/bindings/gamma';
+import { z } from 'zod';
+import type { BaseClient } from '../clients';
+import {
+  makeErrorGuard,
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+} from '../errors';
+import { parseUserInput } from '../input';
+import {
+  decodeOffsetCursor,
+  encodeOffsetCursor,
+  PageSizeSchema,
+  type Paginated,
+  paginate,
+} from '../pagination';
+import { validateWith } from '../response';
+import { snakeCase, toSearchParams } from './params';
+
+const ListMarketClarificationsRequestSchema = z.object({
+  marketId: z.union([z.string(), z.array(z.string())]).optional(),
+  eventId: z.union([z.string(), z.array(z.string())]).optional(),
+  questionId: z.union([z.string(), z.array(z.string())]).optional(),
+  state: z
+    .union([
+      z.enum(MarketClarificationState),
+      z.array(z.enum(MarketClarificationState)),
+    ])
+    .optional(),
+  showInFrontend: z.boolean().optional(),
+  txHash: z.string().optional(),
+  order: z.string().optional(),
+  ascending: z.boolean().optional(),
+  cursor: PaginationCursorSchema.optional(),
+  pageSize: PageSizeSchema.default(20),
+});
+
+export type ListMarketClarificationsRequest = z.input<
+  typeof ListMarketClarificationsRequestSchema
+>;
+
+export type ListMarketClarificationsError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const ListMarketClarificationsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Lists market clarifications — official notes that resolve ambiguity in how a
+ * market settles.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
+ * @throws {@link ListMarketClarificationsError}
+ * Thrown on failure.
+ *
+ * @example
+ * Fetch the first page of results:
+ * ```ts
+ * const result = listMarketClarifications(client, {
+ *   marketId: '512038',
+ *   pageSize: 25,
+ * });
+ *
+ * const firstPage = await result.firstPage();
+ *
+ * // Optionally, fetch additional pages:
+ * for await (const page of result.from(firstPage.nextCursor)) {
+ *   // page.items: MarketClarification[]
+ * }
+ * ```
+ *
+ * @example
+ * Loop through all pages with `for await`:
+ * ```ts
+ * const result = listMarketClarifications(client, {
+ *   marketId: '512038',
+ * });
+ *
+ * for await (const page of result) {
+ *   // page.items: MarketClarification[]
+ * }
+ * ```
+ */
+export function listMarketClarifications(
+  client: BaseClient,
+  request: ListMarketClarificationsRequest = {},
+): Paginated<MarketClarification[]> {
+  const { cursor, pageSize, ...params } = parseUserInput(
+    request,
+    ListMarketClarificationsRequestSchema,
+  );
+
+  return paginate((cursor) => {
+    const decoded = decodeOffsetCursor(cursor, pageSize);
+
+    return client.gamma
+      .get('/market-clarifications', {
+        params: toSearchParams(
+          {
+            ...params,
+            limit: decoded.pageSize + 1,
+            offset: decoded.offset,
+          },
+          snakeCase(),
+        ),
+      })
+      .andThen(validateWith(ListMarketClarificationsResponseSchema))
+      .map((clarifications) => {
+        const hasMore = clarifications.length > decoded.pageSize;
+
+        return {
+          items: clarifications.slice(0, decoded.pageSize),
+          hasMore,
+          nextCursor: hasMore
+            ? encodeOffsetCursor({
+                offset: decoded.offset + decoded.pageSize,
+                pageSize: decoded.pageSize,
+              })
+            : undefined,
+        };
+      });
+  }, cursor);
+}

--- a/packages/client/src/decorators/discovery.ts
+++ b/packages/client/src/decorators/discovery.ts
@@ -2,6 +2,7 @@ import type {
   Comment,
   Event,
   Market,
+  MarketClarification,
   PublicProfile,
   RelatedTag,
   Series,
@@ -38,6 +39,7 @@ import {
   type ListCommentsByUserAddressRequest,
   type ListCommentsRequest,
   type ListEventsRequest,
+  type ListMarketClarificationsRequest,
   type ListMarketsRequest,
   type ListSeriesRequest,
   type ListTagsRequest,
@@ -46,6 +48,7 @@ import {
   listComments,
   listCommentsByUserAddress,
   listEvents,
+  listMarketClarifications,
   listMarkets,
   listSeries,
   listSports,
@@ -315,6 +318,28 @@ export type DiscoveryActions = {
    * ```
    */
   fetchSeries(request: FetchSeriesRequest): Promise<Series>;
+
+  /**
+   * Lists market clarifications — notes that resolve ambiguity in how a market
+   * settles.
+   *
+   * @throws {@link ListMarketClarificationsError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const paginator = client.listMarketClarifications({
+   *   marketId: '512038',
+   * });
+   *
+   * for await (const page of paginator) {
+   *   // page.items: MarketClarification[]
+   * }
+   * ```
+   */
+  listMarketClarifications(
+    request?: ListMarketClarificationsRequest,
+  ): Paginated<MarketClarification[]>;
 
   /**
    * Lists tags.
@@ -615,6 +640,7 @@ export function discoveryActions(client: BaseClient): DiscoveryActions {
     fetchMarketTags: fetchMarketTags.bind(null, client),
     listSeries: listSeries.bind(null, client),
     fetchSeries: fetchSeries.bind(null, client),
+    listMarketClarifications: listMarketClarifications.bind(null, client),
     listTags: listTags.bind(null, client),
     fetchTag: fetchTag.bind(null, client),
     fetchRelatedTags: fetchRelatedTags.bind(null, client),

--- a/packages/client/tests/integration/market-clarifications.test.ts
+++ b/packages/client/tests/integration/market-clarifications.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from './fixtures';
+import { expectNonEmptyPage, expectPageWindow } from './helpers';
+
+describe('MarketClarifications', () => {
+  describe('listMarketClarifications', () => {
+    it('fetches market clarifications', async ({ publicClient }) => {
+      const paginator = publicClient.listMarketClarifications({
+        pageSize: 50,
+      });
+      const result = await paginator.firstPage().then(expectNonEmptyPage);
+
+      expect(result.items.length).toBeGreaterThan(0);
+      await expectPageWindow(paginator, result, 49);
+      expect(result.items[0]).toEqual(
+        expect.objectContaining({
+          id: expect.any(Number),
+        }),
+      );
+    });
+
+    it('filters by market id', async ({ publicClient }) => {
+      const {
+        items: [clarification],
+      } = await publicClient
+        .listMarketClarifications({ pageSize: 1 })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      const marketId = clarification.marketId;
+      expect(marketId).toBeDefined();
+
+      const filtered = await publicClient
+        .listMarketClarifications({ marketId: marketId as string })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      for (const item of filtered.items) {
+        expect(item.marketId).toBe(marketId);
+      }
+    });
+  });
+});


### PR DESCRIPTION
Adds read access to market clarifications — the official notes that resolve ambiguity in how a market settles.

## What
- `listMarketClarifications` on the public client: SDK-owned offset pagination over `gamma-api/market-clarifications`, with `marketId` / `eventId` / `state` / `questionId` / `showInFrontend` / `txHash` filters.
- `MarketClarificationSchema` + `MarketClarificationState` enum in `@polymarket/bindings`. Numeric upstream ids are branded to strings; timestamps normalized; `state` modeled as an enum.

## Notes
- `marketId` accepts number-or-string at the boundary since the upstream returns it as a JSON number (mirrors `EventIdSchema`).
- Filters map camelCase input to the upstream snake_case query keys (`market_id`, `event_id`, …); arrays repeat per key.

## Testing
- Bindings: schema normalization (numeric ids → branded strings, enum resolves, sparse records tolerate nullish optionals).
- Client integration (live): paginates the feed and confirms the `marketId` filter narrows results to the requested market.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` all green.

Refs: DEV-342

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API with established pagination and validation patterns; no auth, writes, or settlement logic changes.
> 
> **Overview**
> Adds **read access to market clarifications** (official settlement notes) through the public client and gamma bindings.
> 
> **Bindings** introduce `MarketClarificationSchema`, a `MarketClarificationState` lifecycle enum, and wire normalization for upstream quirks (numeric `marketId` → branded string, shared id/address/hash/timestamp types).
> 
> **Client** adds `listMarketClarifications`, calling `GET /market-clarifications` with SDK-owned offset pagination (`limit`/`offset` + cursor), camelCase filters mapped to snake_case query params (`marketId`, `eventId`, `questionId`, `state`, `showInFrontend`, `txHash`, sort options), and response validation. The method is exported from actions and exposed on the discovery decorator as `client.listMarketClarifications`.
> 
> **Tests** cover schema parsing (full and sparse records) and live integration for pagination and `marketId` filtering. Patch changesets bump `@polymarket/bindings` and `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d731b5b69421e63973a280cd9c483a7af4fd1d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->