### PR TITLE
docs(client): refine Perps public surface

### DIFF
--- a/.changeset/dev-311-perps-public-surface.md
+++ b/.changeset/dev-311-perps-public-surface.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Improve the Perps public SDK surface with explicit request types, root exports, and TSDoc examples.

--- a/packages/client/src/actions/perps.test-d.ts
+++ b/packages/client/src/actions/perps.test-d.ts
@@ -1,5 +1,38 @@
 import { PerpsInstrumentCategory } from '@polymarket/bindings/perps';
-import { describe, it } from 'vitest';
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+  CancelPerpsOrderRequest,
+  CancelPerpsOrdersRequest,
+  DepositToPerpsRequest,
+  FetchPerpsAccountConfigRequest,
+  FetchPerpsBookRequest,
+  FetchPerpsOpenOrdersRequest,
+  FetchPerpsOrdersRequest,
+  FetchPerpsTickerRequest,
+  FetchPerpsTickersRequest,
+  ListPerpsCandlesRequest,
+  ListPerpsDepositsRequest,
+  ListPerpsEquityHistoryRequest,
+  ListPerpsFillsRequest,
+  ListPerpsFundingHistoryRequest,
+  ListPerpsFundingPaymentsRequest,
+  ListPerpsPnlHistoryRequest,
+  ListPerpsTradesRequest,
+  ListPerpsWithdrawalsRequest,
+  OpenPerpsSessionRequest,
+  PerpsSessionAccountError,
+  PerpsSessionLifecycleError,
+  PerpsSessionTradingError,
+  PlacePerpsOrderRequest,
+  PlacePerpsOrderWithTpSlRequest,
+  PlacePerpsPositionTpSlRequest,
+  PostPerpsOrdersRequest,
+  RevokePerpsCredentialsRequest,
+  FetchPerpsInstrumentsRequest as RootFetchPerpsInstrumentsRequest,
+  UpdatePerpsLeverageRequest,
+  WithdrawFromPerpsRequest,
+} from '../index';
+import { FetchPerpsTickerError } from '../index';
 import type { FetchPerpsInstrumentsRequest } from './perps';
 
 describe('FetchPerpsInstrumentsRequest', () => {
@@ -18,5 +51,55 @@ describe('FetchPerpsInstrumentsRequest', () => {
       instrumentType: 'perpetual',
     };
     void request;
+  });
+});
+
+describe('public Perps exports', () => {
+  it('exports Perps request types from the root entry point', () => {
+    expectTypeOf<RootFetchPerpsInstrumentsRequest>().toEqualTypeOf<FetchPerpsInstrumentsRequest>();
+    expectTypeOf<FetchPerpsTickerRequest>().toEqualTypeOf<{
+      instrumentId: number;
+    }>();
+
+    type RootPerpsRequests = [
+      FetchPerpsTickersRequest,
+      FetchPerpsBookRequest,
+      ListPerpsCandlesRequest,
+      ListPerpsFundingHistoryRequest,
+      ListPerpsTradesRequest,
+      DepositToPerpsRequest,
+      OpenPerpsSessionRequest,
+      RevokePerpsCredentialsRequest,
+      WithdrawFromPerpsRequest,
+      FetchPerpsAccountConfigRequest,
+      FetchPerpsOpenOrdersRequest,
+      FetchPerpsOrdersRequest,
+      ListPerpsFillsRequest,
+      ListPerpsFundingPaymentsRequest,
+      ListPerpsDepositsRequest,
+      ListPerpsWithdrawalsRequest,
+      ListPerpsEquityHistoryRequest,
+      ListPerpsPnlHistoryRequest,
+      PlacePerpsOrderRequest,
+      PlacePerpsOrderWithTpSlRequest,
+      PostPerpsOrdersRequest,
+      PlacePerpsPositionTpSlRequest,
+      CancelPerpsOrderRequest,
+      CancelPerpsOrdersRequest,
+      UpdatePerpsLeverageRequest,
+    ];
+
+    expectTypeOf<RootPerpsRequests>().toEqualTypeOf<RootPerpsRequests>();
+  });
+
+  it('exports Perps error helpers from the root entry point', () => {
+    type RootPerpsSessionErrors = [
+      PerpsSessionAccountError,
+      PerpsSessionLifecycleError,
+      PerpsSessionTradingError,
+    ];
+
+    expectTypeOf<RootPerpsSessionErrors>().toEqualTypeOf<RootPerpsSessionErrors>();
+    void FetchPerpsTickerError;
   });
 });

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -22,6 +22,7 @@ import {
   type PerpsFeeScheduleEntry,
   type PerpsFundingRate,
   type PerpsInstrument,
+  type PerpsInstrumentCategory,
   PerpsInstrumentCategorySchema,
   PerpsInstrumentIdSchema,
   type PerpsKlineInterval,
@@ -104,7 +105,10 @@ export type {
   PerpsPositionTpSlTrigger,
   PerpsPostOrderAck,
   PerpsSession,
+  PerpsSessionAccountError,
   PerpsSessionEvent,
+  PerpsSessionLifecycleError,
+  PerpsSessionTradingError,
   PerpsTpSlTrigger,
   PerpsUpdateLeverageResult,
   PlacePerpsOrderRequest,
@@ -156,11 +160,14 @@ const FetchPerpsInstrumentsRequestSchema = z
     instrumentId: PerpsInstrumentIdSchema.optional(),
     category: PerpsInstrumentCategorySchema.optional(),
   })
-  .default({});
+  .default({}) satisfies z.ZodType<FetchPerpsInstrumentsRequest>;
 
-export type FetchPerpsInstrumentsRequest = z.input<
-  typeof FetchPerpsInstrumentsRequestSchema
->;
+export type FetchPerpsInstrumentsRequest = {
+  /** Perps instrument identifier to fetch. */
+  instrumentId?: number;
+  /** Optional instrument category filter. */
+  category?: PerpsInstrumentCategory;
+};
 
 export type FetchPerpsInstrumentsError = PerpsPublicReadError;
 export const FetchPerpsInstrumentsError = PerpsPublicReadError;
@@ -191,11 +198,12 @@ export async function fetchPerpsInstruments(
 
 const FetchPerpsTickerRequestSchema = z.object({
   instrumentId: PerpsInstrumentIdSchema,
-});
+}) satisfies z.ZodType<FetchPerpsTickerRequest>;
 
-export type FetchPerpsTickerRequest = z.input<
-  typeof FetchPerpsTickerRequestSchema
->;
+export type FetchPerpsTickerRequest = {
+  /** Perps instrument identifier whose ticker should be fetched. */
+  instrumentId: number;
+};
 
 export type FetchPerpsTickerError = PerpsPublicReadError;
 export const FetchPerpsTickerError = PerpsPublicReadError;
@@ -229,11 +237,12 @@ const FetchPerpsTickersRequestSchema = z
   .object({
     instrumentId: PerpsInstrumentIdSchema.optional(),
   })
-  .default({});
+  .default({}) satisfies z.ZodType<FetchPerpsTickersRequest>;
 
