### PR TITLE
fix(client): require 3 minute GTD expirations

### DIFF
--- a/.changeset/gtd-expiration-3min.md
+++ b/.changeset/gtd-expiration-3min.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Require GTD limit order expirations to be at least 3 minutes in the future.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -39,6 +39,7 @@
     "fix-rfq-submission-window-code",
     "fork-environment-configs",
     "fuzzy-hornets-report",
+    "gtd-expiration-3min",
     "harden-rfq-invalid-frames",
     "lazy-trades-fix",
     "legacy-deposit-wallet-default",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -39,7 +39,6 @@
     "fix-rfq-submission-window-code",
     "fork-environment-configs",
     "fuzzy-hornets-report",
-    "gtd-expiration-3min",
     "harden-rfq-invalid-frames",
     "lazy-trades-fix",
     "legacy-deposit-wallet-default",

--- a/packages/client/src/actions/orders/limit.test.ts
+++ b/packages/client/src/actions/orders/limit.test.ts
@@ -7,13 +7,13 @@ describe('PrepareLimitOrderParamsSchema', () => {
     vi.useRealTimers();
   });
 
-  it('accepts a GTD expiration exactly 60 seconds in the future', () => {
+  it('accepts a GTD expiration exactly 3 minutes in the future', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
 
     expect(
       PrepareLimitOrderParamsSchema.safeParse({
-        expiration: Math.floor(Date.now() / 1000) + 60,
+        expiration: Math.floor(Date.now() / 1000) + 180,
         price: 0.52,
         side: OrderSide.BUY,
         size: 10,
@@ -22,13 +22,13 @@ describe('PrepareLimitOrderParamsSchema', () => {
     ).toBe(true);
   });
 
-  it('rejects a GTD expiration less than 60 seconds in the future', () => {
+  it('rejects a GTD expiration less than 3 minutes in the future', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
 
     expect(
       PrepareLimitOrderParamsSchema.safeParse({
-        expiration: Math.floor(Date.now() / 1000) + 59,
+        expiration: Math.floor(Date.now() / 1000) + 179,
         price: 0.52,
         side: OrderSide.BUY,
         size: 10,

--- a/packages/client/src/actions/orders/limit.ts
+++ b/packages/client/src/actions/orders/limit.ts
@@ -22,6 +22,8 @@ import {
 } from './math';
 import type { OrderDraft, PrepareLimitOrderRequest } from './types';
 
+const MINIMUM_LIMIT_ORDER_EXPIRATION_SECONDS = 180;
+
 export const PrepareLimitOrderParamsSchema = z
   .strictObject({
     tokenId: TokenIdSchema,
@@ -34,12 +36,13 @@ export const PrepareLimitOrderParamsSchema = z
   })
   .superRefine((params, context) => {
     if (params.expiration !== undefined) {
-      const minimumExpiration = Math.floor(Date.now() / 1000) + 60;
+      const minimumExpiration =
+        Math.floor(Date.now() / 1000) + MINIMUM_LIMIT_ORDER_EXPIRATION_SECONDS;
 
       if (params.expiration < minimumExpiration) {
         context.addIssue({
           code: 'custom',
-          message: 'Expiration must be at least 60 seconds in the future.',
+          message: 'Expiration must be at least 3 minutes in the future.',
           path: ['expiration'],
         });
       }

--- a/packages/client/src/actions/orders/trade.ts
+++ b/packages/client/src/actions/orders/trade.ts
@@ -139,7 +139,7 @@ export const CreateLimitOrderError = makeErrorGuard(
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
- * GTD expirations must be at least 60 seconds in the future. Add your own
+ * GTD expirations must be at least 3 minutes in the future. Add your own
  * buffer for network latency and clock skew when deriving an expiration from
  * the current time.
  *
@@ -176,7 +176,7 @@ export const PlaceLimitOrderError = makeErrorGuard(
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
- * GTD expirations must be at least 60 seconds in the future. Add your own
+ * GTD expirations must be at least 3 minutes in the future. Add your own
  * buffer for network latency and clock skew when deriving an expiration from
  * the current time.
  *

--- a/packages/client/src/actions/orders/types.ts
+++ b/packages/client/src/actions/orders/types.ts
@@ -130,7 +130,7 @@ export type PrepareLimitOrderRequest = {
    * When provided, the SDK prepares a Good-Til-Date (GTD) limit order that
    * expires at the given timestamp.
    *
-   * The timestamp must be at least 60 seconds in the future. Add your own
+   * The timestamp must be at least 3 minutes in the future. Add your own
    * buffer for network latency and clock skew when deriving it from the
    * current time.
    *

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -91,7 +91,7 @@ export type SecureTradingActions = {
    * Creates a signed limit order for the authenticated account.
    *
    * @remarks
-   * GTD expirations must be at least 60 seconds in the future. Add your own
+   * GTD expirations must be at least 3 minutes in the future. Add your own
    * buffer for network latency and clock skew when deriving an expiration from
    * the current time.
    *
@@ -114,7 +114,7 @@ export type SecureTradingActions = {
    * Creates and posts a limit order for the authenticated account.
    *
    * @remarks
-   * GTD expirations must be at least 60 seconds in the future. Add your own
+   * GTD expirations must be at least 3 minutes in the future. Add your own
    * buffer for network latency and clock skew when deriving an expiration from
    * the current time.
    *


### PR DESCRIPTION
## Summary
- update GTD limit order expiration validation from 60 seconds to 3 minutes
- refresh public docs and boundary tests for the new minimum
- add a patch changeset for @polymarket/client

## Verification
- `pnpm test:client packages/client/src/actions/orders/limit.test.ts`
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens order input validation in the trading path; callers using 1–3 minute expirations will see new rejections before orders reach the API.
> 
> **Overview**
> **GTD limit orders** now must expire at least **3 minutes** ahead (was 60 seconds). `PrepareLimitOrderParamsSchema` in `limit.ts` uses a new `MINIMUM_LIMIT_ORDER_EXPIRATION_SECONDS` (180) constant, and the validation error text matches that rule.
> 
> Public docs on `PrepareLimitOrderRequest`, `createLimitOrder` / `placeLimitOrder`, and the trading decorator are updated to say 3 minutes. Boundary tests in `limit.test.ts` use +180 / +179 seconds. A patch changeset is added for `@polymarket/client`.
> 
> Integrations that still pass expirations between 61s and 179s will fail client-side validation until they bump their timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c821b639704ac4225e9939fc75b5beb09768093c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->