### PR TITLE
fix(bindings): support batched Perps trade frames

### DIFF
--- a/.changeset/perps-session-fills-array-frames.md
+++ b/.changeset/perps-session-fills-array-frames.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Fix Perps session dropping every fill event. The private `fills` channel delivers all fills from a single match event as a batch in `data`, but the session event schema only accepted a single object, so `safeParse` failed and no fill events were emitted while order, balance, and portfolio events arrived normally. Fill frames are now fanned out into one event per fill.
+Fix Perps sessions dropping every fill event. The private `fills` channel delivers all fills from a single match event as a batch in `data`, but the session event schema only accepted a single object, so `safeParse` failed and no fill events were emitted while order, balance, and portfolio events arrived normally. Each frame is now emitted as one event whose payload is the list of fills.

--- a/.changeset/perps-session-fills-array-frames.md
+++ b/.changeset/perps-session-fills-array-frames.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Fix Perps session dropping every fill event. The private `fills` channel delivers all fills from a single match event as a batch in `data`, but the session event schema only accepted a single object, so `safeParse` failed and no fill events were emitted while order, balance, and portfolio events arrived normally. Fill frames are now fanned out into one event per fill.

--- a/.changeset/perps-session-fills-array-frames.md
+++ b/.changeset/perps-session-fills-array-frames.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Fix Perps sessions dropping every fill event. The private `fills` channel delivers all fills from a single match event as a batch in `data`, but the session event schema only accepted a single object, so `safeParse` failed and no fill events were emitted while order, balance, and portfolio events arrived normally. Each frame is now emitted as one event whose payload is the list of fills.
+Support Perps fills frames containing a list of fills.

--- a/.changeset/perps-trades-array-frames.md
+++ b/.changeset/perps-trades-array-frames.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Fix Perps trades subscriptions silently dropping every frame. The `trades::<instrumentId>` channel delivers a batch of trades in `data`, but the event schema only accepted a single object, so `safeParse` failed and no trade events were emitted. Each frame is now emitted as one event whose payload is the list of trades.
+Support Perps trades frames containing a list of trades.

--- a/.changeset/perps-trades-array-frames.md
+++ b/.changeset/perps-trades-array-frames.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Fix Perps trades subscription silently dropping every frame. The `trades::<instrumentId>` channel delivers a batch of trades in `data`, but the event schema only accepted a single object, so `safeParse` failed and no trade events were emitted. Trade frames are now fanned out into one event per trade.
+Fix Perps trades subscriptions silently dropping every frame. The `trades::<instrumentId>` channel delivers a batch of trades in `data`, but the event schema only accepted a single object, so `safeParse` failed and no trade events were emitted. Each frame is now emitted as one event whose payload is the list of trades.

--- a/.changeset/perps-trades-array-frames.md
+++ b/.changeset/perps-trades-array-frames.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Fix Perps trades subscription silently dropping every frame. The `trades::<instrumentId>` channel delivers a batch of trades in `data`, but the event schema only accepted a single object, so `safeParse` failed and no trade events were emitted. Trade frames are now fanned out into one event per trade.

--- a/packages/bindings/src/subscriptions/perps.ts
+++ b/packages/bindings/src/subscriptions/perps.ts
@@ -217,6 +217,26 @@ export const PerpsFillUpdateEventSchema = perpsSessionEventSchema(
 );
 export type PerpsFillUpdateEvent = z.infer<typeof PerpsFillUpdateEventSchema>;
 
