### PR TITLE
feat(client): add perps account stats read

### DIFF
--- a/.changeset/perps-account-stats.md
+++ b/.changeset/perps-account-stats.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/client": patch
+"@polymarket/bindings": patch
+---
+
+Add `session.fetchStats()` for Perps account stats.

--- a/packages/bindings/src/perps/account.ts
+++ b/packages/bindings/src/perps/account.ts
@@ -7,6 +7,7 @@ import {
 import {
   PerpsAssetSchema,
   PerpsDataResponseSchema,
+  PerpsEntityIdSchema,
   PerpsInstrumentIdSchema,
 } from './common';
 
@@ -19,6 +20,30 @@ export const PerpsBalanceSchema = z.object({
 export type PerpsBalance = z.infer<typeof PerpsBalanceSchema>;
 
 export const FetchPerpsBalancesResponseSchema = z.array(PerpsBalanceSchema);
+
+export const PerpsAccountStatsSchema = z
+  .object({
+    volume_7d: DecimalStringSchema,
+    taker_volume_7d: DecimalStringSchema,
+    maker_volume_7d: DecimalStringSchema,
+    account_maker_share_7d: DecimalStringSchema,
+    entity_maker_share_7d: DecimalStringSchema.optional(),
+    entity_id: PerpsEntityIdSchema.optional(),
+    entity_name: z.string().min(1).optional(),
+  })
+  .transform((stats) => ({
+    volume7d: stats.volume_7d,
+    takerVolume7d: stats.taker_volume_7d,
+    makerVolume7d: stats.maker_volume_7d,
+    accountMakerShare7d: stats.account_maker_share_7d,
+    entityMakerShare7d: stats.entity_maker_share_7d,
+    entityId: stats.entity_id,
+    entityName: stats.entity_name,
+  }));
+
+export type PerpsAccountStats = z.infer<typeof PerpsAccountStatsSchema>;
+
+export const FetchPerpsAccountStatsResponseSchema = PerpsAccountStatsSchema;
 
 export const PerpsPortfolioPositionSchema = z
   .object({

--- a/packages/bindings/src/perps/common.ts
+++ b/packages/bindings/src/perps/common.ts
@@ -19,6 +19,7 @@ export type PerpsClientOrderId = Tagged<string, 'PerpsClientOrderId'>;
 export type PerpsTradeId = Tagged<number, 'PerpsTradeId'>;
 export type PerpsWithdrawalId = Tagged<number, 'PerpsWithdrawalId'>;
 export type PerpsInternalTransferId = Tagged<number, 'PerpsInternalTransferId'>;
+export type PerpsEntityId = Tagged<number, 'PerpsEntityId'>;
 export type PerpsFundingInterval = `${number}h`;
 
 function taggedInteger<T extends number>(value: number): T {
@@ -59,6 +60,12 @@ export const PerpsInternalTransferIdSchema = z
   .int()
   .nonnegative()
   .transform(taggedInteger<PerpsInternalTransferId>);
+
+export const PerpsEntityIdSchema = z
+  .number()
+  .int()
+  .positive()
+  .transform(taggedInteger<PerpsEntityId>);
 
 export const PerpsFundingIntervalSchema = z
   .string()

--- a/packages/client/src/websockets/perps/actions/account.ts
+++ b/packages/client/src/websockets/perps/actions/account.ts
@@ -6,6 +6,7 @@ import {
 } from '@polymarket/bindings';
 import {
   FetchPerpsAccountConfigResponseSchema,
+  FetchPerpsAccountStatsResponseSchema,
   FetchPerpsBalancesResponseSchema,
   FetchPerpsOpenOrdersResponseSchema,
   FetchPerpsOrdersResponseSchema,
@@ -19,6 +20,7 @@ import {
   type PerpsAccountConfig,
   type PerpsAccountFill,
   type PerpsAccountFundingPayment,
+  type PerpsAccountStats,
   type PerpsBalance,
   PerpsClientOrderIdSchema,
   type PerpsDeposit,
@@ -126,6 +128,16 @@ export async function fetchPerpsPortfolio(
     api
       .get('/v1/account/portfolio')
       .andThen(validateWith(FetchPerpsPortfolioResponseSchema)),
+  );
+}
+
+export async function fetchPerpsStats(
+  api: ServiceClient,
+): Promise<PerpsAccountStats> {
+  return await unwrap(
+    api
+      .get('/v1/account/stats')
+      .andThen(validateWith(FetchPerpsAccountStatsResponseSchema)),
   );
 }
 

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -633,6 +633,33 @@ describe('PerpsSession', () => {
       ]);
     });
 
+    it('fetches account stats', async () => {
+      server.use(
+        http.get(`${production.perps.rest}/v1/account/stats`, () =>
+          HttpResponse.json({
+            volume_7d: '5000000',
+            taker_volume_7d: '3500000',
+            maker_volume_7d: '1500000',
+            account_maker_share_7d: '0.35',
+            entity_maker_share_7d: '0.40',
+            entity_id: 42,
+            entity_name: 'desk',
+          }),
+        ),
+      );
+      const session = createSession();
+
+      await expect(session.fetchStats()).resolves.toEqual({
+        volume7d: '5000000',
+        takerVolume7d: '3500000',
+        makerVolume7d: '1500000',
+        accountMakerShare7d: '0.35',
+        entityMakerShare7d: '0.40',
+        entityId: 42,
+        entityName: 'desk',
+      });
+    });
+
     it('overlaps and dedupes descending account history pages', async () => {
       const requests: URLSearchParams[] = [];
       server.use(

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -2,6 +2,7 @@ import {
   type PerpsAccountConfig,
   type PerpsAccountFill,
   type PerpsAccountFundingPayment,
+  type PerpsAccountStats,
   type PerpsBalance,
   type PerpsCancelOrderResult,
   type PerpsCommandAck,
@@ -47,6 +48,7 @@ import {
   fetchPerpsOpenOrders,
   fetchPerpsOrders,
   fetchPerpsPortfolio,
+  fetchPerpsStats,
   type ListPerpsDepositsRequest,
   type ListPerpsEquityHistoryRequest,
   type ListPerpsFillsRequest,
@@ -212,6 +214,10 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   async fetchPortfolio(): Promise<PerpsPortfolio> {
     return await fetchPerpsPortfolio(this.#api);
+  }
+
+  async fetchStats(): Promise<PerpsAccountStats> {
+    return await fetchPerpsStats(this.#api);
   }
 
   async fetchAccountConfig(


### PR DESCRIPTION
## Summary
- add Perps account stats response bindings with camelCase normalization
- add a branded PerpsEntityId for liquidity reward entity IDs
- expose session.fetchStats() for authenticated Perps account stats

## Verification
- pnpm --filter @polymarket/bindings build
- pnpm test:client packages/client/src/websockets/perps/session.test.ts
- pnpm test -- perps
- pnpm lint
- pnpm typecheck
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API and types with no trading, auth, or state changes beyond a new GET helper.
> 
> **Overview**
> Adds **read-only Perps account stats** for authenticated sessions: 7-day volume (total, taker, maker), account maker share, and optional entity maker share / id / name.
> 
> **Bindings** introduce `PerpsAccountStatsSchema` (snake_case API → camelCase client types) and a branded **`PerpsEntityId`** for optional entity IDs.
> 
> **Client** wires `GET /v1/account/stats` as `fetchPerpsStats` and exposes **`session.fetchStats()`** on `PerpsSession`, matching other account REST reads (same session auth headers). A session test asserts response parsing and normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c7ac45c19821c284415ae20fa389aa14fb6adae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->