### PR TITLE
fix(client): support legacy wallet gasless execution

### DIFF
--- a/.changeset/legacy-wallet-gasless-execution.md
+++ b/.changeset/legacy-wallet-gasless-execution.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/client': patch
+---
+
+Fix legacy Proxy wallet gasless execution and add live Safe and Proxy wallet coverage.

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -447,17 +447,17 @@ async function* prepareProxyWalletGaslessTransaction(
   const to = client.environment.walletDerivation.proxyFactory;
   const data = encodeProxyCall(params.calls);
   const relayerFee = '0';
-  // gasPrice is included in the signed hash but the relayer only validates
-  // that it is non-empty — it does not use this value when submitting the
-  // transaction on-chain (it applies its own gas pricing). Any non-empty
-  // string satisfies the protocol.
+  // Signed RelayHub parameter; the relayer applies its own execution gas price.
   const gasPrice = '0';
-  // gasLimit is likewise part of the signed hash but is not used by the
-  // relayer when executing the transaction — the relayer applies its own
-  // gas estimation at submission time. The validator only checks non-empty.
-  const gasLimit = '10000000';
+  const gasLimit = (
+    await client.rpc.ethEstimateGas({
+      data,
+      from: client.account.signer,
+      to,
+    })
+  ).toString();
   const relayHub = client.environment.contracts.relayHub;
-  const relay = ZERO_ADDRESS;
+  const relay = executeParams.address;
 
   const hash = buildProxyTransactionHash(
     client.account.signer,

--- a/packages/client/src/rpc.test.ts
+++ b/packages/client/src/rpc.test.ts
@@ -79,6 +79,42 @@ describe('JsonRpcClient', () => {
     ).resolves.toEqual(['0xaaaa', '0xbbbb']);
   });
 
+  it('performs eth_estimateGas requests', async () => {
+    const from = expectEvmAddress('0x0000000000000000000000000000000000000001');
+    const to = expectEvmAddress('0x0000000000000000000000000000000000000002');
+    server.use(
+      http.post(root, async ({ request }) => {
+        await expect(request.json()).resolves.toEqual({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_estimateGas',
+          params: [
+            {
+              data: '0x12345678',
+              from,
+              to,
+            },
+          ],
+        });
+
+        return HttpResponse.json({
+          jsonrpc: '2.0',
+          id: 1,
+          result: '0x15650',
+        });
+      }),
+    );
+    const client = new JsonRpcClient({ url: root });
+
+    await expect(
+      client.ethEstimateGas({
+        data: '0x12345678',
+        from,
+        to,
+      }),
+    ).resolves.toBe(87_632n);
+  });
+
   it('recovers failed eth_call batches while preserving result order', async () => {
     const to = expectEvmAddress('0x0000000000000000000000000000000000000001');
     let requestCount = 0;

--- a/packages/client/src/rpc.ts
+++ b/packages/client/src/rpc.ts
@@ -1,4 +1,8 @@
-import type { EvmAddress, HexString } from '@polymarket/types';
+import {
+  type EvmAddress,
+  type HexString,
+  isHexString,
+} from '@polymarket/types';
 import ky from 'ky';
 import {
   RequestRejectedError,
@@ -9,6 +13,14 @@ import {
 export type EthCallRequest = {
   to: EvmAddress;
   data: HexString;
+};
+
+export type EthEstimateGasRequest = {
+  data?: HexString;
+  from?: EvmAddress;
+  gasPrice?: bigint;
+  to: EvmAddress;
+  value?: bigint;
 };
 
 export type JsonRpcError = {
@@ -64,7 +76,7 @@ export class JsonRpcClient {
       );
     }
 
-    if (!isRpcHexString(response.result)) {
+    if (!isHexString(response.result)) {
       throw new UnexpectedResponseError(
         'Expected JSON-RPC eth_call result to be a hex string',
       );
@@ -81,6 +93,42 @@ export class JsonRpcClient {
     }
 
     return this.#ethCallBatchWithSplit(requests);
+  }
+
+  async ethEstimateGas(request: EthEstimateGasRequest): Promise<bigint> {
+    const call: Record<string, string> = { to: request.to };
+
+    if (request.data !== undefined) {
+      call.data = request.data;
+    }
+
+    if (request.from !== undefined) {
+      call.from = request.from;
+    }
+
+    if (request.gasPrice !== undefined) {
+      call.gasPrice = toRpcQuantity(request.gasPrice);
+    }
+
+    if (request.value !== undefined) {
+      call.value = toRpcQuantity(request.value);
+    }
+
+    const response = await this.#post<HexString>({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_estimateGas',
+      params: [call],
+    });
+
+    if ('error' in response) {
+      throw new RequestRejectedError(
+        `JSON-RPC eth_estimateGas failed: ${response.error.message}`,
+        { cause: response.error, status: 200 },
+      );
+    }
+
+    return BigInt(expectRpcHexResult(response.result, 'eth_estimateGas'));
   }
 
   async #ethCallBatchWithSplit(
@@ -289,18 +337,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function isRpcHexString(value: string): value is HexString {
-  return /^0x[a-fA-F0-9]*$/.test(value);
-}
-
-function expectRpcHexResult(value: unknown): HexString {
-  if (typeof value !== 'string' || !isRpcHexString(value)) {
+function expectRpcHexResult(value: unknown, method = 'eth_call'): HexString {
+  if (typeof value !== 'string' || !isHexString(value)) {
     throw new UnexpectedResponseError(
-      'Expected JSON-RPC eth_call result to be a hex string',
+      `Expected JSON-RPC ${method} result to be a hex string`,
     );
   }
 
   return value;
+}
+
+function toRpcQuantity(value: bigint): HexString {
+  return `0x${value.toString(16)}` as HexString;
 }
 
 function stringifyJsonRpcErrorData(data: unknown): string {

--- a/packages/client/src/rpc.ts
+++ b/packages/client/src/rpc.ts
@@ -1,8 +1,4 @@
-import {
-  type EvmAddress,
-  type HexString,
-  isHexString,
-} from '@polymarket/types';
+import type { EvmAddress, HexString } from '@polymarket/types';
 import ky from 'ky';
 import {
   RequestRejectedError,
@@ -76,7 +72,7 @@ export class JsonRpcClient {
       );
     }
 
-    if (!isHexString(response.result)) {
+    if (!isRpcHexString(response.result)) {
       throw new UnexpectedResponseError(
         'Expected JSON-RPC eth_call result to be a hex string',
       );
@@ -337,8 +333,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+function isRpcHexString(value: string): value is HexString {
+  return /^0x[a-fA-F0-9]*$/.test(value);
+}
+
 function expectRpcHexResult(value: unknown, method = 'eth_call'): HexString {
-  if (typeof value !== 'string' || !isHexString(value)) {
+  if (typeof value !== 'string' || !isRpcHexString(value)) {
     throw new UnexpectedResponseError(
       `Expected JSON-RPC ${method} result to be a hex string`,
     );

--- a/packages/client/tests/integration/fixtures.ts
+++ b/packages/client/tests/integration/fixtures.ts
@@ -92,14 +92,12 @@ export const it: TestAPI<IntegrationFixtures> =
       await use(secureClient);
     },
 
-    depositWalletSigner: async ({ skip }, use) => {
-      await use(
-        createTestSigner(loadPrivateKey('POLYMARKET_PRIVATE_KEY', skip)),
-      );
-    },
-
     depositWalletPrivateKey: async ({ skip }, use) => {
       await use(loadPrivateKey('POLYMARKET_PRIVATE_KEY', skip));
+    },
+
+    depositWalletSigner: async ({ depositWalletPrivateKey }, use) => {
+      await use(createTestSigner(depositWalletPrivateKey));
     },
 
     safeWalletSigner: async ({ skip }, use) => {

--- a/packages/client/tests/integration/gasless.test.ts
+++ b/packages/client/tests/integration/gasless.test.ts
@@ -1,226 +1,67 @@
 import {
   createSecureClient,
-  erc20ApprovalCall,
   type SecureClient,
-  type Signer,
+  type TransactionOutcome,
   WalletType,
 } from '@polymarket/client';
-import {
-  type GaslessWorkflowRequest,
-  prepareGaslessTransaction,
-} from '@polymarket/client/actions';
-import type { EvmSignature } from '@polymarket/types';
-import { HttpResponse, http } from 'msw';
-import { setupServer } from 'msw/node';
-import { afterAll, afterEach, beforeAll } from 'vitest';
 import { describe, expect, it } from './fixtures';
 
-const RELAYER_ROOT = 'https://relayer-v2.polymarket.com';
-const METADATA = 'Test gasless transaction';
-
-let submitRequests: unknown[] = [];
-
-const server = setupServer(
-  http.post(`${RELAYER_ROOT}/submit`, async ({ request }) => {
-    submitRequests.push(await request.json());
-
-    return HttpResponse.json({
-      state: 'STATE_NEW',
-      transactionHash: null,
-      transactionID: 'tx-1',
-    });
-  }),
-);
-
 describe('Gasless', () => {
-  beforeAll(() => {
-    server.listen({ onUnhandledRequest: 'bypass' });
-  });
-
-  afterEach(() => {
-    submitRequests = [];
-  });
-
-  afterAll(() => {
-    server.close();
-  });
-
-  describe('prepareGaslessTransaction submit payloads', () => {
-    it('submits a Deposit Wallet WALLET payload', async ({
-      depositWalletAddress,
-      depositWalletSigner,
-      relayerAuthentication,
-    }) => {
-      const secureClient = await createSecureClient({
-        apiKey: relayerAuthentication,
-        signer: depositWalletSigner,
-        wallet: depositWalletAddress,
-      });
-
-      expect(secureClient.account.walletType).toBe(WalletType.DEPOSIT_WALLET);
-
-      const { call, handle, signature, signRequest } = await prepareAndSubmit(
-        secureClient,
-        depositWalletSigner,
-      );
-
-      expect(signRequest).toMatchObject({
-        kind: 'signGaslessTypedData',
-        payload: {
-          domain: {
-            chainId: secureClient.environment.chainId,
-            name: 'DepositWallet',
-            verifyingContract: depositWalletAddress,
-            version: '1',
-          },
-          message: {
-            calls: [{ data: call.data, target: call.to, value: 0n }],
-            wallet: depositWalletAddress,
-          },
-          primaryType: 'Batch',
-        },
-      });
-      expect(handle.transactionId).toBe('tx-1');
-      expect(submitRequests[0]).toMatchObject({
-        depositWalletParams: {
-          calls: [{ data: call.data, target: call.to, value: '0' }],
-          depositWallet: depositWalletAddress,
-        },
-        from: secureClient.account.signer,
-        metadata: METADATA,
-        signature,
-        to: secureClient.environment.walletDerivation.depositWalletFactory,
-        type: 'WALLET',
-      });
-    });
-
-    it('submits a legacy PROXY payload', async ({
+  describe('legacy wallet execution', () => {
+    it('executes a gasless transaction for a Proxy wallet', async ({
+      builderAuthentication,
       proxyWalletAddress,
       proxyWalletSigner,
-      relayerAuthentication,
     }) => {
       const secureClient = await createSecureClient({
-        apiKey: relayerAuthentication,
+        apiKey: builderAuthentication,
         signer: proxyWalletSigner,
         wallet: proxyWalletAddress,
       });
 
       expect(secureClient.account.walletType).toBe(WalletType.POLY_PROXY);
 
-      const { signature, signRequest } = await prepareAndSubmit(
-        secureClient,
-        proxyWalletSigner,
-      );
-
-      expect(signRequest).toEqual({
-        kind: 'signGaslessMessage',
-        payload: expect.stringMatching(/^0x[0-9a-f]{64}$/),
-      });
-      expect(submitRequests[0]).toMatchObject({
-        from: secureClient.account.signer,
-        metadata: METADATA,
-        proxyWallet: proxyWalletAddress,
-        signature,
-        to: secureClient.environment.walletDerivation.proxyFactory,
-        type: 'PROXY',
-      });
+      await expect(
+        executeRepresentativeGaslessTransaction(
+          secureClient,
+          'Test legacy Proxy wallet gasless execution',
+        ),
+      ).resolves.toBeTruthy();
     });
 
-    it('submits a legacy SAFE payload', async ({
+    it('executes a gasless transaction for a Safe wallet', async ({
+      builderAuthentication,
       safeWalletAddress,
       safeWalletSigner,
-      relayerAuthentication,
     }) => {
       const secureClient = await createSecureClient({
-        apiKey: relayerAuthentication,
+        apiKey: builderAuthentication,
         signer: safeWalletSigner,
         wallet: safeWalletAddress,
       });
 
       expect(secureClient.account.walletType).toBe(WalletType.GNOSIS_SAFE);
 
-      const { call, signature, signRequest } = await prepareAndSubmit(
-        secureClient,
-        safeWalletSigner,
-      );
-
-      expect(signRequest).toEqual({
-        kind: 'signGaslessMessage',
-        payload: expect.stringMatching(/^0x[0-9a-f]{64}$/),
-      });
-      expect(submitRequests[0]).toMatchObject({
-        data: call.data,
-        from: secureClient.account.signer,
-        metadata: METADATA,
-        proxyWallet: safeWalletAddress,
-        signature: packSafeSignature(signature),
-        to: call.to,
-        type: 'SAFE',
-      });
+      await expect(
+        executeRepresentativeGaslessTransaction(
+          secureClient,
+          'Test legacy Safe wallet gasless execution',
+        ),
+      ).resolves.toBeTruthy();
     });
   });
 });
 
-async function prepareAndSubmit(client: SecureClient, signer: Signer) {
-  const call = erc20ApprovalCall(
-    client.environment.contracts.collateralToken,
-    client.environment.contracts.standardExchange,
-    1n,
-  );
-  const workflow = await prepareGaslessTransaction(client, {
-    calls: [call],
-    metadata: METADATA,
+async function executeRepresentativeGaslessTransaction(
+  secureClient: SecureClient,
+  metadata: string,
+): Promise<TransactionOutcome> {
+  const handle = await secureClient.approveErc20({
+    amount: 'max',
+    metadata,
+    spenderAddress: secureClient.environment.contracts.standardExchange,
+    tokenAddress: secureClient.environment.contracts.collateralToken,
   });
 
-  await expect(workflow.next()).resolves.toEqual({
-    done: false,
-    value: { kind: 'requestAddress' },
-  });
-
-  const signRequest = await workflow.next(client.account.signer);
-
-  expect(signRequest.done).toBe(false);
-
-  if (signRequest.done) {
-    throw new Error('Expected a signing request');
-  }
-
-  const signature = await signWorkflowRequest(signer, signRequest.value);
-  const result = await workflow.next(signature);
-
-  expect(result.done).toBe(true);
-
-  if (!result.done) {
-    throw new Error('Expected a transaction handle');
-  }
-
-  return {
-    call,
-    handle: result.value,
-    signature,
-    signRequest: signRequest.value,
-  };
-}
-
-async function signWorkflowRequest(
-  signer: Signer,
-  request: GaslessWorkflowRequest,
-): Promise<EvmSignature> {
-  if (request.kind === 'signGaslessTypedData') {
-    return signer.signTypedData(request.payload);
-  }
-
-  if (request.kind === 'signGaslessMessage') {
-    return signer.signMessage(request.payload);
-  }
-
-  throw new Error('Expected a signing request');
-}
-
-function packSafeSignature(signature: EvmSignature): EvmSignature {
-  const v = Number.parseInt(signature.slice(-2), 16);
-  const packedV =
-    v === 0 || v === 1 ? v + 31 : v === 27 || v === 28 ? v + 4 : v;
-
-  return `${signature.slice(0, -2)}${packedV.toString(16).padStart(2, '0')}` as EvmSignature;
+  return handle.wait();
 }


### PR DESCRIPTION
## Summary
- Estimate Proxy wallet gas for the RelayHub signature and use the relayer-provided relay address.
- Replace mocked gasless payload assertions with live generic Proxy and Safe legacy wallet gasless execution coverage.
- Reuse the deposit wallet private key fixture when constructing the deposit wallet signer.

## Verification
- pnpm exec vitest --project client-integration --run packages/client/tests/integration/gasless.test.ts
- pnpm exec vitest --project client-integration --run packages/client/tests/integration/approvals.test.ts
- pnpm exec vitest --project client --run packages/client/src/rpc.test.ts
- pnpm lint
- pnpm typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signed RelayHub fields and relay address for Proxy gasless txs, which can break relayer validation if estimates or params are wrong; live integration tests increase env/credential dependence but do not alter production auth paths for deposit wallets.
> 
> **Overview**
> Fixes **legacy Proxy** gasless signing so RelayHub parameters match what the relayer expects.
> 
> **Proxy workflow** now sets `gasLimit` from `eth_estimateGas` on the encoded factory call (replacing a fixed placeholder) and uses the relayer’s **`executeParams.address`** as the relay in the signed hash instead of the zero address.
> 
> Adds **`JsonRpcClient.ethEstimateGas`** (with a unit test) to support that estimation.
> 
> **Integration tests** drop MSW submit-shape assertions in favor of live end-to-end gasless runs for **Proxy** and **Safe** wallets via `approveErc20` and `wait()`, using builder API auth. The deposit wallet signer fixture is wired through the shared private-key fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544fdcd1e37d4d49863fd92b4eb1f4d33d02dd81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->