-export type FetchPerpsTickersRequest = z.input<
-  typeof FetchPerpsTickersRequestSchema
->;
+export type FetchPerpsTickersRequest = {
+  /** Optional Perps instrument identifier filter. */
+  instrumentId?: number;
+};
 
 export type FetchPerpsTickersError = PerpsPublicReadError;
 export const FetchPerpsTickersError = PerpsPublicReadError;
@@ -292,9 +301,14 @@ const PerpsBookDepthSchema: z.ZodType<PerpsBookDepth> = z.union([
 const FetchPerpsBookRequestSchema = z.object({
   instrumentId: PerpsInstrumentIdSchema,
   depth: PerpsBookDepthSchema.default(100),
-});
+}) satisfies z.ZodType<FetchPerpsBookRequest>;
 
-export type FetchPerpsBookRequest = z.input<typeof FetchPerpsBookRequestSchema>;
+export type FetchPerpsBookRequest = {
+  /** Perps instrument identifier whose order book should be fetched. */
+  instrumentId: number;
+  /** Number of price levels to return on each side. */
+  depth?: PerpsBookDepth;
+};
 
 export type FetchPerpsBookError = PerpsPublicReadError;
 export const FetchPerpsBookError = PerpsPublicReadError;
@@ -323,29 +337,50 @@ export async function fetchPerpsBook(
   );
 }
 
