### PR TITLE
feat(client): add combo data pagination

### DIFF
--- a/.changeset/combo-data-cursors.md
+++ b/.changeset/combo-data-cursors.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Add Combo activity pagination with normalized activity types, server-cursor Combo position pagination, Combo position sync request fields, and Combo position outcome/redeemable fields.

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -9,6 +9,9 @@ import {
   type EpochMilliseconds,
   EpochSecondsToMillisecondsSchema,
   emptyStringToNull,
+  type IsoDateTimeString,
+  IsoDateTimeStringSchema,
+  PaginationCursorSchema,
   type PositionId,
   PositionIdSchema,
   type TokenId,
@@ -24,6 +27,41 @@ import {
   type Side,
   SideSchema,
 } from './common';
+import { type ComboPositionLeg, ComboPositionLegSchema } from './portfolio';
+
+export enum ComboActivityType {
+  Split = 'SPLIT',
+  Merge = 'MERGE',
+  Convert = 'CONVERT',
+  Compress = 'COMPRESS',
+  Wrap = 'WRAP',
+  Unwrap = 'UNWRAP',
+  Redeem = 'REDEEM',
+}
+
+enum UpstreamComboActivityType {
+  Split = 'Split',
+  Merge = 'Merge',
+  Convert = 'Convert',
+  Compress = 'Compress',
+  Wrap = 'Wrap',
+  Unwrap = 'Unwrap',
+  Redeem = 'Redeem',
+}
+
+const ComboActivityTypeByUpstream = {
+  [UpstreamComboActivityType.Split]: ComboActivityType.Split,
+  [UpstreamComboActivityType.Merge]: ComboActivityType.Merge,
+  [UpstreamComboActivityType.Convert]: ComboActivityType.Convert,
+  [UpstreamComboActivityType.Compress]: ComboActivityType.Compress,
+  [UpstreamComboActivityType.Wrap]: ComboActivityType.Wrap,
+  [UpstreamComboActivityType.Unwrap]: ComboActivityType.Unwrap,
+  [UpstreamComboActivityType.Redeem]: ComboActivityType.Redeem,
+} satisfies Record<UpstreamComboActivityType, ComboActivityType>;
+
+const UpstreamComboActivityTypeSchema = z
+  .enum(UpstreamComboActivityType)
+  .transform((value) => ComboActivityTypeByUpstream[value]);
 
 export type ActivityBase = {
   /** Wallet address whose account history contains this activity. */
@@ -198,6 +236,97 @@ export type Activity =
   | ReferralRewardActivity
   | YieldActivity;
 
+type ComboActivityBase = {
+  /** Stable row id derived from the transaction hash and log index. */
+  id: string;
+  /** Normalized lifecycle activity type. */
+  type: ComboActivityType;
+  /** Module label returned by the activity service. */
+  moduleKind: string;
+  /** Wallet address whose account history contains this activity. */
+  userAddress: Address;
+  /** Combo condition id involved in this activity. */
+  conditionId: ComboConditionId;
+  /** Combo module id. */
+  moduleId: number;
+  /** USDC amount associated with the lifecycle event. */
+  amountUsdc: DecimalString | null;
+  /** Activity time as Unix epoch milliseconds. */
+  timestamp: EpochMilliseconds;
+  /** Activity transaction time as an ISO date-time string. */
+  transactionAt: IsoDateTimeString;
+  /** Polygon transaction hash that produced this activity. */
+  transactionHash: TxHash;
+  /** Log index within the transaction. */
+  logIndex: number;
+  /** Polygon block number. */
+  blockNumber: number;
+  /** Combo legs enriched with market metadata at read time. */
+  legs: ComboPositionLeg[];
+};
+
+export type ComboSplitActivity = ComboActivityBase & {
+  type: ComboActivityType.Split;
+};
+
+export type ComboMergeActivity = ComboActivityBase & {
+  type: ComboActivityType.Merge;
+};
+
+export type ComboConvertActivity = ComboActivityBase & {
+  type: ComboActivityType.Convert;
+};
+
+export type ComboCompressActivity = ComboActivityBase & {
+  type: ComboActivityType.Compress;
+};
+
+export type ComboWrapActivity = ComboActivityBase & {
+  type: ComboActivityType.Wrap;
+};
+
+export type ComboUnwrapActivity = ComboActivityBase & {
+  type: ComboActivityType.Unwrap;
+};
+
+export type ComboRedeemActivity = ComboActivityBase & {
+  type: ComboActivityType.Redeem;
+  /** Redeemed Combo position id. Only redeem rows carry a source position id. */
+  positionId: PositionId;
+  /** USDC payout from the redemption. Only redeem rows carry payout semantics. */
+  payoutUsdc: DecimalString | null;
+};
+
+export type ComboActivity =
+  | ComboSplitActivity
+  | ComboMergeActivity
+  | ComboConvertActivity
+  | ComboCompressActivity
+  | ComboWrapActivity
+  | ComboUnwrapActivity
+  | ComboRedeemActivity;
+
+const RawComboActivitySchema = z.object({
+  id: z.string(),
+  side: UpstreamComboActivityTypeSchema,
+  module_kind: z.string(),
+  user_address: AddressSchema,
+  combo_condition_id: ComboConditionIdSchema,
+  combo_position_id: PositionIdSchema,
+  module_id: z.number().int(),
+  amount_usdc: DecimalishSchema.nullable(),
+  payout_usdc: DecimalishSchema.nullable(),
+  timestamp: EpochSecondsToMillisecondsSchema,
+  tx_dttm: IsoDateTimeStringSchema,
+  tx_hash: TxHashSchema,
+  log_index: z.number().int(),
+  block_number: z.number().int(),
+  legs: z.array(ComboPositionLegSchema),
+});
+
+export const ComboActivitySchema: z.ZodType<ComboActivity> =
+  RawComboActivitySchema.transform(normalizeComboActivity);
+
 const OptionalTextSchema = z.preprocess(
   (value) => (value === '' ? undefined : value),
   z.string().optional(),
@@ -278,13 +407,82 @@ export const TradedSchema = z.object({
 
 export const ListTradesResponseSchema = z.array(TradeSchema);
 export const ListActivityResponseSchema = z.array(ActivitySchema);
+export const ListComboActivityResponseSchema = z
+  .object({
+    activity: z.array(ComboActivitySchema),
+    pagination: z.object({
+      limit: z.number().int(),
+      offset: z.number().int(),
+      has_more: z.boolean(),
+      next_cursor: PaginationCursorSchema.nullish(),
+    }),
+  })
+  .transform(({ pagination, ...rest }) => ({
+    ...rest,
+    pagination: {
+      limit: pagination.limit,
+      offset: pagination.offset,
+      hasMore: pagination.has_more,
+      nextCursor: pagination.next_cursor,
+    },
+  }));
 
 export type Trade = z.infer<typeof TradeSchema>;
 export type Traded = z.infer<typeof TradedSchema>;
 export type ListTradesResponse = z.infer<typeof ListTradesResponseSchema>;
 export type ListActivityResponse = z.infer<typeof ListActivityResponseSchema>;
+export type ListComboActivityResponse = z.infer<
+  typeof ListComboActivityResponseSchema
+>;
 
+type RawComboActivity = z.infer<typeof RawComboActivitySchema>;
 type RawActivity = z.infer<typeof RawActivitySchema>;
+
+function normalizeComboActivity(activity: RawComboActivity): ComboActivity {
+  const base = normalizeComboActivityBase(activity);
+
+  switch (activity.side) {
+    case ComboActivityType.Split:
+      return { ...base, type: ComboActivityType.Split };
+    case ComboActivityType.Merge:
+      return { ...base, type: ComboActivityType.Merge };
+    case ComboActivityType.Convert:
+      return { ...base, type: ComboActivityType.Convert };
+    case ComboActivityType.Compress:
+      return { ...base, type: ComboActivityType.Compress };
+    case ComboActivityType.Wrap:
+      return { ...base, type: ComboActivityType.Wrap };
+    case ComboActivityType.Unwrap:
+      return { ...base, type: ComboActivityType.Unwrap };
+    case ComboActivityType.Redeem:
+      return {
+        ...base,
+        type: ComboActivityType.Redeem,
+        positionId: activity.combo_position_id,
+        payoutUsdc: activity.payout_usdc,
+      };
+  }
+}
+
+function normalizeComboActivityBase(
+  activity: RawComboActivity,
+): ComboActivityBase {
+  return {
+    id: activity.id,
+    type: activity.side,
+    moduleKind: activity.module_kind,
+    userAddress: activity.user_address,
+    conditionId: activity.combo_condition_id,
+    moduleId: activity.module_id,
+    amountUsdc: activity.amount_usdc,
+    timestamp: activity.timestamp,
+    transactionAt: activity.tx_dttm,
+    transactionHash: activity.tx_hash,
+    logIndex: activity.log_index,
+    blockNumber: activity.block_number,
+    legs: activity.legs,
+  };
+}
 
 function normalizeActivity(activity: RawActivity): Activity {
   const base = normalizeActivityBase(activity);

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -23,6 +23,13 @@ export enum ComboPositionStatus {
 
 export const ComboPositionStatusSchema = z.enum(ComboPositionStatus);
 
+export enum ComboPositionOutcome {
+  Yes = 'YES',
+  No = 'NO',
+}
+
+export const ComboPositionOutcomeSchema = z.enum(ComboPositionOutcome);
+
 export const PositionSchema = z
   .object({
     proxyWallet: AddressSchema.nullish(),
@@ -197,14 +204,19 @@ export const ComboPositionSchema = z
   .object({
     combo_condition_id: ComboConditionIdSchema,
     combo_position_id: PositionIdSchema,
+    side: ComboPositionOutcomeSchema,
     module_id: z.number().int(),
     user_address: AddressSchema,
     shares_balance: DecimalishSchema,
     entry_avg_price_usdc: DecimalishSchema.nullish(),
     entry_cost_usdc: DecimalishSchema.nullish(),
+    realized_payout_usdc: DecimalishSchema.nullish(),
+    total_cost_usdc: DecimalishSchema.nullish(),
     status: ComboPositionStatusSchema,
+    redeemable: z.boolean(),
     first_entry_at: IsoDateTimeStringSchema,
     resolved_at: IsoDateTimeStringSchema.nullish(),
+    updated_at: IsoDateTimeStringSchema.optional(),
     legs_total: z.number().int(),
     legs_resolved: z.number().int(),
     legs_pending: z.number().int(),
@@ -214,13 +226,17 @@ export const ComboPositionSchema = z
     ({
       combo_condition_id,
       combo_position_id,
+      side,
       module_id,
       user_address,
       shares_balance,
       entry_avg_price_usdc,
       entry_cost_usdc,
+      realized_payout_usdc,
+      total_cost_usdc,
       first_entry_at,
       resolved_at,
+      updated_at,
       legs_total,
       legs_resolved,
       legs_pending,
@@ -229,13 +245,17 @@ export const ComboPositionSchema = z
       ...rest,
       conditionId: combo_condition_id,
       positionId: combo_position_id,
+      outcome: side,
       moduleId: module_id,
       userAddress: user_address,
       shares: shares_balance,
       entryAvgPriceUsdc: entry_avg_price_usdc,
       entryCostUsdc: entry_cost_usdc,
+      realizedPayoutUsdc: realized_payout_usdc,
+      totalCostUsdc: total_cost_usdc,
       firstEntryAt: first_entry_at,
       resolvedAt: resolved_at,
+      updatedAt: updated_at,
       legsTotal: legs_total,
       legsResolved: legs_resolved,
       legsPending: legs_pending,

--- a/packages/client/src/actions/activity.ts
+++ b/packages/client/src/actions/activity.ts
@@ -1,8 +1,13 @@
-import { PaginationCursorSchema } from '@polymarket/bindings';
+import {
+  ComboConditionIdSchema,
+  PaginationCursorSchema,
+} from '@polymarket/bindings';
 import {
   type Activity,
   ActivityTypeSchema,
+  type ComboActivity,
   ListActivityResponseSchema,
+  ListComboActivityResponseSchema,
   ListTradesResponseSchema,
   SideSchema,
   type Trade,
@@ -26,10 +31,10 @@ import {
   paginate,
 } from '../pagination';
 import { validateWith } from '../response';
-import { toDataSearchParams } from './params';
+import { snakeCase, toDataSearchParams, toSearchParams } from './params';
 
-const ActivitySortBySchema = z.enum(['TIMESTAMP', 'TOKENS', 'CASH']);
-const SortDirectionSchema = z.enum(['ASC', 'DESC']);
+export { ComboActivityType } from '@polymarket/bindings/data';
+
 const TradeFilterTypeSchema = z.enum(['CASH', 'TOKENS']);
 
 const ListTradesRequestSchema = z
@@ -43,6 +48,8 @@ const ListTradesRequestSchema = z
     eventId: z.array(z.number().int()).optional(),
     user: z.string().optional(),
     side: SideSchema.optional(),
+    start: z.number().int().min(0).optional(),
+    end: z.number().int().min(0).optional(),
   })
   .refine((value) => !(value.market && value.eventId), {
     message: 'Provide market or eventId, not both',
@@ -57,28 +64,7 @@ const ListTradesRequestSchema = z
     },
   );
 
-const ListActivityRequestSchema = z
-  .object({
-    cursor: PaginationCursorSchema.optional(),
-    pageSize: PageSizeSchema.default(20),
-    user: z.string(),
-    market: z.array(z.string()).optional(),
-    eventId: z.array(z.number().int()).optional(),
-    type: z.array(ActivityTypeSchema).optional(),
-    start: z.number().int().optional(),
-    end: z.number().int().optional(),
-    sortBy: ActivitySortBySchema.optional(),
-    sortDirection: SortDirectionSchema.optional(),
-    side: SideSchema.optional(),
-  })
-  .refine((value) => !(value.market && value.eventId), {
-    message: 'Provide market or eventId, not both',
-    path: ['eventId'],
-  });
-
 export type ListTradesRequest = z.input<typeof ListTradesRequestSchema>;
-export type ListActivityRequest = z.input<typeof ListActivityRequestSchema>;
-
 export type ListTradesError =
   | RateLimitError
   | RequestRejectedError
@@ -169,6 +155,30 @@ export function listTrades(
   }, cursor);
 }
 
+const ActivitySortBySchema = z.enum(['TIMESTAMP', 'TOKENS', 'CASH']);
+const SortDirectionSchema = z.enum(['ASC', 'DESC']);
+
+const ListActivityRequestSchema = z
+  .object({
+    cursor: PaginationCursorSchema.optional(),
+    pageSize: PageSizeSchema.default(20),
+    user: z.string(),
+    market: z.array(z.string()).optional(),
+    eventId: z.array(z.number().int()).optional(),
+    type: z.array(ActivityTypeSchema).optional(),
+    start: z.number().int().min(0).optional(),
+    end: z.number().int().min(0).optional(),
+    sortBy: ActivitySortBySchema.optional(),
+    sortDirection: SortDirectionSchema.optional(),
+    side: SideSchema.optional(),
+  })
+  .refine((value) => !(value.market && value.eventId), {
+    message: 'Provide market or eventId, not both',
+    path: ['eventId'],
+  });
+
+export type ListActivityRequest = z.input<typeof ListActivityRequestSchema>;
+
 export type ListActivityError =
   | RateLimitError
   | RequestRejectedError
@@ -257,4 +267,111 @@ export function listActivity(
         };
       });
   }, cursor);
+}
+
+const ComboConditionIdFilterSchema = z.union([
+  ComboConditionIdSchema,
+  z.array(ComboConditionIdSchema),
+]);
+
+const ListComboActivityRequestSchema = z.object({
+  cursor: PaginationCursorSchema.optional(),
+  pageSize: PageSizeSchema.default(50),
+  user: z.string(),
+  conditionId: ComboConditionIdFilterSchema.optional(),
+});
+
+export type ListComboActivityRequest = z.input<
+  typeof ListComboActivityRequestSchema
+>;
+
+export type ListComboActivityError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const ListComboActivityError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Lists combo lifecycle activity for a wallet.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
+ * @throws {@link ListComboActivityError}
+ * Thrown on failure.
+ *
+ * @example
+ * Fetch the first page of results:
+ * ```ts
+ * const result = listComboActivity(client, {
+ *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+ *   pageSize: 10,
+ * });
+ *
+ * const firstPage = await result.firstPage();
+ *
+ * // Optionally, fetch additional pages:
+ * for await (const page of result.from(firstPage.nextCursor)) {
+ *   // page.items: ComboActivity[]
+ * }
+ * ```
+ */
+export function listComboActivity(
+  client: BaseClient,
+  request: ListComboActivityRequest,
+): Paginated<ComboActivity[]> {
+  const { cursor, pageSize, conditionId, ...params } = parseUserInput(
+    request,
+    ListComboActivityRequestSchema,
+  );
+
+  return paginate((cursor) => {
+    const searchParams = toSearchParams(
+      {
+        ...params,
+        limit: pageSize,
+        cursor,
+      },
+      snakeCase(),
+    );
+
+    appendConditionId(searchParams, conditionId);
+
+    return client.data
+      .get('/v1/activity/combos', {
+        params: searchParams,
+      })
+      .andThen(validateWith(ListComboActivityResponseSchema))
+      .map((response) => {
+        const nextCursor = response.pagination.nextCursor ?? undefined;
+
+        return {
+          items: response.activity,
+          hasMore: nextCursor !== undefined,
+          nextCursor,
+        };
+      });
+  }, cursor);
+}
+
+function appendConditionId(
+  searchParams: URLSearchParams,
+  conditionId: z.output<typeof ComboConditionIdFilterSchema> | undefined,
+): void {
+  if (conditionId === undefined) {
+    return;
+  }
+
+  searchParams.append(
+    'market_id',
+    Array.isArray(conditionId) ? conditionId.join(',') : conditionId,
+  );
 }

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -1,7 +1,6 @@
 import {
   ComboConditionIdSchema,
   PaginationCursorSchema,
-  PositionIdSchema,
 } from '@polymarket/bindings';
 import {
   type ClosedPosition,
@@ -38,7 +37,18 @@ import {
 import { readBlob, validateWith } from '../response';
 import { snakeCase, toDataSearchParams, toSearchParams } from './params';
 
-export { ComboPositionStatus } from '@polymarket/bindings/data';
+export {
+  ComboPositionOutcome,
+  ComboPositionStatus,
+} from '@polymarket/bindings/data';
+
+export enum ComboPositionSort {
+  CurrentValueDesc = 'current_value_desc',
+  FirstEntryDesc = 'first_entry_desc',
+  EntryCostDesc = 'entry_cost_desc',
+  ResolvedAtDesc = 'resolved_at_desc',
+  UpdatedAsc = 'updated_asc',
+}
 
 const PositionSortBySchema = z.enum([
   'CURRENT',
@@ -53,14 +63,6 @@ const PositionSortBySchema = z.enum([
 ]);
 
 const PositionSortDirectionSchema = z.enum(['ASC', 'DESC']);
-
-const ClosedPositionSortBySchema = z.enum([
-  'REALIZEDPNL',
-  'TITLE',
-  'PRICE',
-  'AVGPRICE',
-  'TIMESTAMP',
-]);
 
 const ListPositionsRequestSchema = z
   .object({
@@ -81,60 +83,7 @@ const ListPositionsRequestSchema = z
     path: ['eventId'],
   });
 
-const ListClosedPositionsRequestSchema = z
-  .object({
-    cursor: PaginationCursorSchema.optional(),
-    user: z.string(),
-    market: z.array(z.string()).optional(),
-    title: z.string().max(100).optional(),
-    eventId: z.array(z.number().int()).optional(),
-    pageSize: PageSizeSchema.default(20),
-    sortBy: ClosedPositionSortBySchema.optional(),
-    sortDirection: PositionSortDirectionSchema.optional(),
-  })
-  .refine((value) => !(value.market && value.eventId), {
-    message: 'Provide market or eventId, not both',
-    path: ['eventId'],
-  });
-
-const ListComboPositionsRequestSchema = z.object({
-  cursor: PaginationCursorSchema.optional(),
-  user: z.string(),
-  pageSize: PageSizeSchema.default(20),
-  status: ComboPositionStatusSchema.optional(),
-  conditionId: ComboConditionIdSchema.optional(),
-  positionId: PositionIdSchema.optional(),
-});
-
-const FetchPortfolioValueRequestSchema = z.object({
-  user: z.string(),
-  market: z.array(z.string()).optional(),
-});
-
-const FetchTradedMarketCountRequestSchema = z.object({
-  user: z.string(),
-});
-
-const DownloadAccountingSnapshotRequestSchema = z.object({
-  user: z.string(),
-});
-
 export type ListPositionsRequest = z.input<typeof ListPositionsRequestSchema>;
-export type ListClosedPositionsRequest = z.input<
-  typeof ListClosedPositionsRequestSchema
->;
-export type ListComboPositionsRequest = z.input<
-  typeof ListComboPositionsRequestSchema
->;
-export type FetchPortfolioValueRequest = z.input<
-  typeof FetchPortfolioValueRequestSchema
->;
-export type FetchTradedMarketCountRequest = z.input<
-  typeof FetchTradedMarketCountRequestSchema
->;
-export type DownloadAccountingSnapshotRequest = z.input<
-  typeof DownloadAccountingSnapshotRequestSchema
->;
 
 export type ListPositionsError =
   | RateLimitError
@@ -226,6 +175,34 @@ export function listPositions(
   }, cursor);
 }
 
+const ClosedPositionSortBySchema = z.enum([
+  'REALIZEDPNL',
+  'TITLE',
+  'PRICE',
+  'AVGPRICE',
+  'TIMESTAMP',
+]);
+
+const ListClosedPositionsRequestSchema = z
+  .object({
+    cursor: PaginationCursorSchema.optional(),
+    user: z.string(),
+    market: z.array(z.string()).optional(),
+    title: z.string().max(100).optional(),
+    eventId: z.array(z.number().int()).optional(),
+    pageSize: PageSizeSchema.default(20),
+    sortBy: ClosedPositionSortBySchema.optional(),
+    sortDirection: PositionSortDirectionSchema.optional(),
+  })
+  .refine((value) => !(value.market && value.eventId), {
+    message: 'Provide market or eventId, not both',
+    path: ['eventId'],
+  });
+
+export type ListClosedPositionsRequest = z.input<
+  typeof ListClosedPositionsRequestSchema
+>;
+
 export type ListClosedPositionsError =
   | RateLimitError
   | RequestRejectedError
@@ -233,20 +210,6 @@ export type ListClosedPositionsError =
   | UnexpectedResponseError
   | UserInputError;
 export const ListClosedPositionsError = makeErrorGuard(
-  RateLimitError,
-  RequestRejectedError,
-  TransportError,
-  UnexpectedResponseError,
-  UserInputError,
-);
-
-export type ListComboPositionsError =
-  | RateLimitError
-  | RequestRejectedError
-  | TransportError
-  | UnexpectedResponseError
-  | UserInputError;
-export const ListComboPositionsError = makeErrorGuard(
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -330,6 +293,42 @@ export function listClosedPositions(
   }, cursor);
 }
 
+const ComboPositionSortSchema = z.enum(ComboPositionSort);
+
+const ComboConditionIdFilterSchema = z.union([
+  ComboConditionIdSchema,
+  z.array(ComboConditionIdSchema),
+]);
+
+const ListComboPositionsRequestSchema = z.object({
+  cursor: PaginationCursorSchema.optional(),
+  user: z.string(),
+  pageSize: PageSizeSchema.default(20),
+  status: ComboPositionStatusSchema.optional(),
+  sort: ComboPositionSortSchema.optional(),
+  conditionId: ComboConditionIdFilterSchema.optional(),
+  updatedAfter: z.number().int().min(0).optional(),
+  updatedBefore: z.number().int().min(0).optional(),
+});
+
+export type ListComboPositionsRequest = z.input<
+  typeof ListComboPositionsRequestSchema
+>;
+
+export type ListComboPositionsError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const ListComboPositionsError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
 /**
  * Lists combo positions for a wallet.
  *
@@ -363,50 +362,81 @@ export function listClosedPositions(
  *   status: ComboPositionStatus.Open,
  * });
  * ```
+ *
+ * @example
+ * Incrementally sync changed combo positions:
+ * ```ts
+ * const result = listComboPositions(client, {
+ *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+ *   updatedAfter: 1_797_360_000,
+ *   sort: ComboPositionSort.UpdatedAsc,
+ *   pageSize: 1000,
+ * });
+ * ```
  */
 export function listComboPositions(
   client: BaseClient,
   request: ListComboPositionsRequest,
 ): Paginated<ComboPosition[]> {
-  const { cursor, pageSize, ...params } = parseUserInput(
+  const { cursor, pageSize, conditionId, ...params } = parseUserInput(
     request,
     ListComboPositionsRequestSchema,
   );
 
   return paginate((cursor) => {
-    const decoded = decodeOffsetCursor(cursor, pageSize);
+    const searchParams = toSearchParams(
+      {
+        ...params,
+        limit: pageSize,
+        cursor,
+      },
+      snakeCase({
+        updatedAfter: 'updatedAfter',
+        updatedBefore: 'updatedBefore',
+      }),
+    );
+
+    appendConditionId(searchParams, conditionId);
 
     return client.data
       .get('/v1/positions/combos', {
-        params: toSearchParams(
-          {
-            ...params,
-            limit: decoded.pageSize + 1,
-            offset: decoded.offset,
-          },
-          snakeCase({
-            conditionId: 'combo_condition_id',
-            positionId: 'combo_position_id',
-          }),
-        ),
+        params: searchParams,
       })
       .andThen(validateWith(ListComboPositionsResponseSchema))
       .map((response) => {
-        const hasMore = response.combos.length > decoded.pageSize;
+        const nextCursor = response.pagination.nextCursor ?? undefined;
 
         return {
-          items: response.combos.slice(0, decoded.pageSize),
-          hasMore,
-          nextCursor: hasMore
-            ? encodeOffsetCursor({
-                offset: decoded.offset + decoded.pageSize,
-                pageSize: decoded.pageSize,
-              })
-            : undefined,
+          items: response.combos,
+          hasMore: nextCursor !== undefined,
+          nextCursor,
         };
       });
   }, cursor);
 }
+
+function appendConditionId(
+  searchParams: URLSearchParams,
+  conditionId: z.output<typeof ComboConditionIdFilterSchema> | undefined,
+): void {
+  if (conditionId === undefined) {
+    return;
+  }
+
+  searchParams.append(
+    'market_id',
+    Array.isArray(conditionId) ? conditionId.join(',') : conditionId,
+  );
+}
+
+const FetchPortfolioValueRequestSchema = z.object({
+  user: z.string(),
+  market: z.array(z.string()).optional(),
+});
+
+export type FetchPortfolioValueRequest = z.input<
+  typeof FetchPortfolioValueRequestSchema
+>;
 
 export type FetchPortfolioValueError =
   | RateLimitError
@@ -455,6 +485,14 @@ export async function fetchPortfolioValue(
   );
 }
 
+const FetchTradedMarketCountRequestSchema = z.object({
+  user: z.string(),
+});
+
+export type FetchTradedMarketCountRequest = z.input<
+  typeof FetchTradedMarketCountRequestSchema
+>;
+
 export type FetchTradedMarketCountError =
   | RateLimitError
   | RequestRejectedError
@@ -501,6 +539,14 @@ export async function fetchTradedMarketCount(
       .andThen(validateWith(TradedSchema)),
   );
 }
+
+const DownloadAccountingSnapshotRequestSchema = z.object({
+  user: z.string(),
+});
+
+export type DownloadAccountingSnapshotRequest = z.input<
+  typeof DownloadAccountingSnapshotRequestSchema
+>;
 
 export type DownloadAccountingSnapshotError =
   | RateLimitError

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -5,6 +5,7 @@ import type {
 import type {
   Activity,
   ClosedPosition,
+  ComboActivity,
   ComboPosition,
   MetaMarketPosition,
   Position,
@@ -26,12 +27,14 @@ import {
   type ListAccountTradesRequest,
   type ListActivityRequest,
   type ListClosedPositionsRequest,
+  type ListComboActivityRequest,
   type ListComboPositionsRequest,
   type ListMarketPositionsRequest,
   type ListPositionsRequest,
   listAccountTrades,
   listActivity,
   listClosedPositions,
+  listComboActivity,
   listComboPositions,
   listMarketPositions,
   listPositions,
@@ -68,6 +71,8 @@ export type SecureDownloadAccountingSnapshotRequest =
   DefaultAccountWallet<DownloadAccountingSnapshotRequest>;
 export type SecureListActivityRequest =
   DefaultAccountWallet<ListActivityRequest>;
+export type SecureListComboActivityRequest =
+  DefaultAccountWallet<ListComboActivityRequest>;
 
 type CommonAccountActions = {
   /**
@@ -288,6 +293,26 @@ export type PublicAccountActions = Prettify<
      * ```
      */
     listActivity(request: ListActivityRequest): Paginated<Activity[]>;
+    /**
+     * Lists combo lifecycle activity for a wallet.
+     *
+     * @throws {@link ListComboActivityError}
+     * Thrown on failure.
+     *
+     * @example
+     * Fetch the first page of results:
+     * ```ts
+     * const paginator = client.listComboActivity({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     *   pageSize: 10,
+     * });
+     *
+     * const firstPage = await paginator.firstPage();
+     * ```
+     */
+    listComboActivity(
+      request: ListComboActivityRequest,
+    ): Paginated<ComboActivity[]>;
   }
 >;
 
@@ -377,6 +402,17 @@ export type SecureAccountActions = Prettify<
      */
     listActivity(request?: SecureListActivityRequest): Paginated<Activity[]>;
     /**
+     * Lists combo lifecycle activity for a wallet.
+     *
+     * Defaults to the authenticated account's wallet when `user` is omitted.
+     *
+     * @throws {@link ListComboActivityError}
+     * Thrown on failure.
+     */
+    listComboActivity(
+      request?: SecureListComboActivityRequest,
+    ): Paginated<ComboActivity[]>;
+    /**
      * Lists trades for the authenticated account across all pages.
      *
      * @throws {@link ListAccountTradesError}
@@ -463,6 +499,7 @@ function publicAccountActions(client: BaseClient): PublicAccountActions {
     downloadAccountingSnapshot: downloadAccountingSnapshot.bind(null, client),
     listMarketPositions: listMarketPositions.bind(null, client),
     listActivity: listActivity.bind(null, client),
+    listComboActivity: listComboActivity.bind(null, client),
   };
 }
 
@@ -504,6 +541,8 @@ export function accountActions(
     ) => downloadAccountingSnapshot(client, withAccountWallet(client, request)),
     listActivity: (request?: SecureListActivityRequest) =>
       listActivity(client, withAccountWallet(client, request)),
+    listComboActivity: (request?: SecureListComboActivityRequest) =>
+      listComboActivity(client, withAccountWallet(client, request)),
     listAccountTrades: listAccountTrades.bind(null, client),
     fetchNotifications: fetchNotifications.bind(null, client),
     dropNotifications: dropNotifications.bind(null, client),
@@ -524,8 +563,14 @@ export {
   ListAccountTradesError,
   ListActivityError,
   ListClosedPositionsError,
+  ListComboActivityError,
   ListComboPositionsError,
   ListMarketPositionsError,
   ListPositionsError,
 } from '../actions';
-export { ComboPositionStatus } from '../actions/portfolio';
+export { ComboActivityType } from '../actions/activity';
+export {
+  ComboPositionOutcome,
+  ComboPositionSort,
+  ComboPositionStatus,
+} from '../actions/portfolio';

--- a/packages/client/tests/integration/activity.test.ts
+++ b/packages/client/tests/integration/activity.test.ts
@@ -1,7 +1,7 @@
-import { ActivityType } from '@polymarket/client';
+import { ActivityType, ComboActivityType } from '@polymarket/client';
 import { expectPresent, isSameEvmAddress } from '@polymarket/types';
 import { describe, expect, it } from './fixtures';
-import { expectNonEmptyPage } from './helpers';
+import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
 
@@ -69,6 +69,44 @@ describe('Activity', () => {
       expect(expectPresent(result.items[0]).wallet).toSatisfy((wallet) =>
         isSameEvmAddress(wallet, depositWalletAddress),
       );
+    });
+  });
+
+  describe('listComboActivity', () => {
+    it('lists combo lifecycle activity for a wallet', async ({
+      publicClient,
+    }) => {
+      const paginator = publicClient.listComboActivity({
+        user: TEST_USER,
+        pageSize: 1,
+      });
+      const result = await paginator.firstPage().then(expectNonEmptyPage);
+      const item = expectPresent(result.items[0]);
+
+      await expectPageWindow(paginator, result, 1);
+      expect(Object.values(ComboActivityType)).toContain(item.type);
+      expect(item).toEqual(
+        expect.objectContaining({
+          conditionId: expect.any(String),
+          timestamp: expect.any(Number),
+          transactionAt: expect.any(String),
+          transactionHash: expect.any(String),
+          type: expect.any(String),
+          userAddress: TEST_USER,
+        }),
+      );
+
+      if (item.type === ComboActivityType.Redeem) {
+        expect(item).toHaveProperty('payoutUsdc');
+        expect(item).toEqual(
+          expect.objectContaining({
+            positionId: expect.any(String),
+          }),
+        );
+      } else {
+        expect(item).not.toHaveProperty('payoutUsdc');
+        expect(item).not.toHaveProperty('positionId');
+      }
     });
   });
 });

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -1,3 +1,4 @@
+import { ComboPositionOutcome, ComboPositionSort } from '@polymarket/client';
 import { isSameEvmAddress } from '@polymarket/types';
 import { describe, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
@@ -68,6 +69,43 @@ describe('Portfolio', () => {
       expect(result.items[0]?.wallet).toSatisfy((wallet) =>
         isSameEvmAddress(wallet, depositWalletAddress),
       );
+    });
+  });
+
+  describe('listComboPositions', () => {
+    it('lists combo positions for a wallet', async ({ publicClient }) => {
+      const paginator = publicClient.listComboPositions({
+        user: TEST_USER,
+        pageSize: 1,
+        sort: ComboPositionSort.FirstEntryDesc,
+      });
+      const result = await paginator.firstPage().then(expectNonEmptyPage);
+
+      await expectPageWindow(paginator, result, 1);
+      expect(Object.values(ComboPositionOutcome)).toContain(
+        result.items[0].outcome,
+      );
+      expect(result.items[0]).toEqual(
+        expect.objectContaining({
+          conditionId: expect.any(String),
+          positionId: expect.any(String),
+          redeemable: expect.any(Boolean),
+          userAddress: TEST_USER,
+          realizedPayoutUsdc: expect.any(String),
+          totalCostUsdc: expect.any(String),
+        }),
+      );
+
+      const filtered = await publicClient
+        .listComboPositions({
+          user: TEST_USER,
+          pageSize: 1,
+          conditionId: result.items[0].conditionId,
+        })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      expect(filtered.items[0].conditionId).toBe(result.items[0].conditionId);
     });
   });
 


### PR DESCRIPTION
## Summary
- add paginated Combo activity support with normalized lifecycle activity types
- switch Combo positions to server cursors and add sync filters/sort options
- normalize Combo position side to SDK-facing outcome and expose redeemable/cost/payout fields

## Verification
- pnpm --filter @polymarket/bindings build
- pnpm --filter @polymarket/client build
- pnpm lint
- pnpm typecheck
- pnpm test:client:integration portfolio.test.ts activity.test.ts
- pnpm test
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public API changes include new endpoints, cursor-based combo position pagination (breaking for callers relying on offset behavior), removed `positionId` filter, and new required/normalized combo position fields.
> 
> **Overview**
> Adds **paginated Combo lifecycle activity** to the SDK: new `ComboActivity` types with normalized `ComboActivityType` values, Zod parsing from `/v1/activity/combos`, and `listComboActivity` on public/secure clients using **server `next_cursor`** pagination (optional `conditionId` → `market_id` filter).
> 
> **Combo positions** move from offset-based paging to **server cursors** on `/v1/positions/combos`. Request options gain `sort` (`ComboPositionSort`), `updatedAfter` / `updatedBefore` for incremental sync, and multi-value `conditionId` filtering; **`positionId` filter is removed**. Bindings expose **`outcome`** (from API `side`), **`redeemable`**, **`realizedPayoutUsdc`**, **`totalCostUsdc`**, and **`updatedAt`**.
> 
> Minor client tweaks: non-negative `start`/`end` on trades and activity lists. Integration tests cover combo activity and combo position listing/pagination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9233e699e58bd96778983cb49510211eb5801905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->