### PR TITLE
fix(client): normalize combo data field names

### DIFF
--- a/.changeset/combo-data-field-names.md
+++ b/.changeset/combo-data-field-names.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Normalize Combo data field names to use wallet, amount, and payout consistently with the existing activity and portfolio surfaces.

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -241,16 +241,14 @@ type ComboActivityBase = {
   id: string;
   /** Normalized lifecycle activity type. */
   type: ComboActivityType;
-  /** Module label returned by the activity service. */
-  moduleKind: string;
   /** Wallet address whose account history contains this activity. */
-  userAddress: Address;
+  wallet: Address;
   /** Combo condition id involved in this activity. */
   conditionId: ComboConditionId;
   /** Combo module id. */
   moduleId: number;
-  /** USDC amount associated with the lifecycle event. */
-  amountUsdc: DecimalString | null;
+  /** Amount associated with the lifecycle event in USD. */
+  amount: DecimalString | null;
   /** Activity time as Unix epoch milliseconds. */
   timestamp: EpochMilliseconds;
   /** Activity transaction time as an ISO date-time string. */
@@ -293,8 +291,8 @@ export type ComboRedeemActivity = ComboActivityBase & {
   type: ComboActivityType.Redeem;
   /** Redeemed Combo position id. Only redeem rows carry a source position id. */
   positionId: PositionId;
-  /** USDC payout from the redemption. Only redeem rows carry payout semantics. */
-  payoutUsdc: DecimalString | null;
+  /** Payout from the redemption in USD. Only redeem rows carry payout semantics. */
+  payout: DecimalString | null;
 };
 
 export type ComboActivity =
@@ -459,7 +457,7 @@ function normalizeComboActivity(activity: RawComboActivity): ComboActivity {
         ...base,
         type: ComboActivityType.Redeem,
         positionId: activity.combo_position_id,
-        payoutUsdc: activity.payout_usdc,
+        payout: activity.payout_usdc,
       };
   }
 }
@@ -470,11 +468,10 @@ function normalizeComboActivityBase(
   return {
     id: activity.id,
     type: activity.side,
-    moduleKind: activity.module_kind,
-    userAddress: activity.user_address,
+    wallet: activity.user_address,
     conditionId: activity.combo_condition_id,
     moduleId: activity.module_id,
-    amountUsdc: activity.amount_usdc,
+    amount: activity.amount_usdc,
     timestamp: activity.timestamp,
     transactionAt: activity.tx_dttm,
     transactionHash: activity.tx_hash,

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -247,7 +247,7 @@ export const ComboPositionSchema = z
       positionId: combo_position_id,
       outcome: side,
       moduleId: module_id,
-      userAddress: user_address,
+      wallet: user_address,
       shares: shares_balance,
       entryAvgPriceUsdc: entry_avg_price_usdc,
       entryCostUsdc: entry_cost_usdc,

--- a/packages/client/tests/integration/activity.test.ts
+++ b/packages/client/tests/integration/activity.test.ts
@@ -92,19 +92,19 @@ describe('Activity', () => {
           transactionAt: expect.any(String),
           transactionHash: expect.any(String),
           type: expect.any(String),
-          userAddress: TEST_USER,
+          wallet: TEST_USER,
         }),
       );
 
       if (item.type === ComboActivityType.Redeem) {
-        expect(item).toHaveProperty('payoutUsdc');
+        expect(item).toHaveProperty('payout');
         expect(item).toEqual(
           expect.objectContaining({
             positionId: expect.any(String),
           }),
         );
       } else {
-        expect(item).not.toHaveProperty('payoutUsdc');
+        expect(item).not.toHaveProperty('payout');
         expect(item).not.toHaveProperty('positionId');
       }
     });

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -90,7 +90,7 @@ describe('Portfolio', () => {
           conditionId: expect.any(String),
           positionId: expect.any(String),
           redeemable: expect.any(Boolean),
-          userAddress: TEST_USER,
+          wallet: TEST_USER,
           realizedPayoutUsdc: expect.any(String),
           totalCostUsdc: expect.any(String),
         }),


### PR DESCRIPTION
## Summary
- rename Combo activity owner field from userAddress to wallet
- rename Combo activity amount fields from amountUsdc/payoutUsdc to amount/payout
- omit moduleKind from Combo activity responses
- rename Combo position userAddress to wallet

Follow-up to https://github.com/Polymarket/ts-sdk/pull/188

## Verification
- pnpm --filter @polymarket/bindings build
- pnpm --filter @polymarket/client build
- pnpm lint
- pnpm typecheck
- pnpm test:client:integration portfolio.test.ts activity.test.ts
- pnpm test
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public SDK field renames are breaking for consumers of Combo activity/position types, though behavior and upstream parsing are unchanged.
> 
> **Overview**
> **Combo activity and position** normalized client shapes now align with the rest of activity/portfolio: owner is **`wallet`** (was `userAddress`), lifecycle amounts use **`amount`** / redeem **`payout`** (was `amountUsdc` / `payoutUsdc`), and **`moduleKind`** is no longer exposed on normalized Combo activity rows.
> 
> Bindings mappers in `activity.ts` and `portfolio.ts` still read the same upstream snake_case fields; only the exported TypeScript types and transform output change. Integration tests for `listComboActivity` and `listComboPositions` assert the new property names.
> 
> Patch changesets bump `@polymarket/bindings` and `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2e487fe053449996249b00f1d9cccc53838fe47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->