-const PerpsCandlesRequestBaseSchema = z.object({
+const ListPerpsCandlesInitialRequestSchema = z.object({
   instrumentId: PerpsInstrumentIdSchema,
   interval: PerpsKlineIntervalSchema,
   start: TimestampInputSchema.optional(),
   end: TimestampInputSchema.optional(),
-});
+  cursor: PaginationCursorSchema.optional(),
+}) satisfies z.ZodType<
+  Extract<ListPerpsCandlesRequest, { instrumentId: number }>
+>;
+
+const ListPerpsCandlesCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsCandlesRequest, { cursor: PaginationCursor }>
+>;
 
 const ListPerpsCandlesRequestSchema = z.union([
-  PerpsCandlesRequestBaseSchema.extend({
-    cursor: PaginationCursorSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
+  ListPerpsCandlesInitialRequestSchema.transform(({ cursor, ...request }) => ({
     cursor,
     params: toPerpsCandlesParams(request),
   })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  ListPerpsCandlesCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsCandlesRequest = z.input<
-  typeof ListPerpsCandlesRequestSchema
->;
+export type ListPerpsCandlesRequest =
+  | {
+      /** Perps instrument identifier whose candles should be listed. */
+      instrumentId: number;
+      /** Candle interval. */
+      interval: PerpsKlineInterval;
+      /** Inclusive start timestamp in milliseconds. */
+      start?: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export type ListPerpsCandlesError = PerpsPublicReadError;
 export const ListPerpsCandlesError = PerpsPublicReadError;
@@ -413,22 +448,60 @@ const TimeRangePerpsRequestBaseSchema = z.object({
   end: TimestampInputSchema.optional(),
 });
 
-const ListPerpsFundingHistoryRequestSchema = z.union([
+const ListPerpsFundingHistoryInitialRequestSchema =
   TimeRangePerpsRequestBaseSchema.extend({
     cursor: PaginationCursorSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
-    cursor,
-    params: toPerpsTimeRangeParams(request),
-  })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  }) satisfies z.ZodType<
+    Extract<ListPerpsFundingHistoryRequest, { instrumentId: number }>
+  >;
+
+const ListPerpsFundingHistoryCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsFundingHistoryRequest, { cursor: PaginationCursor }>
+>;
+
+const ListPerpsFundingHistoryRequestSchema = z.union([
+  ListPerpsFundingHistoryInitialRequestSchema.transform(
+    ({ cursor, ...request }) => ({
+      cursor,
+      params: toPerpsTimeRangeParams(request),
+    }),
+  ),
+  ListPerpsFundingHistoryCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsFundingHistoryRequest = z.input<
-  typeof ListPerpsFundingHistoryRequestSchema
+const ListPerpsTradesInitialRequestSchema =
+  TimeRangePerpsRequestBaseSchema.extend({
+    cursor: PaginationCursorSchema.optional(),
+  }) satisfies z.ZodType<
+    Extract<ListPerpsTradesRequest, { instrumentId: number }>
+  >;
+
+const ListPerpsTradesCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsTradesRequest, { cursor: PaginationCursor }>
 >;
+
+export type ListPerpsFundingHistoryRequest =
+  | {
+      /** Perps instrument identifier whose funding history should be listed. */
+      instrumentId: number;
+      /** Inclusive start timestamp in milliseconds. */
+      start?: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export type ListPerpsFundingHistoryError = PerpsPublicReadError;
 export const ListPerpsFundingHistoryError = PerpsPublicReadError;
@@ -491,21 +564,31 @@ export function listPerpsFundingHistory(
 }
 
 const ListPerpsTradesRequestSchema = z.union([
-  TimeRangePerpsRequestBaseSchema.extend({
-    cursor: PaginationCursorSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
+  ListPerpsTradesInitialRequestSchema.transform(({ cursor, ...request }) => ({
     cursor,
     params: toPerpsTimeRangeParams(request),
   })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  ListPerpsTradesCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsTradesRequest = z.input<
-  typeof ListPerpsTradesRequestSchema
->;
+export type ListPerpsTradesRequest =
+  | {
+      /** Perps instrument identifier whose recent trades should be listed. */
+      instrumentId: number;
+      /** Inclusive start timestamp in milliseconds. */
+      start?: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export type ListPerpsTradesError = PerpsPublicReadError;
 export const ListPerpsTradesError = PerpsPublicReadError;
@@ -639,7 +722,10 @@ type PerpsFundingCursorState = z.infer<typeof PerpsFundingCursorStateSchema>;
 type PerpsTradesCursorState = z.infer<typeof PerpsTradesCursorStateSchema>;
 
 function toPerpsCandlesParams(
-  request: z.output<typeof PerpsCandlesRequestBaseSchema>,
+  request: Omit<
+    z.output<typeof ListPerpsCandlesInitialRequestSchema>,
+    'cursor'
+  >,
 ): PerpsCandlesParams {
   const now = Date.now();
   return {
@@ -779,39 +865,49 @@ const CreatePerpsSessionRequestSchema = z.strictObject({
     .positive()
     .default(DEFAULT_PERPS_CREDENTIAL_EXPIRES_IN),
   label: z.string().min(1).optional(),
-});
+}) satisfies z.ZodType<CreatePerpsSessionRequest>;
 
 const ResumePerpsSessionRequestSchema = z.strictObject({
   credentials: PerpsCredentialsSchema,
-});
+}) satisfies z.ZodType<ResumePerpsSessionRequest>;
 
 const OpenPerpsSessionRequestSchema = z.union([
   CreatePerpsSessionRequestSchema,
   ResumePerpsSessionRequestSchema,
-]);
+]) satisfies z.ZodType<OpenPerpsSessionRequest>;
 
-const RevokePerpsCredentialsRequestSchema = z.object({
-  proxy: z.string().transform((value) => expectEvmAddress(value)),
-});
+const RevokePerpsCredentialsRequestInputSchema = z.object({
+  proxy: z.string(),
+}) satisfies z.ZodType<RevokePerpsCredentialsRequest>;
 
-export type CreatePerpsSessionRequest = z.input<
-  typeof CreatePerpsSessionRequestSchema
->;
+const RevokePerpsCredentialsRequestSchema =
+  RevokePerpsCredentialsRequestInputSchema.transform((request) => ({
+    proxy: expectEvmAddress(request.proxy),
+  }));
+
+export type CreatePerpsSessionRequest = {
+  /** Delegated credential lifetime in milliseconds. */
+  expiresIn?: number;
+  /** Optional label for the delegated credentials. */
+  label?: string;
+};
 type ParsedCreatePerpsSessionRequest = z.output<
   typeof CreatePerpsSessionRequestSchema
 >;
 
-export type ResumePerpsSessionRequest = z.input<
-  typeof ResumePerpsSessionRequestSchema
->;
+export type ResumePerpsSessionRequest = {
+  /** Existing delegated Perps credentials to validate and resume. */
+  credentials: PerpsCredentials;
+};
 
 export type OpenPerpsSessionRequest =
   | CreatePerpsSessionRequest
   | ResumePerpsSessionRequest;
 
-export type RevokePerpsCredentialsRequest = z.input<
-  typeof RevokePerpsCredentialsRequestSchema
->;
+export type RevokePerpsCredentialsRequest = {
+  /** Proxy address whose delegated credentials should be revoked. */
+  proxy: string;
+};
 
 const PerpsBaseUnitAmountSchema = z.bigint().positive().max(MAX_UINT256);
 
@@ -828,17 +924,23 @@ export type PerpsDepositWorkflow = AsyncGenerator<
 const DepositToPerpsRequestSchema = z.object({
   amount: PerpsBaseUnitAmountSchema,
   metadata: GaslessTransactionMetadataSchema.optional(),
-});
+}) satisfies z.ZodType<DepositToPerpsRequest>;
 
 const WithdrawFromPerpsRequestSchema = z.object({
   amount: PerpsBaseUnitAmountSchema,
-});
+}) satisfies z.ZodType<WithdrawFromPerpsRequest>;
 
-export type DepositToPerpsRequest = z.input<typeof DepositToPerpsRequestSchema>;
+export type DepositToPerpsRequest = {
+  /** Collateral amount in base units. */
+  amount: bigint;
+  /** Optional wallet-visible metadata for gasless deposit workflows. */
+  metadata?: string;
+};
 
-export type WithdrawFromPerpsRequest = z.input<
-  typeof WithdrawFromPerpsRequestSchema
->;
+export type WithdrawFromPerpsRequest = {
+  /** Collateral amount in base units. */
+  amount: bigint;
+};
 
 export type OpenPerpsSessionError =
   | RateLimitError

--- a/packages/client/src/decorators/perps.ts
+++ b/packages/client/src/decorators/perps.ts
@@ -43,17 +43,80 @@ import type { Paginated } from '../pagination';
 import type { TransactionHandle } from '../types';
 
 export type {
+  CancelPerpsOrderRequest,
+  CancelPerpsOrdersRequest,
+  CreatePerpsSessionRequest,
+  DepositToPerpsRequest,
+  FetchPerpsAccountConfigRequest,
+  FetchPerpsBookRequest,
+  FetchPerpsInstrumentsRequest,
+  FetchPerpsOpenOrdersRequest,
+  FetchPerpsOrdersRequest,
+  FetchPerpsTickerRequest,
+  FetchPerpsTickersRequest,
+  ListPerpsCandlesRequest,
+  ListPerpsDepositsRequest,
+  ListPerpsEquityHistoryRequest,
+  ListPerpsFillsRequest,
+  ListPerpsFundingHistoryRequest,
+  ListPerpsFundingPaymentsRequest,
+  ListPerpsPnlHistoryRequest,
+  ListPerpsTradesRequest,
+  ListPerpsWithdrawalsRequest,
+  OpenPerpsSessionRequest,
+  PerpsBookDepth,
   PerpsCancelOrderResult,
+  PerpsOrderRequest,
+  PerpsPlacedTpSlOrder,
+  PerpsPlacedTpSlOrders,
+  PerpsPlaceFokOrderRequest,
+  PerpsPlaceGtcOrderRequest,
+  PerpsPlaceIocOrderRequest,
+  PerpsPositionTpSlTrigger,
   PerpsPostOrderAck,
   PerpsSession,
+  PerpsSessionAccountError,
   PerpsSessionEvent,
+  PerpsSessionLifecycleError,
+  PerpsSessionTradingError,
+  PerpsTpSlTrigger,
   PerpsUpdateLeverageResult,
+  PlacePerpsOrderRequest,
+  PlacePerpsOrderResult,
+  PlacePerpsOrderWithTpSlRequest,
+  PlacePerpsOrderWithTpSlResult,
+  PlacePerpsPositionTpSlRequest,
+  PlacePerpsPositionTpSlResult,
+  PostPerpsOrdersRequest,
+  ResumePerpsSessionRequest,
+  RevokePerpsCredentialsRequest,
+  UpdatePerpsLeverageRequest,
+  WithdrawFromPerpsRequest,
 } from '../actions';
-export { UpdatePerpsLeverageError } from '../actions';
+export {
+  DepositToPerpsError,
+  FetchPerpsBookError,
+  FetchPerpsFeesError,
+  FetchPerpsInstrumentsError,
+  FetchPerpsTickerError,
+  FetchPerpsTickersError,
+  ListPerpsCandlesError,
+  ListPerpsFundingHistoryError,
+  ListPerpsTradesError,
+  OpenPerpsSessionError,
+  RevokePerpsCredentialsError,
+  UpdatePerpsLeverageError,
+  WithdrawFromPerpsError,
+} from '../actions';
 
 export type PublicPerpsActions = {
   /**
    * Fetches Perps instruments.
+   *
+   * @example
+   * ```ts
+   * const instruments = await client.fetchPerpsInstruments();
+   * ```
    *
    * @throws {@link FetchPerpsInstrumentsError}
    * Thrown on failure.
@@ -65,6 +128,11 @@ export type PublicPerpsActions = {
   /**
    * Fetches the current Perps ticker for an instrument.
    *
+   * @example
+   * ```ts
+   * const ticker = await client.fetchPerpsTicker({ instrumentId: 1 });
+   * ```
+   *
    * @throws {@link FetchPerpsTickerError}
    * Thrown on failure.
    */
@@ -72,6 +140,11 @@ export type PublicPerpsActions = {
 
   /**
    * Fetches current Perps tickers.
+   *
+   * @example
+   * ```ts
+   * const tickers = await client.fetchPerpsTickers();
+   * ```
    *
    * @throws {@link FetchPerpsTickersError}
    * Thrown on failure.
@@ -81,6 +154,11 @@ export type PublicPerpsActions = {
   /**
    * Fetches a Perps order book.
    *
+   * @example
+   * ```ts
+   * const book = await client.fetchPerpsBook({ instrumentId: 1, depth: 100 });
+   * ```
+   *
    * @throws {@link FetchPerpsBookError}
    * Thrown on failure.
    */
@@ -89,6 +167,16 @@ export type PublicPerpsActions = {
   /**
    * Lists Perps candles for an instrument with SDK-owned pagination.
    *
+   * @example
+   * ```ts
+   * for await (const candles of client.listPerpsCandles({
+   *   instrumentId: 1,
+   *   interval: PerpsKlineInterval.OneMinute,
+   * })) {
+   *   console.log(candles);
+   * }
+   * ```
+   *
    * @throws {@link ListPerpsCandlesError}
    * Thrown on failure.
    */
@@ -96,6 +184,15 @@ export type PublicPerpsActions = {
 
   /**
    * Lists Perps funding-rate history for an instrument with SDK-owned pagination.
+   *
+   * @example
+   * ```ts
+   * for await (const rates of client.listPerpsFundingHistory({
+   *   instrumentId: 1,
+   * })) {
+   *   console.log(rates);
+   * }
+   * ```
    *
    * @throws {@link ListPerpsFundingHistoryError}
    * Thrown on failure.
@@ -107,6 +204,13 @@ export type PublicPerpsActions = {
   /**
    * Lists recent Perps trades for an instrument with SDK-owned pagination.
    *
+   * @example
+   * ```ts
+   * for await (const trades of client.listPerpsTrades({ instrumentId: 1 })) {
+   *   console.log(trades);
+   * }
+   * ```
+   *
    * @throws {@link ListPerpsTradesError}
    * Thrown on failure.
    */
@@ -117,6 +221,11 @@ export type PublicPerpsActions = {
   /**
    * Fetches the Perps fee schedule.
    *
+   * @example
+   * ```ts
+   * const fees = await client.fetchPerpsFees();
+   * ```
+   *
    * @throws {@link FetchPerpsFeesError}
    * Thrown on failure.
    */
@@ -126,6 +235,11 @@ export type PublicPerpsActions = {
 export type SecurePerpsActions = PublicPerpsActions & {
   /**
    * Deposits collateral into Perps for the authenticated signer account.
+   *
+   * @example
+   * ```ts
+   * const transaction = await client.depositToPerps({ amount: 100_000_000n });
+   * ```
    *
    * @throws {@link DepositToPerpsError}
    * Thrown on failure.
@@ -141,6 +255,11 @@ export type SecurePerpsActions = PublicPerpsActions & {
    * longer credential lifetime, or pass existing credentials to validate and
    * resume a previous session.
    *
+   * @example
+   * ```ts
+   * const session = await client.openPerpsSession();
+   * ```
+   *
    * @throws {@link OpenPerpsSessionError}
    * Thrown on failure.
    */
@@ -152,6 +271,11 @@ export type SecurePerpsActions = PublicPerpsActions & {
    * @remarks
    * This can revoke credentials outside the currently open Perps session.
    *
+   * @example
+   * ```ts
+   * await client.revokePerpsCredentials({ proxy: session.credentials.proxy });
+   * ```
+   *
    * @throws {@link RevokePerpsCredentialsError}
    * Thrown on failure.
    */
@@ -159,6 +283,11 @@ export type SecurePerpsActions = PublicPerpsActions & {
 
   /**
    * Requests a Perps withdrawal to the authenticated wallet.
+   *
+   * @example
+   * ```ts
+   * const withdrawalId = await client.withdrawFromPerps({ amount: 100_000_000n });
+   * ```
    *
    * @throws {@link WithdrawFromPerpsError}
    * Thrown on failure.

--- a/packages/client/src/websockets/perps/actions/account.ts
+++ b/packages/client/src/websockets/perps/actions/account.ts
@@ -24,16 +24,19 @@ import {
   type PerpsBalance,
   PerpsClientOrderIdSchema,
   type PerpsDeposit,
+  type PerpsDepositStatus,
   PerpsDepositStatusSchema,
   type PerpsEquityPoint,
   type PerpsInstrumentId,
   PerpsInstrumentIdSchema,
   type PerpsOrder,
   PerpsOrderIdSchema,
+  type PerpsPnlInterval,
   PerpsPnlIntervalSchema,
   type PerpsPnlPoint,
   type PerpsPortfolio,
   type PerpsWithdrawal,
+  type PerpsWithdrawalStatus,
   PerpsWithdrawalStatusSchema,
 } from '@polymarket/bindings/perps';
 import { invariant, unwrap } from '@polymarket/types';
@@ -145,11 +148,12 @@ const FetchPerpsAccountConfigRequestSchema = z
   .object({
     instrumentId: PerpsInstrumentIdSchema.optional(),
   })
-  .default({});
+  .default({}) satisfies z.ZodType<FetchPerpsAccountConfigRequest>;
 
-export type FetchPerpsAccountConfigRequest = z.input<
-  typeof FetchPerpsAccountConfigRequestSchema
->;
+export type FetchPerpsAccountConfigRequest = {
+  /** Optional Perps instrument identifier filter. */
+  instrumentId?: number;
+};
 
 export async function fetchPerpsAccountConfig(
   api: ServiceClient,
@@ -169,11 +173,12 @@ const FetchPerpsOpenOrdersRequestSchema = z
   .object({
     instrumentId: PerpsInstrumentIdSchema.optional(),
   })
-  .default({});
+  .default({}) satisfies z.ZodType<FetchPerpsOpenOrdersRequest>;
 
-export type FetchPerpsOpenOrdersRequest = z.input<
-  typeof FetchPerpsOpenOrdersRequestSchema
->;
+export type FetchPerpsOpenOrdersRequest = {
+  /** Optional Perps instrument identifier filter. */
+  instrumentId?: number;
+};
 
 export async function fetchPerpsOpenOrders(
   api: ServiceClient,
@@ -189,7 +194,7 @@ export async function fetchPerpsOpenOrders(
   );
 }
 
-const FetchPerpsOrdersRequestSchema = z
+const FetchPerpsOrdersRequestInputSchema = z
   .object({
     orderId: PerpsOrderIdSchema.optional(),
     clientOrderId: PerpsClientOrderIdSchema.optional(),
@@ -197,16 +202,29 @@ const FetchPerpsOrdersRequestSchema = z
     start: TimestampInputSchema.optional(),
     end: TimestampInputSchema.optional(),
   })
-  .default({})
-  .transform(({ end, start, ...request }) => ({
-    ...request,
-    endTimestamp: end,
-    startTimestamp: start,
-  }));
+  .default({}) satisfies z.ZodType<FetchPerpsOrdersRequest>;
 
-export type FetchPerpsOrdersRequest = z.input<
-  typeof FetchPerpsOrdersRequestSchema
->;
+const FetchPerpsOrdersRequestSchema =
+  FetchPerpsOrdersRequestInputSchema.transform(
+    ({ end, start, ...request }) => ({
+      ...request,
+      endTimestamp: end,
+      startTimestamp: start,
+    }),
+  );
+
+export type FetchPerpsOrdersRequest = {
+  /** Optional order identifier filter. */
+  orderId?: number;
+  /** Optional caller-supplied idempotency identifier filter. */
+  clientOrderId?: string;
+  /** Optional Perps instrument identifier filter. */
+  instrumentId?: number;
+  /** Inclusive start timestamp in milliseconds. */
+  start?: number;
+  /** Inclusive end timestamp in milliseconds. */
+  end?: number;
+};
 
 export async function fetchPerpsOrders(
   api: ServiceClient,
@@ -222,20 +240,44 @@ export async function fetchPerpsOrders(
   );
 }
 
-const ListPerpsFillsRequestSchema = z.union([
-  PerpsHistoryRequestBaseSchema.extend({
+const ListPerpsFillsInitialRequestSchema = PerpsHistoryRequestBaseSchema.extend(
+  {
     cursor: PaginationCursorSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
+  },
+) satisfies z.ZodType<
+  Exclude<ListPerpsFillsRequest, { cursor: PaginationCursor }>
+>;
+
+const ListPerpsFillsCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsFillsRequest, { cursor: PaginationCursor }>
+>;
+
+const ListPerpsFillsRequestSchema = z.union([
+  ListPerpsFillsInitialRequestSchema.transform(({ cursor, ...request }) => ({
     cursor,
     params: toPerpsHistoryParams(request, ONE_DAY_MS),
   })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  ListPerpsFillsCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsFillsRequest = z.input<typeof ListPerpsFillsRequestSchema>;
+export type ListPerpsFillsRequest =
+  | {
+      /** Inclusive start timestamp in milliseconds. */
+      start?: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export function listPerpsFills(
   api: ServiceClient,
@@ -280,23 +322,48 @@ export function listPerpsFills(
   }, cursor);
 }
 
-const ListPerpsFundingPaymentsRequestSchema = z.union([
+const ListPerpsFundingPaymentsInitialRequestSchema =
   PerpsHistoryRequestBaseSchema.extend({
     cursor: PaginationCursorSchema.optional(),
     instrumentId: PerpsInstrumentIdSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
-    cursor,
-    params: toPerpsHistoryParams(request, ONE_DAY_MS),
-  })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  }) satisfies z.ZodType<
+    Exclude<ListPerpsFundingPaymentsRequest, { cursor: PaginationCursor }>
+  >;
+
+const ListPerpsFundingPaymentsCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsFundingPaymentsRequest, { cursor: PaginationCursor }>
+>;
+
+const ListPerpsFundingPaymentsRequestSchema = z.union([
+  ListPerpsFundingPaymentsInitialRequestSchema.transform(
+    ({ cursor, ...request }) => ({
+      cursor,
+      params: toPerpsHistoryParams(request, ONE_DAY_MS),
+    }),
+  ),
+  ListPerpsFundingPaymentsCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsFundingPaymentsRequest = z.input<
-  typeof ListPerpsFundingPaymentsRequestSchema
->;
+export type ListPerpsFundingPaymentsRequest =
+  | {
+      /** Optional Perps instrument identifier filter. */
+      instrumentId?: number;
+      /** Inclusive start timestamp in milliseconds. */
+      start?: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export function listPerpsFundingPayments(
   api: ServiceClient,
@@ -348,24 +415,49 @@ export function listPerpsFundingPayments(
   }, cursor);
 }
 
-const ListPerpsDepositsRequestSchema = z.union([
+const ListPerpsDepositsInitialRequestSchema =
   PerpsHistoryRequestBaseSchema.extend({
     cursor: PaginationCursorSchema.optional(),
     depositStatus: PerpsDepositStatusSchema.optional(),
     hash: TxHashSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
+  }) satisfies z.ZodType<
+    Exclude<ListPerpsDepositsRequest, { cursor: PaginationCursor }>
+  >;
+
+const ListPerpsDepositsCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsDepositsRequest, { cursor: PaginationCursor }>
+>;
+
+const ListPerpsDepositsRequestSchema = z.union([
+  ListPerpsDepositsInitialRequestSchema.transform(({ cursor, ...request }) => ({
     cursor,
     params: toPerpsHistoryParams(request, NINETY_DAYS_MS),
   })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  ListPerpsDepositsCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsDepositsRequest = z.input<
-  typeof ListPerpsDepositsRequestSchema
->;
+export type ListPerpsDepositsRequest =
+  | {
+      /** Optional deposit status filter. */
+      depositStatus?: PerpsDepositStatus;
+      /** Optional transaction hash filter. */
+      hash?: string;
+      /** Inclusive start timestamp in milliseconds. */
+      start?: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export function listPerpsDeposits(
   api: ServiceClient,
@@ -410,24 +502,51 @@ export function listPerpsDeposits(
   }, cursor);
 }
 
-const ListPerpsWithdrawalsRequestSchema = z.union([
+const ListPerpsWithdrawalsInitialRequestSchema =
   PerpsHistoryRequestBaseSchema.extend({
     cursor: PaginationCursorSchema.optional(),
     withdrawalStatus: PerpsWithdrawalStatusSchema.optional(),
     hash: TxHashSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
-    cursor,
-    params: toPerpsHistoryParams(request, NINETY_DAYS_MS),
-  })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  }) satisfies z.ZodType<
+    Exclude<ListPerpsWithdrawalsRequest, { cursor: PaginationCursor }>
+  >;
+
+const ListPerpsWithdrawalsCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsWithdrawalsRequest, { cursor: PaginationCursor }>
+>;
+
+const ListPerpsWithdrawalsRequestSchema = z.union([
+  ListPerpsWithdrawalsInitialRequestSchema.transform(
+    ({ cursor, ...request }) => ({
+      cursor,
+      params: toPerpsHistoryParams(request, NINETY_DAYS_MS),
+    }),
+  ),
+  ListPerpsWithdrawalsCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsWithdrawalsRequest = z.input<
-  typeof ListPerpsWithdrawalsRequestSchema
->;
+export type ListPerpsWithdrawalsRequest =
+  | {
+      /** Optional withdrawal status filter. */
+      withdrawalStatus?: PerpsWithdrawalStatus;
+      /** Optional transaction hash filter. */
+      hash?: string;
+      /** Inclusive start timestamp in milliseconds. */
+      start?: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export function listPerpsWithdrawals(
   api: ServiceClient,
@@ -475,22 +594,47 @@ export function listPerpsWithdrawals(
   }, cursor);
 }
 
-const ListPerpsEquityHistoryRequestSchema = z.union([
+const ListPerpsEquityHistoryInitialRequestSchema =
   PerpsIntervalHistoryRequestBaseSchema.extend({
     cursor: PaginationCursorSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
-    cursor,
-    params: toPerpsIntervalHistoryParams(request),
-  })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  }) satisfies z.ZodType<
+    Exclude<ListPerpsEquityHistoryRequest, { cursor: PaginationCursor }>
+  >;
+
+const ListPerpsEquityHistoryCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsEquityHistoryRequest, { cursor: PaginationCursor }>
+>;
+
+const ListPerpsEquityHistoryRequestSchema = z.union([
+  ListPerpsEquityHistoryInitialRequestSchema.transform(
+    ({ cursor, ...request }) => ({
+      cursor,
+      params: toPerpsIntervalHistoryParams(request),
+    }),
+  ),
+  ListPerpsEquityHistoryCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsEquityHistoryRequest = z.input<
-  typeof ListPerpsEquityHistoryRequestSchema
->;
+export type ListPerpsEquityHistoryRequest =
+  | {
+      /** History interval. */
+      interval: PerpsPnlInterval;
+      /** Inclusive start timestamp in milliseconds. */
+      start: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export function listPerpsEquityHistory(
   api: ServiceClient,
@@ -544,22 +688,47 @@ export function listPerpsEquityHistory(
   }, cursor);
 }
 
-const ListPerpsPnlHistoryRequestSchema = z.union([
+const ListPerpsPnlHistoryInitialRequestSchema =
   PerpsIntervalHistoryRequestBaseSchema.extend({
     cursor: PaginationCursorSchema.optional(),
-  }).transform(({ cursor, ...request }) => ({
-    cursor,
-    params: toPerpsIntervalHistoryParams(request),
-  })),
-  z.object({ cursor: PaginationCursorSchema }).transform(({ cursor }) => ({
+  }) satisfies z.ZodType<
+    Exclude<ListPerpsPnlHistoryRequest, { cursor: PaginationCursor }>
+  >;
+
+const ListPerpsPnlHistoryCursorRequestSchema = z.object({
+  cursor: PaginationCursorSchema,
+}) satisfies z.ZodType<
+  Extract<ListPerpsPnlHistoryRequest, { cursor: PaginationCursor }>
+>;
+
+const ListPerpsPnlHistoryRequestSchema = z.union([
+  ListPerpsPnlHistoryInitialRequestSchema.transform(
+    ({ cursor, ...request }) => ({
+      cursor,
+      params: toPerpsIntervalHistoryParams(request),
+    }),
+  ),
+  ListPerpsPnlHistoryCursorRequestSchema.transform(({ cursor }) => ({
     cursor,
     params: undefined,
   })),
 ]);
 
-export type ListPerpsPnlHistoryRequest = z.input<
-  typeof ListPerpsPnlHistoryRequestSchema
->;
+export type ListPerpsPnlHistoryRequest =
+  | {
+      /** History interval. */
+      interval: PerpsPnlInterval;
+      /** Inclusive start timestamp in milliseconds. */
+      start: number;
+      /** Inclusive end timestamp in milliseconds. */
+      end?: number;
+      /** Opaque cursor returned by a previous page. */
+      cursor?: PaginationCursor;
+    }
+  | {
+      /** Opaque cursor returned by a previous page. */
+      cursor: PaginationCursor;
+    };
 
 export function listPerpsPnlHistory(
   api: ServiceClient,

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -79,7 +79,7 @@ export type PerpsPlaceIocOrderRequest = {
   quantity: PerpsDecimalInput;
   /** Immediate-or-cancel execution. */
   timeInForce: PerpsTimeInForce.IOC;
-  postOnly?: undefined;
+  postOnly?: never;
   /** Optional caller-supplied idempotency identifier. */
   clientOrderId?: string;
 };
@@ -104,7 +104,7 @@ export type PerpsPlaceFokOrderRequest = {
   quantity: PerpsDecimalInput;
   /** Fill-or-kill execution. */
   timeInForce: PerpsTimeInForce.FOK;
-  postOnly?: undefined;
+  postOnly?: never;
   /** Optional caller-supplied idempotency identifier. */
   clientOrderId?: string;
 };
@@ -141,7 +141,7 @@ const PerpsTpSlTriggerSchema = z.object({
 
 const PerpsPositionTpSlTriggerSchema = z.object({
   triggerPrice: PerpsDecimalInputSchema,
-});
+}) satisfies z.ZodType<PerpsPositionTpSlTrigger>;
 
 export type PerpsPositionTpSlTrigger = {
   triggerPrice: PerpsDecimalInput;
@@ -209,16 +209,195 @@ const PlacePerpsOrderWithTpSlRequestSchema = z.intersection(
   ),
 ) satisfies z.ZodType<PlacePerpsOrderWithTpSlRequest>;
 
-export type PlacePerpsOrderRequest = PerpsOrderRequest & {
-  expiresAt?: number;
-  stopLoss?: undefined;
-  takeProfit?: undefined;
-};
+export type PlacePerpsOrderRequest =
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Limit price. */
+      price: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Good-til-cancelled execution. */
+      timeInForce: PerpsTimeInForce.GTC;
+      /** Whether the order must rest instead of taking liquidity. */
+      postOnly?: boolean;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      takeProfit?: never;
+      stopLoss?: never;
+    }
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Optional limit price. Omit for market-style execution. */
+      price?: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Immediate-or-cancel execution. */
+      timeInForce: PerpsTimeInForce.IOC;
+      postOnly?: never;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      takeProfit?: never;
+      stopLoss?: never;
+    }
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Optional limit price. Omit for market-style execution. */
+      price?: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Fill-or-kill execution. */
+      timeInForce: PerpsTimeInForce.FOK;
+      postOnly?: never;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      takeProfit?: never;
+      stopLoss?: never;
+    };
 
-export type PlacePerpsOrderWithTpSlRequest = PerpsOrderRequest &
-  PerpsTpSlPairRequest & {
-    expiresAt?: number;
-  };
+export type PlacePerpsOrderWithTpSlRequest =
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Limit price. */
+      price: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Good-til-cancelled execution. */
+      timeInForce: PerpsTimeInForce.GTC;
+      /** Whether the order must rest instead of taking liquidity. */
+      postOnly?: boolean;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      /** Take-profit trigger to place with the entry order. */
+      takeProfit: PerpsTpSlTrigger;
+      /** Optional stop-loss trigger to place with the entry order. */
+      stopLoss?: PerpsTpSlTrigger;
+    }
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Limit price. */
+      price: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Good-til-cancelled execution. */
+      timeInForce: PerpsTimeInForce.GTC;
+      /** Whether the order must rest instead of taking liquidity. */
+      postOnly?: boolean;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      /** Optional take-profit trigger to place with the entry order. */
+      takeProfit?: PerpsTpSlTrigger;
+      /** Stop-loss trigger to place with the entry order. */
+      stopLoss: PerpsTpSlTrigger;
+    }
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Optional limit price. Omit for market-style execution. */
+      price?: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Immediate-or-cancel execution. */
+      timeInForce: PerpsTimeInForce.IOC;
+      postOnly?: never;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      /** Take-profit trigger to place with the entry order. */
+      takeProfit: PerpsTpSlTrigger;
+      /** Optional stop-loss trigger to place with the entry order. */
+      stopLoss?: PerpsTpSlTrigger;
+    }
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Optional limit price. Omit for market-style execution. */
+      price?: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Immediate-or-cancel execution. */
+      timeInForce: PerpsTimeInForce.IOC;
+      postOnly?: never;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      /** Optional take-profit trigger to place with the entry order. */
+      takeProfit?: PerpsTpSlTrigger;
+      /** Stop-loss trigger to place with the entry order. */
+      stopLoss: PerpsTpSlTrigger;
+    }
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Optional limit price. Omit for market-style execution. */
+      price?: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Fill-or-kill execution. */
+      timeInForce: PerpsTimeInForce.FOK;
+      postOnly?: never;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      /** Take-profit trigger to place with the entry order. */
+      takeProfit: PerpsTpSlTrigger;
+      /** Optional stop-loss trigger to place with the entry order. */
+      stopLoss?: PerpsTpSlTrigger;
+    }
+  | {
+      /** Perps instrument identifier to trade. */
+      instrumentId: number;
+      /** Trade direction. */
+      side: OrderSide;
+      /** Optional limit price. Omit for market-style execution. */
+      price?: PerpsDecimalInput;
+      /** Order quantity. */
+      quantity: PerpsDecimalInput;
+      /** Fill-or-kill execution. */
+      timeInForce: PerpsTimeInForce.FOK;
+      postOnly?: never;
+      /** Optional caller-supplied idempotency identifier. */
+      clientOrderId?: string;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+      /** Optional take-profit trigger to place with the entry order. */
+      takeProfit?: PerpsTpSlTrigger;
+      /** Stop-loss trigger to place with the entry order. */
+      stopLoss: PerpsTpSlTrigger;
+    };
 
 export type PlacePerpsOrderRequestWithOptions =
   | PlacePerpsOrderRequest
@@ -369,11 +548,23 @@ const CancelPerpsOrderRequestSchema = z.union([
     orderId: z.undefined().optional(),
     expiresAt: z.number().int().positive().optional(),
   }),
-]);
+]) satisfies z.ZodType<CancelPerpsOrderRequest>;
 
-export type CancelPerpsOrderRequest = z.input<
-  typeof CancelPerpsOrderRequestSchema
->;
+export type CancelPerpsOrderRequest =
+  | {
+      /** Order identifier to cancel. */
+      orderId: number;
+      clientOrderId?: never;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+    }
+  | {
+      /** Caller-supplied idempotency identifier to cancel. */
+      clientOrderId: string;
+      orderId?: never;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+    };
 
 export async function cancelPerpsOrder(
   transport: PerpsTradingTransport,
@@ -404,11 +595,23 @@ const CancelPerpsOrdersRequestSchema = z.union([
     orderIds: z.undefined().optional(),
     expiresAt: z.number().int().positive().optional(),
   }),
-]);
+]) satisfies z.ZodType<CancelPerpsOrdersRequest>;
 
-export type CancelPerpsOrdersRequest = z.input<
-  typeof CancelPerpsOrdersRequestSchema
->;
+export type CancelPerpsOrdersRequest =
+  | {
+      /** Order identifiers to cancel. */
+      orderIds: number[];
+      clientOrderIds?: never;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+    }
+  | {
+      /** Caller-supplied idempotency identifiers to cancel. */
+      clientOrderIds: string[];
+      orderIds?: never;
+      /** Optional command expiration timestamp in milliseconds. */
+      expiresAt?: number;
+    };
 
 export async function cancelPerpsOrders(
   transport: PerpsTradingTransport,
@@ -435,11 +638,16 @@ const UpdatePerpsLeverageRequestSchema = z.object({
   instrumentId: PerpsInstrumentIdSchema,
   leverage: z.number().int().positive(),
   crossMargin: z.boolean(),
-});
+}) satisfies z.ZodType<UpdatePerpsLeverageRequest>;
 
-export type UpdatePerpsLeverageRequest = z.input<
-  typeof UpdatePerpsLeverageRequestSchema
->;
+export type UpdatePerpsLeverageRequest = {
+  /** Perps instrument identifier whose leverage should be updated. */
+  instrumentId: number;
+  /** Target leverage multiplier. */
+  leverage: number;
+  /** Whether the instrument should use cross margin. */
+  crossMargin: boolean;
+};
 
 export type UpdatePerpsLeverageError =
   | RequestRejectedError

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -32,10 +32,12 @@ import {
 import { type Pushable, pushable } from 'it-pushable';
 import { z } from 'zod';
 import {
+  type RateLimitError,
   RequestRejectedError,
   SigningError,
   TimeoutError,
   TransportError,
+  type UnexpectedResponseError,
   UserInputError,
 } from '../../errors';
 import type { Paginated } from '../../pagination';
@@ -173,6 +175,21 @@ export type PerpsSessionOptions = {
   wsUrl: string;
 };
 
+export type PerpsSessionLifecycleError = RequestRejectedError | TransportError;
+
+export type PerpsSessionAccountError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+
+export type PerpsSessionTradingError =
+  | RequestRejectedError
+  | SigningError
+  | TransportError
+  | UserInputError;
+
 export type PerpsPlacedTpSlOrder = {
   orderId: PerpsOrderId;
 };
@@ -229,10 +246,22 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     return this.#closing !== undefined;
   }
 
+  /**
+   * Connects and authenticates the session WebSocket.
+   *
+   * @throws {@link PerpsSessionLifecycleError}
+   * Thrown on failure.
+   */
   async connect(): Promise<void> {
     await this.#connect(false);
   }
 
+  /**
+   * Closes the session and releases pending requests.
+   *
+   * @throws {@link PerpsSessionLifecycleError}
+   * Thrown on failure.
+   */
   async close(): Promise<void> {
     if (this.#closing === undefined) {
       this.#closing = this.#shutdown();
@@ -240,68 +269,152 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     await this.#closing;
   }
 
+  /**
+   * Iterates authenticated Perps account events emitted by this session.
+   *
+   * @example
+   * ```ts
+   * for await (const event of session) {
+   *   if (event.type === 'order') {
+   *     console.log(event.payload.id);
+   *   }
+   * }
+   * ```
+   */
   [Symbol.asyncIterator](): AsyncIterator<PerpsSessionEvent> {
     return this.#queue[Symbol.asyncIterator]();
   }
 
+  /**
+   * Fetches current Perps balances for the authenticated account.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   async fetchBalances(): Promise<PerpsBalance[]> {
     return await fetchPerpsBalances(this.#api);
   }
 
+  /**
+   * Fetches the current Perps portfolio for the authenticated account.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   async fetchPortfolio(): Promise<PerpsPortfolio> {
     return await fetchPerpsPortfolio(this.#api);
   }
 
+  /**
+   * Fetches account-level Perps statistics for the authenticated account.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   async fetchStats(): Promise<PerpsAccountStats> {
     return await fetchPerpsStats(this.#api);
   }
 
+  /**
+   * Fetches Perps account configuration, optionally filtered by instrument.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   async fetchAccountConfig(
     request?: FetchPerpsAccountConfigRequest,
   ): Promise<PerpsAccountConfig[]> {
     return await fetchPerpsAccountConfig(this.#api, request);
   }
 
+  /**
+   * Fetches currently open Perps orders, optionally filtered by instrument.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   async fetchOpenOrders(
     request?: FetchPerpsOpenOrdersRequest,
   ): Promise<PerpsOrder[]> {
     return await fetchPerpsOpenOrders(this.#api, request);
   }
 
+  /**
+   * Fetches Perps orders for the authenticated account.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   async fetchOrders(request?: FetchPerpsOrdersRequest): Promise<PerpsOrder[]> {
     return await fetchPerpsOrders(this.#api, request);
   }
 
+  /**
+   * Lists Perps fills with SDK-owned pagination.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   listFills(
     request: ListPerpsFillsRequest = {},
   ): Paginated<PerpsAccountFill[]> {
     return listPerpsFills(this.#api, request);
   }
 
+  /**
+   * Lists Perps funding payments with SDK-owned pagination.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   listFundingPayments(
     request: ListPerpsFundingPaymentsRequest = {},
   ): Paginated<PerpsAccountFundingPayment[]> {
     return listPerpsFundingPayments(this.#api, request);
   }
 
+  /**
+   * Lists Perps deposits with SDK-owned pagination.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   listDeposits(
     request: ListPerpsDepositsRequest = {},
   ): Paginated<PerpsDeposit[]> {
     return listPerpsDeposits(this.#api, request);
   }
 
+  /**
+   * Lists Perps withdrawals with SDK-owned pagination.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   listWithdrawals(
     request: ListPerpsWithdrawalsRequest = {},
   ): Paginated<PerpsWithdrawal[]> {
     return listPerpsWithdrawals(this.#api, request);
   }
 
+  /**
+   * Lists Perps equity history with SDK-owned pagination.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   listEquityHistory(
     request: ListPerpsEquityHistoryRequest,
   ): Paginated<PerpsEquityPoint[]> {
     return listPerpsEquityHistory(this.#api, request);
   }
 
+  /**
+   * Lists Perps PnL history with SDK-owned pagination.
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown on failure.
+   */
   listPnlHistory(
     request: ListPerpsPnlHistoryRequest,
   ): Paginated<PerpsPnlPoint[]> {
@@ -311,7 +424,31 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   /**
    * Places one Perps order and resolves with the first matching orders update.
    *
-   * @throws Thrown on failure.
+   * @example
+   * ```ts
+   * const { order } = await session.placeOrder({
+   *   instrumentId: 1,
+   *   price: '100',
+   *   quantity: '1',
+   *   side: OrderSide.BUY,
+   *   timeInForce: PerpsTimeInForce.GTC,
+   * });
+   * ```
+   *
+   * @example
+   * ```ts
+   * const { order, tpSl } = await session.placeOrder({
+   *   instrumentId: 1,
+   *   price: '100',
+   *   quantity: '1',
+   *   side: OrderSide.BUY,
+   *   stopLoss: { triggerPrice: '90' },
+   *   timeInForce: PerpsTimeInForce.GTC,
+   * });
+   * ```
+   *
+   * @throws {@link PerpsSessionTradingError}
+   * Thrown on failure.
    */
   async placeOrder(
     request: PlacePerpsOrderWithTpSlRequest,
@@ -348,6 +485,9 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
    *
    * @remarks
    * This is a low-level method. Most SDK consumers should prefer `placeOrder`.
+   *
+   * @throws {@link PerpsSessionTradingError}
+   * Thrown on failure.
    */
   async postOrders(
     request: PostPerpsOrdersRequest,
@@ -399,6 +539,27 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     return { order: update.payload, tpSl };
   }
 
+  /**
+   * Places take-profit and/or stop-loss protection for the current position.
+   *
+   * @remarks
+   * The exit side is inferred from the current position for the requested
+   * instrument.
+   *
+   * @example
+   * ```ts
+   * const { tpSl } = await session.placePositionTpSl({
+   *   instrumentId: 1,
+   *   stopLoss: { triggerPrice: '90' },
+   * });
+   * ```
+   *
+   * @throws {@link PerpsSessionAccountError}
+   * Thrown when the current position cannot be read.
+   *
+   * @throws {@link PerpsSessionTradingError}
+   * Thrown when the TP/SL command fails.
+   */
   async placePositionTpSl(
     request: PlacePerpsPositionTpSlRequest,
   ): Promise<PlacePerpsPositionTpSlResult> {
@@ -459,6 +620,9 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
    *
    * @remarks
    * The returned status reflects whether the cancel happened.
+   *
+   * @throws {@link PerpsSessionTradingError}
+   * Thrown on failure.
    */
   async cancelOrder(
     request: CancelPerpsOrderRequest,
@@ -471,6 +635,9 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
    *
    * @remarks
    * Each returned status reflects whether that cancel happened.
+   *
+   * @throws {@link PerpsSessionTradingError}
+   * Thrown on failure.
    */
   async cancelOrders(
     request: CancelPerpsOrdersRequest,
@@ -478,6 +645,21 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     return await cancelPerpsOrders(this.#tradingTransport(), request);
   }
 
+  /**
+   * Updates Perps leverage and margin mode for an instrument.
+   *
+   * @example
+   * ```ts
+   * await session.updateLeverage({
+   *   crossMargin: true,
+   *   instrumentId: 1,
+   *   leverage: 2,
+   * });
+   * ```
+   *
+   * @throws {@link UpdatePerpsLeverageError}
+   * Thrown on failure.
+   */
   async updateLeverage(
     request: UpdatePerpsLeverageRequest,
   ): Promise<PerpsUpdateLeverageResult> {


### PR DESCRIPTION
## Summary
- replace Perps public method argument aliases with explicit exported request object types
- tie request schemas back to the public request contracts with `satisfies` or typed pre-transform input schemas
- expand root Perps exports and add TSDoc examples for client/session workflows
- add type-level coverage for public Perps request and error exports

## Verification
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and documentation changes with schema contract checks; runtime parsing paths are refactored but not intended to change API behavior.
> 
> **Overview**
> Refines the **Perps public SDK surface** so consumers see hand-authored request object types (with TSDoc on fields) instead of `z.input<>` aliases inferred from parsers. Internal Zod schemas are aligned to those contracts via `satisfies`, including split **initial vs cursor-only** shapes for paginated list APIs and clearer **discriminated unions** for orders, cancels, and TP/SL placement (`postOnly?: never`, mutual exclusion of `orderId` vs `clientOrderId`).
> 
> **Root exports** are expanded through the Perps decorator and action re-exports: request types, session error unions (`PerpsSessionLifecycleError`, `PerpsSessionAccountError`, `PerpsSessionTradingError`), and public read/trading error guards. **TSDoc `@example` blocks** are added on client Perps methods and `PerpsSession` lifecycle, account, and trading APIs.
> 
> Adds **`perps.test-d.ts`** coverage that root `../index` exports match module types and that `FetchPerpsInstrumentsRequest` does not expose unsupported filters. Patch changeset for `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1182ebb51a405954ba9710b6230eb6c6247bcc32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->