### PR TITLE
fix(client): remove Perps instrument type filter

### DIFF
--- a/.changeset/perps-instruments-filter.md
+++ b/.changeset/perps-instruments-filter.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Remove the degenerate `instrumentType` filter from `fetchPerpsInstruments` requests.

--- a/packages/client/src/actions/perps.test-d.ts
+++ b/packages/client/src/actions/perps.test-d.ts
@@ -1,0 +1,22 @@
+import { PerpsInstrumentCategory } from '@polymarket/bindings/perps';
+import { describe, it } from 'vitest';
+import type { FetchPerpsInstrumentsRequest } from './perps';
+
+describe('FetchPerpsInstrumentsRequest', () => {
+  it('allows current instrument filters', () => {
+    const request: FetchPerpsInstrumentsRequest = {
+      category: PerpsInstrumentCategory.Crypto,
+      instrumentId: 1,
+    };
+    void request;
+  });
+
+  it('does not expose instrument type filtering', () => {
+    const request: FetchPerpsInstrumentsRequest = {
+      category: PerpsInstrumentCategory.Crypto,
+      // @ts-expect-error instrument type has no meaningful public filter today.
+      instrumentType: 'perpetual',
+    };
+    void request;
+  });
+});

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -24,7 +24,6 @@ import {
   type PerpsInstrument,
   PerpsInstrumentCategorySchema,
   PerpsInstrumentIdSchema,
-  PerpsInstrumentTypeSchema,
   type PerpsKlineInterval,
   PerpsKlineIntervalSchema,
   type PerpsPublicTrade,
@@ -155,7 +154,6 @@ type PerpsTimeRangeParams = {
 const FetchPerpsInstrumentsRequestSchema = z
   .object({
     instrumentId: PerpsInstrumentIdSchema.optional(),
-    instrumentType: PerpsInstrumentTypeSchema.optional(),
     category: PerpsInstrumentCategorySchema.optional(),
   })
   .default({});


### PR DESCRIPTION
## Summary
- Remove the public `instrumentType` option from `fetchPerpsInstruments` requests because it only has one meaningful value today.
- Keep `instrumentId` and `category` filtering intact.
- Add type-level coverage and a patch changeset for `@polymarket/client`.

## Verification
- `pnpm test:client --run packages/client/src/actions/perps.test.ts packages/client/src/actions/perps.test-d.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow public API change on a read-only Perps helper; callers passing `instrumentType` will get a TypeScript error but behavior for supported filters is unchanged.
> 
> **Overview**
> Removes the public **`instrumentType`** option from **`fetchPerpsInstruments`** / **`FetchPerpsInstrumentsRequest`** because it only maps to one meaningful value today, so the filter was misleading noise on the instruments API.
> 
> **`instrumentId`** and **`category`** filtering are unchanged. A new **`perps.test-d.ts`** asserts the type no longer accepts **`instrumentType`**, and a patch changeset records the **`@polymarket/client`** update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578890d0d104ee8809098f8ff140bb101a703bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->