+/**
+ * A `fills` frame carries every fill produced by a single match event as a
+ * batch in `data`, unlike the single-object payloads on the other session
+ * channels. This schema validates that batch envelope and fans it out into one
+ * {@link PerpsFillUpdateEvent} per fill so consumers observe individual fills.
+ */
+export const PerpsFillBatchEventSchema =
+  PerpsSessionUpdateEnvelopeSchema.extend({
+    ch: z.literal('fills'),
+    data: z.array(PerpsAccountFillUpdateSchema),
+  }).transform(({ ch, ts, sq, data }) =>
+    data.map<PerpsFillUpdateEvent>((payload) => ({
+      type: 'fill' as const,
+      channel: ch,
+      timestamp: ts,
+      sequence: sq,
+      payload,
+    })),
+  );
+
 export const PerpsFundingUpdateEventSchema = perpsSessionEventSchema(
   'funding',
   'funding',

--- a/packages/bindings/src/subscriptions/perps.ts
+++ b/packages/bindings/src/subscriptions/perps.ts
@@ -67,6 +67,26 @@ export const PerpsTradeEventSchema = PerpsUpdateEnvelopeSchema.extend({
 
 export type PerpsTradeEvent = z.infer<typeof PerpsTradeEventSchema>;
 
+/**
+ * A `trades::<instrumentId>` frame carries a batch of trades in `data`, unlike
+ * the single-object payloads on the book and bbo channels. This schema
+ * validates that batch envelope and fans it out into one {@link PerpsTradeEvent}
+ * per trade so consumers observe individual trades.
+ */
+export const PerpsTradeBatchEventSchema = PerpsUpdateEnvelopeSchema.extend({
+  ch: TradesChannelSchema,
+  data: z.array(PerpsPublicTradeUpdateSchema),
+}).transform(({ ch, ts, sq, data }) =>
+  data.map<PerpsTradeEvent>((payload) => ({
+    topic: 'perps.trades' as const,
+    type: 'trade' as const,
+    channel: ch,
+    timestamp: ts,
+    sequence: sq,
+    payload,
+  })),
+);
+
 export const PerpsBboEventSchema = PerpsUpdateEnvelopeSchema.extend({
   ch: BboChannelSchema,
   data: PerpsBboUpdateSchema,

--- a/packages/bindings/src/subscriptions/perps.ts
+++ b/packages/bindings/src/subscriptions/perps.ts
@@ -55,7 +55,7 @@ const PerpsUpdateEnvelopeSchema = z.object({
 
 export const PerpsTradeEventSchema = PerpsUpdateEnvelopeSchema.extend({
   ch: TradesChannelSchema,
-  data: PerpsPublicTradeUpdateSchema,
+  data: z.array(PerpsPublicTradeUpdateSchema),
 }).transform(({ ch, ts, sq, data }) => ({
   topic: 'perps.trades' as const,
   type: 'trade' as const,
@@ -66,25 +66,6 @@ export const PerpsTradeEventSchema = PerpsUpdateEnvelopeSchema.extend({
 }));
 
 export type PerpsTradeEvent = z.infer<typeof PerpsTradeEventSchema>;
-
-/**
- * Validates a `trades::<instrumentId>` frame, whose `data` is an array of
- * trades, and fans it out into one {@link PerpsTradeEvent} per trade so
- * consumers observe individual trades.
- */
-export const PerpsTradeBatchEventSchema = PerpsUpdateEnvelopeSchema.extend({
-  ch: TradesChannelSchema,
-  data: z.array(PerpsPublicTradeUpdateSchema),
-}).transform(({ ch, ts, sq, data }) =>
-  data.map<PerpsTradeEvent>((payload) => ({
-    topic: 'perps.trades' as const,
-    type: 'trade' as const,
-    channel: ch,
-    timestamp: ts,
-    sequence: sq,
-    payload,
-  })),
-);
 
 export const PerpsBboEventSchema = PerpsUpdateEnvelopeSchema.extend({
   ch: BboChannelSchema,

--- a/packages/bindings/src/subscriptions/perps.ts
+++ b/packages/bindings/src/subscriptions/perps.ts
@@ -68,10 +68,9 @@ export const PerpsTradeEventSchema = PerpsUpdateEnvelopeSchema.extend({
 export type PerpsTradeEvent = z.infer<typeof PerpsTradeEventSchema>;
 
 /**
- * A `trades::<instrumentId>` frame carries a batch of trades in `data`, unlike
- * the single-object payloads on the book and bbo channels. This schema
- * validates that batch envelope and fans it out into one {@link PerpsTradeEvent}
- * per trade so consumers observe individual trades.
+ * Validates a `trades::<instrumentId>` frame, whose `data` is an array of
+ * trades, and fans it out into one {@link PerpsTradeEvent} per trade so
+ * consumers observe individual trades.
  */
 export const PerpsTradeBatchEventSchema = PerpsUpdateEnvelopeSchema.extend({
   ch: TradesChannelSchema,

--- a/packages/bindings/src/subscriptions/perps.ts
+++ b/packages/bindings/src/subscriptions/perps.ts
@@ -213,29 +213,9 @@ export type PerpsOrderUpdateEvent = z.infer<typeof PerpsOrderUpdateEventSchema>;
 export const PerpsFillUpdateEventSchema = perpsSessionEventSchema(
   'fill',
   'fills',
-  PerpsAccountFillUpdateSchema,
+  z.array(PerpsAccountFillUpdateSchema),
 );
 export type PerpsFillUpdateEvent = z.infer<typeof PerpsFillUpdateEventSchema>;
-
-/**
- * A `fills` frame carries every fill produced by a single match event as a
- * batch in `data`, unlike the single-object payloads on the other session
- * channels. This schema validates that batch envelope and fans it out into one
- * {@link PerpsFillUpdateEvent} per fill so consumers observe individual fills.
- */
-export const PerpsFillBatchEventSchema =
-  PerpsSessionUpdateEnvelopeSchema.extend({
-    ch: z.literal('fills'),
-    data: z.array(PerpsAccountFillUpdateSchema),
-  }).transform(({ ch, ts, sq, data }) =>
-    data.map<PerpsFillUpdateEvent>((payload) => ({
-      type: 'fill' as const,
-      channel: ch,
-      timestamp: ts,
-      sequence: sq,
-      payload,
-    })),
-  );
 
 export const PerpsFundingUpdateEventSchema = perpsSessionEventSchema(
   'funding',

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -134,6 +134,36 @@ describe('PerpsSession', () => {
 
       await session.close();
     });
+
+    it('fans out batched fill frames into one event per fill', async () => {
+      const connection = captureConnection(server, perps);
+      const session = createSession();
+
+      await session.connect();
+
+      await connection.send(fillsUpdate({ sequence: 1, tradeIds: [1, 2] }));
+
+      await expect(waitForNextEvent(session)).resolves.toMatchObject({
+        done: false,
+        value: {
+          channel: 'fills',
+          payload: { instrumentId: 1, side: 'long', tradeId: 1 },
+          sequence: 1,
+          type: 'fill',
+        },
+      });
+      await expect(waitForNextEvent(session)).resolves.toMatchObject({
+        done: false,
+        value: {
+          channel: 'fills',
+          payload: { instrumentId: 1, side: 'long', tradeId: 2 },
+          sequence: 1,
+          type: 'fill',
+        },
+      });
+
+      await session.close();
+    });
   });
 
   describe('reconnects', () => {
@@ -1217,6 +1247,31 @@ function balanceUpdate(request: { balance: string; sequence: number }) {
       balance: request.balance,
       value: request.balance,
     },
+    sq: request.sequence,
+    ts: 1_700_000_000_000,
+  };
+}
+
+function fillsUpdate(request: { sequence: number; tradeIds: number[] }) {
+  return {
+    ch: 'fills',
+    data: request.tradeIds.map((tid) => ({
+      coid: '550e8400e29b41d4a716446655440000',
+      fea: 'USDC',
+      fee: '1.25',
+      iid: 1,
+      liq: false,
+      oid: 123,
+      p: '100.00',
+      pep: '100.00',
+      pnl: '100.00',
+      psz: '26.86',
+      qty: '10.00',
+      side: 'long',
+      taker: true,
+      tid,
+      ts: 1_700_000_000_000,
+    })),
     sq: request.sequence,
     ts: 1_700_000_000_000,
   };

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -135,7 +135,7 @@ describe('PerpsSession', () => {
       await session.close();
     });
 
-    it('fans out batched fill frames into one event per fill', async () => {
+    it('emits one event for a batched fill frame', async () => {
       const connection = captureConnection(server, perps);
       const session = createSession();
 
@@ -147,16 +147,10 @@ describe('PerpsSession', () => {
         done: false,
         value: {
           channel: 'fills',
-          payload: { instrumentId: 1, side: 'long', tradeId: 1 },
-          sequence: 1,
-          type: 'fill',
-        },
-      });
-      await expect(waitForNextEvent(session)).resolves.toMatchObject({
-        done: false,
-        value: {
-          channel: 'fills',
-          payload: { instrumentId: 1, side: 'long', tradeId: 2 },
+          payload: [
+            { instrumentId: 1, side: 'long', tradeId: 1 },
+            { instrumentId: 1, side: 'long', tradeId: 2 },
+          ],
           sequence: 1,
           type: 'fill',
         },

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -19,7 +19,6 @@ import {
   type PerpsWithdrawal,
 } from '@polymarket/bindings/perps';
 import {
-  PerpsFillBatchEventSchema,
   type PerpsOrderUpdateEvent,
   type PerpsSessionEvent,
   PerpsSessionUpdateEventSchema,
@@ -838,20 +837,6 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   #handleMessage(rawMessage: unknown): void {
     if (this.#handleResponse(rawMessage)) return;
-
-    const fills = PerpsFillBatchEventSchema.safeParse(rawMessage);
-    if (fills.success) {
-      const [first] = fills.data;
-      if (first !== undefined) {
-        // Every fill in the batch shares the frame's channel and sequence, so
-        // the gap check runs once for the frame, not per fanned-out event.
-        this.#pushSequenceGapIfNeeded(first);
-        for (const event of fills.data) {
-          this.#emitEvent(event);
-        }
-      }
-      return;
-    }
 
     const parsed = PerpsSessionUpdateEventSchema.safeParse(rawMessage);
     if (!parsed.success) return;

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -19,6 +19,7 @@ import {
   type PerpsWithdrawal,
 } from '@polymarket/bindings/perps';
 import {
+  PerpsFillBatchEventSchema,
   type PerpsOrderUpdateEvent,
   type PerpsSessionEvent,
   PerpsSessionUpdateEventSchema,
@@ -837,6 +838,20 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   #handleMessage(rawMessage: unknown): void {
     if (this.#handleResponse(rawMessage)) return;
+
+    const fills = PerpsFillBatchEventSchema.safeParse(rawMessage);
+    if (fills.success) {
+      const [first] = fills.data;
+      if (first !== undefined) {
+        // Every fill in the batch shares the frame's channel and sequence, so
+        // the gap check runs once for the frame, not per fanned-out event.
+        this.#pushSequenceGapIfNeeded(first);
+        for (const event of fills.data) {
+          this.#emitEvent(event);
+        }
+      }
+      return;
+    }
 
     const parsed = PerpsSessionUpdateEventSchema.safeParse(rawMessage);
     if (!parsed.success) return;

--- a/packages/client/src/websockets/perps/subscription.test.ts
+++ b/packages/client/src/websockets/perps/subscription.test.ts
@@ -1,5 +1,4 @@
 import { PerpsKlineInterval } from '@polymarket/bindings/perps';
-import type { PerpsMarketDataEvent } from '@polymarket/bindings/subscriptions';
 import { ws } from 'msw';
 import { setupServer } from 'msw/node';
 import {
@@ -121,7 +120,7 @@ describe('PerpsSubscriptionManager', () => {
     });
   });
 
-  it('fans out batched trade frames into one event per trade', async () => {
+  it('emits one event for a batched trade frame', async () => {
     const connection = captureConnection(server, perpsSubscriptions);
 
     const handle = await manager.subscribe({
@@ -155,24 +154,18 @@ describe('PerpsSubscriptionManager', () => {
       ts: 1_700_000_000_002,
     });
 
-    const trades: PerpsMarketDataEvent[] = [];
     for await (const event of handle) {
-      trades.push(event);
-      if (trades.length === 2) break;
+      expect(event).toMatchObject({
+        payload: [
+          { instrumentId: 1, price: '100', side: 'long', tradeId: 1 },
+          { instrumentId: 1, price: '101', side: 'short', tradeId: 2 },
+        ],
+        sequence: 5,
+        topic: 'perps.trades',
+        type: 'trade',
+      });
+      break;
     }
-
-    expect(trades).toMatchObject([
-      {
-        payload: { instrumentId: 1, price: '100', side: 'long', tradeId: 1 },
-        topic: 'perps.trades',
-        type: 'trade',
-      },
-      {
-        payload: { instrumentId: 1, price: '101', side: 'short', tradeId: 2 },
-        topic: 'perps.trades',
-        type: 'trade',
-      },
-    ]);
   });
 
   it('reconnects and resubscribes active channels after an unexpected close', {

--- a/packages/client/src/websockets/perps/subscription.test.ts
+++ b/packages/client/src/websockets/perps/subscription.test.ts
@@ -1,4 +1,5 @@
 import { PerpsKlineInterval } from '@polymarket/bindings/perps';
+import type { PerpsMarketDataEvent } from '@polymarket/bindings/subscriptions';
 import { ws } from 'msw';
 import { setupServer } from 'msw/node';
 import {
@@ -118,6 +119,60 @@ describe('PerpsSubscriptionManager', () => {
         type: 'book',
       },
     });
+  });
+
+  it('fans out batched trade frames into one event per trade', async () => {
+    const connection = captureConnection(server, perpsSubscriptions);
+
+    const handle = await manager.subscribe({
+      instrumentId: 1,
+      topic: 'perps.trades',
+    });
+
+    await connection.send({
+      ch: 'trades::1',
+      data: [
+        {
+          tid: 1,
+          iid: 1,
+          side: 'long',
+          p: '100',
+          qty: '1',
+          ts: 1_700_000_000_000,
+          hash: `0x${'a'.repeat(64)}`,
+        },
+        {
+          tid: 2,
+          iid: 1,
+          side: 'short',
+          p: '101',
+          qty: '2',
+          ts: 1_700_000_000_001,
+          hash: `0x${'b'.repeat(64)}`,
+        },
+      ],
+      sq: 5,
+      ts: 1_700_000_000_002,
+    });
+
+    const trades: PerpsMarketDataEvent[] = [];
+    for await (const event of handle) {
+      trades.push(event);
+      if (trades.length === 2) break;
+    }
+
+    expect(trades).toMatchObject([
+      {
+        payload: { instrumentId: 1, price: '100', side: 'long', tradeId: 1 },
+        topic: 'perps.trades',
+        type: 'trade',
+      },
+      {
+        payload: { instrumentId: 1, price: '101', side: 'short', tradeId: 2 },
+        topic: 'perps.trades',
+        type: 'trade',
+      },
+    ]);
   });
 
   it('reconnects and resubscribes active channels after an unexpected close', {

--- a/packages/client/src/websockets/perps/subscription.ts
+++ b/packages/client/src/websockets/perps/subscription.ts
@@ -1,7 +1,6 @@
 import {
   type PerpsMarketDataEvent,
   PerpsMarketDataEventSchema,
-  PerpsTradeBatchEventSchema,
 } from '@polymarket/bindings/subscriptions';
 import { invariant } from '@polymarket/types';
 import type {
@@ -139,17 +138,6 @@ export class PerpsSubscriptionManager
   }
 
   #onConnectionMessage(message: unknown): void {
-    // Trade frames carry a batch of trades in `data`, so they parse into an
-    // array of events. Try that shape first, then fall back to the
-    // single-event schemas that cover every other channel.
-    const trades = PerpsTradeBatchEventSchema.safeParse(message);
-    if (trades.success) {
-      for (const event of trades.data) {
-        this.#subscriptions.dispatch(event);
-      }
-      return;
-    }
-
     const parsed = PerpsMarketDataEventSchema.safeParse(message);
     if (!parsed.success) return;
     this.#subscriptions.dispatch(parsed.data);
@@ -285,6 +273,9 @@ function matcherFor(
 ): (event: PerpsMarketDataEvent) => boolean {
   switch (subscription.topic) {
     case 'perps.trades':
+      return (event) =>
+        event.topic === 'perps.trades' &&
+        event.channel === `trades::${subscription.instrumentId}`;
     case 'perps.bbo':
     case 'perps.book':
       return (event) =>

--- a/packages/client/src/websockets/perps/subscription.ts
+++ b/packages/client/src/websockets/perps/subscription.ts
@@ -1,6 +1,7 @@
 import {
   type PerpsMarketDataEvent,
   PerpsMarketDataEventSchema,
+  PerpsTradeBatchEventSchema,
 } from '@polymarket/bindings/subscriptions';
 import { invariant } from '@polymarket/types';
 import type {
@@ -138,6 +139,14 @@ export class PerpsSubscriptionManager
   }
 
   #onConnectionMessage(message: unknown): void {
+    const trades = PerpsTradeBatchEventSchema.safeParse(message);
+    if (trades.success) {
+      for (const event of trades.data) {
+        this.#subscriptions.dispatch(event);
+      }
+      return;
+    }
+
     const parsed = PerpsMarketDataEventSchema.safeParse(message);
     if (!parsed.success) return;
     this.#subscriptions.dispatch(parsed.data);

--- a/packages/client/src/websockets/perps/subscription.ts
+++ b/packages/client/src/websockets/perps/subscription.ts
@@ -139,6 +139,9 @@ export class PerpsSubscriptionManager
   }
 
   #onConnectionMessage(message: unknown): void {
+    // Trade frames carry a batch of trades in `data`, so they parse into an
+    // array of events. Try that shape first, then fall back to the
+    // single-event schemas that cover every other channel.
     const trades = PerpsTradeBatchEventSchema.safeParse(message);
     if (trades.success) {
       for (const event of trades.data) {


### PR DESCRIPTION
## Summary

- Support `trades::<instrumentId>` frames whose `data` contains a list of trades.
- Emit one SDK event per WebSocket frame with the trade list as its payload.
- Match trade subscriptions by channel now that the payload is a list.
- Add regression coverage for a frame containing multiple trades.

The Perps producer intentionally emits one list-based frame for all trades produced by an `UpdateBook` event. The previous single-trade schema rejected these frames, so subscriptions silently dropped them.

## Verification

- `pnpm --filter @polymarket/bindings build`
- targeted Perps subscription tests
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Event payload types change from a single trade/fill object to an array, which is a breaking contract for consumers that assumed scalar payloads; behavior fix is localized to Perps WebSocket parsing and matching.
> 
> **Overview**
> Fixes Perps WebSocket parsing and routing when the server sends **list-shaped** `data` on public **trades** and session **fills** channels (one SDK event per frame, with the full list as `payload`).
> 
> **Bindings** now validate `data` as `z.array(...)` for `PerpsTradeEventSchema` and `PerpsFillUpdateEventSchema` instead of a single object, so batched producer frames are no longer rejected and dropped.
> 
> **Client** trade subscriptions match on `event.channel === trades::<instrumentId>` because trade `payload` is no longer a single record with `instrumentId`. Regression tests cover multi-trade and multi-fill frames.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea3e62582ff7eebc3c9393ac74b09a47b5d9d0e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->