### PR TITLE
fix(bindings): parse Combo activity type

### DIFF
--- a/.changeset/combo-activity-type.md
+++ b/.changeset/combo-activity-type.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Parse Combo lifecycle activity from the canonical API `type` field instead of the legacy `side` verb.

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -41,29 +41,7 @@ export enum ComboActivityType {
   Redeem = 'REDEEM',
 }
 
-enum UpstreamComboActivityType {
-  Split = 'Split',
-  Merge = 'Merge',
-  Convert = 'Convert',
-  Compress = 'Compress',
-  Wrap = 'Wrap',
-  Unwrap = 'Unwrap',
-  Redeem = 'Redeem',
-}
-
-const ComboActivityTypeByUpstream = {
-  [UpstreamComboActivityType.Split]: ComboActivityType.Split,
-  [UpstreamComboActivityType.Merge]: ComboActivityType.Merge,
-  [UpstreamComboActivityType.Convert]: ComboActivityType.Convert,
-  [UpstreamComboActivityType.Compress]: ComboActivityType.Compress,
-  [UpstreamComboActivityType.Wrap]: ComboActivityType.Wrap,
-  [UpstreamComboActivityType.Unwrap]: ComboActivityType.Unwrap,
-  [UpstreamComboActivityType.Redeem]: ComboActivityType.Redeem,
-} satisfies Record<UpstreamComboActivityType, ComboActivityType>;
-
-const UpstreamComboActivityTypeSchema = z
-  .enum(UpstreamComboActivityType)
-  .transform((value) => ComboActivityTypeByUpstream[value]);
+const ComboActivityTypeSchema = z.enum(ComboActivityType);
 
 export type ActivityBase = {
   /** Wallet address whose account history contains this activity. */
@@ -308,8 +286,7 @@ export type ComboActivity =
 
 const RawComboActivitySchema = z.object({
   id: ComboActivityIdSchema,
-  side: UpstreamComboActivityTypeSchema,
-  module_kind: z.string(),
+  type: ComboActivityTypeSchema,
   user_address: AddressSchema,
   combo_condition_id: ComboConditionIdSchema,
   combo_position_id: PositionIdSchema,
@@ -441,7 +418,7 @@ type RawActivity = z.infer<typeof RawActivitySchema>;
 function normalizeComboActivity(activity: RawComboActivity): ComboActivity {
   const base = normalizeComboActivityBase(activity);
 
-  switch (activity.side) {
+  switch (activity.type) {
     case ComboActivityType.Split:
       return { ...base, type: ComboActivityType.Split };
     case ComboActivityType.Merge:
@@ -469,7 +446,7 @@ function normalizeComboActivityBase(
 ): ComboActivityBase {
   return {
     id: activity.id,
-    type: activity.side,
+    type: activity.type,
     wallet: activity.user_address,
     conditionId: activity.combo_condition_id,
     moduleId: activity.module_id,


### PR DESCRIPTION
## Summary
- Parse Combo lifecycle activity from the canonical API type field.
- Stop deriving Combo activity types from the legacy side verb.
- Update the Combo activity changeset.

## Verification
- pnpm --filter @polymarket/bindings build
- pnpm --filter @polymarket/client build
- pnpm typecheck
- pnpm lint
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Parsing depends on the API sending `type` in the expected enum shape; payloads that still only provide `side` would fail validation or misclassify combo activity.
> 
> **Overview**
> Combo lifecycle rows in `@polymarket/bindings` are now parsed from the API’s **`type`** field (values like `SPLIT`, `MERGE`, …) instead of the legacy **`side`** verb with Title Case values (`Split`, `Merge`, …).
> 
> The upstream enum, transform map, and `module_kind` on the raw schema are removed; **`ComboActivityTypeSchema`** validates `type` directly, and **`normalizeComboActivity`** / **`normalizeComboActivityBase`** branch on **`activity.type`**. A patch changeset covers **`@polymarket/bindings`** and **`@polymarket/client`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7649a5e1c79beefafac6cbba8eb293fdec40ae1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->