### PR TITLE
fix(bindings): support batched Perps fill frames

### DIFF
--- a/.changeset/perps-session-fills-array-frames.md
+++ b/.changeset/perps-session-fills-array-frames.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Fix Perps session dropping every fill event. The private `fills` channel delivers all fills from a single match event as a batch in `data`, but the session event schema only accepted a single object, so `safeParse` failed and no fill events were emitted while order, balance, and portfolio events arrived normally. Fill frames are now fanned out into one event per fill.
+Fix Perps sessions dropping every fill event. The private `fills` channel delivers all fills from a single match event as a batch in `data`, but the session event schema only accepted a single object, so `safeParse` failed and no fill events were emitted while order, balance, and portfolio events arrived normally. Each frame is now emitted as one event whose payload is the list of fills.

--- a/.changeset/perps-session-fills-array-frames.md
+++ b/.changeset/perps-session-fills-array-frames.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Fix Perps session dropping every fill event. The private `fills` channel delivers all fills from a single match event as a batch in `data`, but the session event schema only accepted a single object, so `safeParse` failed and no fill events were emitted while order, balance, and portfolio events arrived normally. Fill frames are now fanned out into one event per fill.

--- a/.changeset/perps-session-fills-array-frames.md
+++ b/.changeset/perps-session-fills-array-frames.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Fix Perps sessions dropping every fill event. The private `fills` channel delivers all fills from a single match event as a batch in `data`, but the session event schema only accepted a single object, so `safeParse` failed and no fill events were emitted while order, balance, and portfolio events arrived normally. Each frame is now emitted as one event whose payload is the list of fills.
+Support Perps fills frames containing a list of fills.

--- a/packages/bindings/src/subscriptions/perps.ts
+++ b/packages/bindings/src/subscriptions/perps.ts
@@ -217,6 +217,26 @@ export const PerpsFillUpdateEventSchema = perpsSessionEventSchema(
 );
 export type PerpsFillUpdateEvent = z.infer<typeof PerpsFillUpdateEventSchema>;
 
