### PR TITLE
fix(bindings): brand Combo activity IDs

### DIFF
--- a/.changeset/combo-data-field-names.md
+++ b/.changeset/combo-data-field-names.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Normalize Combo data field names to use wallet, amount, and payout consistently with the existing activity and portfolio surfaces.
+Normalize Combo data field names to use wallet, amount, and payout consistently with the existing activity and portfolio surfaces, and brand Combo activity row IDs.

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import {
+  type ComboActivityId,
+  ComboActivityIdSchema,
   type ComboConditionId,
   ComboConditionIdSchema,
   type CtfConditionId,
@@ -238,7 +240,7 @@ export type Activity =
 
 type ComboActivityBase = {
   /** Stable row id derived from the transaction hash and log index. */
-  id: string;
+  id: ComboActivityId;
   /** Normalized lifecycle activity type. */
   type: ComboActivityType;
   /** Wallet address whose account history contains this activity. */
@@ -305,7 +307,7 @@ export type ComboActivity =
   | ComboRedeemActivity;
 
 const RawComboActivitySchema = z.object({
-  id: z.string(),
+  id: ComboActivityIdSchema,
   side: UpstreamComboActivityTypeSchema,
   module_kind: z.string(),
   user_address: AddressSchema,

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -47,6 +47,7 @@ export type CategoryId = Tagged<string, 'CategoryId'>;
 export type ChatId = Tagged<string, 'ChatId'>;
 export type ClobRewardId = Tagged<string, 'ClobRewardId'>;
 export type CommentId = Tagged<string, 'CommentId'>;
+export type ComboActivityId = Tagged<string, 'ComboActivityId'>;
 export type ComboConditionId = Tagged<HexString, 'ComboConditionId'>;
 export type CtfConditionId = Tagged<HexString, 'CtfConditionId'>;
 /** @deprecated Use {@link CtfConditionId}. */
@@ -118,6 +119,10 @@ export function toClobRewardId(value: string): ClobRewardId {
 
 export function toCommentId(value: string): CommentId {
   return toTaggedString<CommentId>(value);
+}
+
+export function toComboActivityId(value: string): ComboActivityId {
+  return toTaggedString<ComboActivityId>(value);
 }
 
 export function toCtfConditionId(value: string): CtfConditionId {
@@ -282,6 +287,7 @@ export const ApiKeySchema = z.string().transform(toApiKey);
 export const BuilderCodeSchema = z.string().transform(toBuilderCode);
 export const ClobRewardIdSchema = z.string().transform(toClobRewardId);
 export const CommentIdSchema = z.string().transform(toCommentId);
+export const ComboActivityIdSchema = z.string().transform(toComboActivityId);
 export const ComboConditionIdSchema = z.string().transform(toComboConditionId);
 export const CtfConditionIdSchema = z.string().transform(toCtfConditionId);
 export const OptionalCtfConditionIdSchema = z.preprocess(


### PR DESCRIPTION
## Summary
- Add a branded ComboActivityId primitive for Combo lifecycle activity row IDs.
- Parse Combo activity IDs through the shared branded schema.
- Update the existing Combo data changeset wording.

## Verification
- pnpm --filter @polymarket/bindings build
- pnpm typecheck
- pnpm lint
- git diff --check