### PR TITLE
fix(client): wait for confirmed gasless transactions

### DIFF
--- a/.changeset/wait-confirmed-gasless-transactions.md
+++ b/.changeset/wait-confirmed-gasless-transactions.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/client': patch
+---
+
+Wait for gasless relayer transactions to reach confirmed state before resolving transaction handles.

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -864,10 +864,7 @@ class GaslessTransactionHandle implements TransactionHandle {
         transactionId: this.transactionId,
       });
 
-      if (
-        transaction.state === RelayerTransactionState.STATE_MINED ||
-        transaction.state === RelayerTransactionState.STATE_CONFIRMED
-      ) {
+      if (transaction.state === RelayerTransactionState.STATE_CONFIRMED) {
         const transactionHash =
           transaction.transactionHash ?? this.transactionHash;
 

--- a/packages/client/src/clients.test.ts
+++ b/packages/client/src/clients.test.ts
@@ -112,6 +112,7 @@ describe('secure client gasless wallet setup', () => {
     });
 
     expect(submit.called).toBe(true);
+    expect(submit.transactionFetches).toBe(2);
     expect(client.account).toEqual({
       signer: signerAddress,
       wallet: expectedWallet,
@@ -438,7 +439,7 @@ function mockDepositWalletDeployments(
 }
 
 function mockDeployDepositWallet() {
-  const state = { called: false };
+  const state = { called: false, transactionFetches: 0 };
   const transactionId = '00000000-0000-0000-0000-000000000001';
   const transactionHash = `0x${'1'.repeat(64)}`;
 
@@ -452,13 +453,16 @@ function mockDeployDepositWallet() {
         transactionID: transactionId,
       });
     }),
-    http.get(`${relayerRoot}/v1/account/transactions/${transactionId}`, () =>
-      HttpResponse.json({
-        state: 'STATE_MINED',
+    http.get(`${relayerRoot}/v1/account/transactions/${transactionId}`, () => {
+      state.transactionFetches += 1;
+
+      return HttpResponse.json({
+        state:
+          state.transactionFetches === 1 ? 'STATE_MINED' : 'STATE_CONFIRMED',
         transaction_hash: transactionHash,
         transaction_id: transactionId,
-      }),
-    ),
+      });
+    }),
   );
 
   return state;


### PR DESCRIPTION
## Summary
- wait for relayer gasless transactions to reach `STATE_CONFIRMED` before resolving `handle.wait()`
- cover the default Deposit Wallet deployment path by mocking `STATE_MINED` followed by `STATE_CONFIRMED`
- add a patch changeset for `@polymarket/client`

## Why
`handle.wait()` previously resolved at `STATE_MINED`. For newly deployed Deposit Wallets, the relayer wallet registry is not ready until `STATE_CONFIRMED`, so an immediately-following Deposit Wallet approval batch can fail with `wallet registry validation failed: wallet ... is not registered`.

## Verification
- `pnpm test:client packages/client/src/clients.test.ts`
- `pnpm test:client`
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes settlement semantics for all gasless waits (slightly longer polls) but fixes a real race on new Deposit Wallet flows; scope is narrow and covered by tests.
> 
> **Overview**
> **Gasless `handle.wait()`** now resolves only when the relayer reports **`STATE_CONFIRMED`**, not when the tx is merely **`STATE_MINED`**. That keeps callers from continuing before the relayer wallet registry is ready—e.g. right after Deposit Wallet deploy, an immediate approval batch could fail with “wallet … is not registered”.
> 
> Tests for default Deposit Wallet deployment mock **`STATE_MINED` then `STATE_CONFIRMED`** on status polls and assert **two** transaction fetches. A patch changeset is added for `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c056ec6013c066ec37c11b27caf16b00f48d039b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->