+/**
+ * A `fills` frame carries every fill produced by a single match event as a
+ * batch in `data`, unlike the single-object payloads on the other session
+ * channels. This schema validates that batch envelope and fans it out into one
+ * {@link PerpsFillUpdateEvent} per fill so consumers observe individual fills.
+ */
+export const PerpsFillBatchEventSchema =
+  PerpsSessionUpdateEnvelopeSchema.extend({
+    ch: z.literal('fills'),
+    data: z.array(PerpsAccountFillUpdateSchema),
+  }).transform(({ ch, ts, sq, data }) =>
+    data.map<PerpsFillUpdateEvent>((payload) => ({
+      type: 'fill' as const,
+      channel: ch,
+      timestamp: ts,
+      sequence: sq,
+      payload,
+    })),
+  );
+
 export const PerpsFundingUpdateEventSchema = perpsSessionEventSchema(
   'funding',
   'funding',

--- a/packages/bindings/src/subscriptions/perps.ts
+++ b/packages/bindings/src/subscriptions/perps.ts
@@ -213,29 +213,9 @@ export type PerpsOrderUpdateEvent = z.infer<typeof PerpsOrderUpdateEventSchema>;
 export const PerpsFillUpdateEventSchema = perpsSessionEventSchema(
   'fill',
   'fills',
-  PerpsAccountFillUpdateSchema,
+  z.array(PerpsAccountFillUpdateSchema),
 );
 export type PerpsFillUpdateEvent = z.infer<typeof PerpsFillUpdateEventSchema>;
-
-/**
- * A `fills` frame carries every fill produced by a single match event as a
- * batch in `data`, unlike the single-object payloads on the other session
- * channels. This schema validates that batch envelope and fans it out into one
- * {@link PerpsFillUpdateEvent} per fill so consumers observe individual fills.
- */
-export const PerpsFillBatchEventSchema =
-  PerpsSessionUpdateEnvelopeSchema.extend({
-    ch: z.literal('fills'),
-    data: z.array(PerpsAccountFillUpdateSchema),
-  }).transform(({ ch, ts, sq, data }) =>
-    data.map<PerpsFillUpdateEvent>((payload) => ({
-      type: 'fill' as const,
-      channel: ch,
-      timestamp: ts,
-      sequence: sq,
-      payload,
-    })),
-  );
 
 export const PerpsFundingUpdateEventSchema = perpsSessionEventSchema(
   'funding',

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -134,6 +134,36 @@ describe('PerpsSession', () => {
 
       await session.close();
     });
+
+    it('fans out batched fill frames into one event per fill', async () => {
+      const connection = captureConnection(server, perps);
+      const session = createSession();
+
+      await session.connect();
+
+      await connection.send(fillsUpdate({ sequence: 1, tradeIds: [1, 2] }));
+
+      await expect(waitForNextEvent(session)).resolves.toMatchObject({
+        done: false,
+        value: {
+          channel: 'fills',
+          payload: { instrumentId: 1, side: 'long', tradeId: 1 },
+          sequence: 1,
+          type: 'fill',
+        },
+      });
+      await expect(waitForNextEvent(session)).resolves.toMatchObject({
+        done: false,
+        value: {
+          channel: 'fills',
+          payload: { instrumentId: 1, side: 'long', tradeId: 2 },
+          sequence: 1,
+          type: 'fill',
+        },
+      });
+
+      await session.close();
+    });
   });
 
   describe('reconnects', () => {
@@ -1217,6 +1247,31 @@ function balanceUpdate(request: { balance: string; sequence: number }) {
       balance: request.balance,
       value: request.balance,
     },
+    sq: request.sequence,
+    ts: 1_700_000_000_000,
+  };
+}
+
+function fillsUpdate(request: { sequence: number; tradeIds: number[] }) {
+  return {
+    ch: 'fills',
+    data: request.tradeIds.map((tid) => ({
+      coid: '550e8400e29b41d4a716446655440000',
+      fea: 'USDC',
+      fee: '1.25',
+      iid: 1,
+      liq: false,
+      oid: 123,
+      p: '100.00',
+      pep: '100.00',
+      pnl: '100.00',
+      psz: '26.86',
+      qty: '10.00',
+      side: 'long',
+      taker: true,
+      tid,
+      ts: 1_700_000_000_000,
+    })),
     sq: request.sequence,
     ts: 1_700_000_000_000,
   };

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -135,7 +135,7 @@ describe('PerpsSession', () => {
       await session.close();
     });
 
-    it('fans out batched fill frames into one event per fill', async () => {
+    it('emits one event for a batched fill frame', async () => {
       const connection = captureConnection(server, perps);
       const session = createSession();
 
@@ -147,16 +147,10 @@ describe('PerpsSession', () => {
         done: false,
         value: {
           channel: 'fills',
-          payload: { instrumentId: 1, side: 'long', tradeId: 1 },
-          sequence: 1,
-          type: 'fill',
-        },
-      });
-      await expect(waitForNextEvent(session)).resolves.toMatchObject({
-        done: false,
-        value: {
-          channel: 'fills',
-          payload: { instrumentId: 1, side: 'long', tradeId: 2 },
+          payload: [
+            { instrumentId: 1, side: 'long', tradeId: 1 },
+            { instrumentId: 1, side: 'long', tradeId: 2 },
+          ],
           sequence: 1,
           type: 'fill',
         },

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -19,7 +19,6 @@ import {
   type PerpsWithdrawal,
 } from '@polymarket/bindings/perps';
 import {
-  PerpsFillBatchEventSchema,
   type PerpsOrderUpdateEvent,
   type PerpsSessionEvent,
   PerpsSessionUpdateEventSchema,
@@ -838,20 +837,6 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   #handleMessage(rawMessage: unknown): void {
     if (this.#handleResponse(rawMessage)) return;
-
-    const fills = PerpsFillBatchEventSchema.safeParse(rawMessage);
-    if (fills.success) {
-      const [first] = fills.data;
-      if (first !== undefined) {
-        // Every fill in the batch shares the frame's channel and sequence, so
-        // the gap check runs once for the frame, not per fanned-out event.
-        this.#pushSequenceGapIfNeeded(first);
-        for (const event of fills.data) {
-          this.#emitEvent(event);
-        }
-      }
-      return;
-    }
 
     const parsed = PerpsSessionUpdateEventSchema.safeParse(rawMessage);
     if (!parsed.success) return;

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -19,6 +19,7 @@ import {
   type PerpsWithdrawal,
 } from '@polymarket/bindings/perps';
 import {
+  PerpsFillBatchEventSchema,
   type PerpsOrderUpdateEvent,
   type PerpsSessionEvent,
   PerpsSessionUpdateEventSchema,
@@ -837,6 +838,20 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   #handleMessage(rawMessage: unknown): void {
     if (this.#handleResponse(rawMessage)) return;
+
+    const fills = PerpsFillBatchEventSchema.safeParse(rawMessage);
+    if (fills.success) {
+      const [first] = fills.data;
+      if (first !== undefined) {
+        // Every fill in the batch shares the frame's channel and sequence, so
+        // the gap check runs once for the frame, not per fanned-out event.
+        this.#pushSequenceGapIfNeeded(first);
+        for (const event of fills.data) {
+          this.#emitEvent(event);
+        }
+      }
+      return;
+    }
 
     const parsed = PerpsSessionUpdateEventSchema.safeParse(rawMessage);
     if (!parsed.success) return;


### PR DESCRIPTION
## Summary

- Support `fills` frames whose `data` contains a list of fills.
- Emit one SDK event per WebSocket frame with the fill list as its payload.
- Keep sequence-gap handling at the frame level.
- Add regression coverage for a frame containing multiple fills.

The Perps producer intentionally emits one list-based frame for all fills produced by an `UpdateBook` event. The previous single-fill schema rejected these frames, so sessions silently dropped them.

This PR is stacked on #194 so the public trades and authenticated fills changes can be merged together while remaining independently reviewable.

## Verification

- `pnpm --filter @polymarket/bindings build`
- combined Perps subscription and session tests (31 passed)
- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public shape of fill session events from a single object to an array, which can break consumers that assumed one fill per event; behavior fix is limited to subscription parsing and tests.
> 
> **Overview**
> **Perps session `fills` WebSocket frames** can carry multiple fills in `data`; the bindings schema now accepts **`z.array(PerpsAccountFillUpdateSchema)`** instead of a single fill, so list-based frames from `UpdateBook` are parsed instead of rejected and dropped.
> 
> The SDK still emits **one `fill` event per frame**, with **`payload` as an array of fills**; frame-level **sequence** handling is unchanged. A **session test** asserts a batched frame maps to one event with two fills in the payload. Patch bumps are noted in the changeset for `@polymarket/bindings` and `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c750fdef5751647048d5c7fe2426798288406e46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->