### PR TITLE
fix(client): align perps cursor error types

### DIFF
--- a/.changeset/perps-account-cursor-error.md
+++ b/.changeset/perps-account-cursor-error.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Align Perps session account pagination cursor decode failures with the rest of the SDK by throwing `UserInputError`.

--- a/packages/client/src/websockets/perps/actions/account.ts
+++ b/packages/client/src/websockets/perps/actions/account.ts
@@ -39,7 +39,7 @@ import {
 import { invariant, unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import { snakeCase, toSearchParams } from '../../../actions/params';
-import { TransportError } from '../../../errors';
+import { UserInputError } from '../../../errors';
 import { parseUserInput } from '../../../input';
 import { type Page, type Paginated, paginate } from '../../../pagination';
 import { validateWith } from '../../../response';
@@ -643,7 +643,7 @@ function decodePerpsAccountCursor<T>(
   try {
     return schema.parse(JSON.parse(atob(cursor)));
   } catch (error) {
-    throw new TransportError('Invalid Perps account pagination cursor', {
+    throw new UserInputError('Invalid Perps account pagination cursor', {
       cause: error,
     });
   }

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -1,4 +1,4 @@
-import { OrderSide } from '@polymarket/bindings';
+import { OrderSide, toPaginationCursor } from '@polymarket/bindings';
 import {
   type PerpsCredentials,
   PerpsPnlInterval,
@@ -18,7 +18,7 @@ import {
   vi,
 } from 'vitest';
 import { production } from '../../environments';
-import { RequestRejectedError } from '../../errors';
+import { RequestRejectedError, UserInputError } from '../../errors';
 import { captureConnection, waitForNextEvent } from '../testing';
 import { PerpsSession } from './session';
 
@@ -846,6 +846,26 @@ describe('PerpsSession', () => {
         entityMakerShare7d: '0.40',
         entityId: 42,
         entityName: 'desk',
+      });
+    });
+
+    it('throws user input errors for invalid account pagination cursors', () => {
+      const cursor = toPaginationCursor(
+        btoa(JSON.stringify({ kind: 'perpsTrades' })),
+      );
+      const session = createSession();
+
+      let thrown: unknown;
+      try {
+        session.listFills({ cursor }).firstPage();
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(UserInputError);
+      expect(thrown).toMatchObject({
+        message: 'Invalid Perps account pagination cursor',
+        cause: expect.any(Error),
       });
     });
 


### PR DESCRIPTION
## Summary
- Align Perps session account pagination cursor decode failures with the rest of the SDK by throwing `UserInputError`
- Add regression coverage for invalid session account cursors
- Add a patch changeset

## Verification
- `pnpm test:client packages/client/src/websockets/perps/session.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-class change for invalid user-supplied pagination cursors only; no API or transport behavior change beyond how failures are classified.
> 
> **Overview**
> **Perps session account pagination** now throws `UserInputError` when `decodePerpsAccountCursor` cannot base64-decode or schema-parse a cursor, instead of `TransportError`. That matches generic pagination and other Perps cursor helpers so callers can treat bad cursors as client input mistakes.
> 
> A **session test** asserts `listFills({ cursor }).firstPage()` fails with `UserInputError` and message `Invalid Perps account pagination cursor`. A **patch changeset** records the `@polymarket/client` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f3aedcf6b02c383ae47c751dff855c47aa47d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->