### PR TITLE
fix(rfq): keep sessions open for new error codes

### DIFF
--- a/.changeset/tidy-rfq-errors.md
+++ b/.changeset/tidy-rfq-errors.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Keep RFQ quoter sessions connected when the server returns new error codes and surface terminal websocket failures through the session iterator.

--- a/.changeset/tidy-rfq-errors.md
+++ b/.changeset/tidy-rfq-errors.md
@@ -3,4 +3,7 @@
 "@polymarket/client": patch
 ---
 
-Keep RFQ quoter sessions connected when the server returns new error codes and surface terminal websocket failures through the session iterator.
+Harden RFQ quoter sessions:
+
+- Unknown error codes no longer fail the session; they flow through as plain strings via the now-open `RfqErrorCode` type (known codes moved to `RfqKnownErrorCode`).
+- Unsolicited connection loss now fails in-flight operations and the session iterator with the new `ConnectionLostError`, carrying the close `code` and `reason`.

--- a/packages/bindings/src/rfq.test.ts
+++ b/packages/bindings/src/rfq.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { RfqErrorCode, RfqQuoterInboundMessageSchema } from './rfq';
+import { RfqKnownErrorCode, RfqQuoterInboundMessageSchema } from './rfq';
 
 describe('RFQ quoter inbound messages', () => {
   it('parses confirmed trade broadcasts without maker identity', () => {
@@ -38,12 +38,12 @@ describe('RFQ quoter inbound messages', () => {
     });
 
     expect(message).toMatchObject({
-      code: RfqErrorCode.QuoteValidationTimeoutInternal,
+      code: RfqKnownErrorCode.QuoteValidationTimeoutInternal,
       type: 'rfq_error',
     });
   });
 
-  it('keeps unknown RFQ error codes forward compatible', () => {
+  it('passes unknown RFQ error codes through as strings', () => {
     const message = RfqQuoterInboundMessageSchema.parse({
       type: 'RFQ_ERROR',
       request_type: 'RFQ_QUOTE',
@@ -53,7 +53,7 @@ describe('RFQ quoter inbound messages', () => {
     });
 
     expect(message).toMatchObject({
-      code: undefined,
+      code: 'FUTURE_ERROR_CODE',
       type: 'rfq_error',
     });
   });

--- a/packages/bindings/src/rfq.test.ts
+++ b/packages/bindings/src/rfq.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { RfqQuoterInboundMessageSchema } from './rfq';
+import { RfqErrorCode, RfqQuoterInboundMessageSchema } from './rfq';
 
 describe('RFQ quoter inbound messages', () => {
   it('parses confirmed trade broadcasts without maker identity', () => {
@@ -26,5 +26,35 @@ describe('RFQ quoter inbound messages', () => {
     });
     expect(message).not.toHaveProperty('makerAddress');
     expect(message).not.toHaveProperty('txHash');
+  });
+
+  it('parses known RFQ error codes', () => {
+    const message = RfqQuoterInboundMessageSchema.parse({
+      type: 'RFQ_ERROR',
+      request_type: 'RFQ_QUOTE',
+      rfq_id: 'rfq-1',
+      code: 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
+      error: 'quote validation timed out',
+    });
+
+    expect(message).toMatchObject({
+      code: RfqErrorCode.QuoteValidationTimeoutInternal,
+      type: 'rfq_error',
+    });
+  });
+
+  it('keeps unknown RFQ error codes forward compatible', () => {
+    const message = RfqQuoterInboundMessageSchema.parse({
+      type: 'RFQ_ERROR',
+      request_type: 'RFQ_QUOTE',
+      rfq_id: 'rfq-1',
+      code: 'FUTURE_ERROR_CODE',
+      error: 'future request failed',
+    });
+
+    expect(message).toMatchObject({
+      code: undefined,
+      type: 'rfq_error',
+    });
   });
 });

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -87,9 +87,11 @@ export enum RfqErrorCode {
   LegMetadataUnavailable = 'LEG_METADATA_UNAVAILABLE',
   MakerAlreadyResponded = 'MAKER_ALREADY_RESPONDED',
   MakerNotRequired = 'MAKER_NOT_REQUIRED',
+  MakerQuoteLimited = 'MAKER_QUOTE_LIMITED',
   PreExecutionBalanceReservationFailed = 'PRE_EXECUTION_BALANCE_RESERVATION_FAILED',
   QuoteMismatch = 'QUOTE_MISMATCH',
   QuoteUnavailable = 'QUOTE_UNAVAILABLE',
+  QuoteValidationTimeoutInternal = 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
   RateLimited = 'RATE_LIMITED',
   RequestFailed = 'REQUEST_FAILED',
   ServiceUnavailable = 'SERVICE_UNAVAILABLE',
@@ -106,6 +108,13 @@ export const RfqConfirmationDecisionSchema = z.enum(RfqConfirmationDecision);
 export const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
 export const RfqRequestedSizeUnitSchema = z.enum(RfqRequestedSizeUnit);
 export const RfqErrorCodeSchema = z.enum(RfqErrorCode);
+
+// Error codes evolve independently of released clients. Unknown codes remain
+// operation-level failures instead of invalidating a long-lived RFQ session.
+const RfqWireErrorCodeSchema = z.string().transform((value) => {
+  const parsed = RfqErrorCodeSchema.safeParse(value);
+  return parsed.success ? parsed.data : undefined;
+});
 
 export type ComboMarket = {
   id: MarketId;
@@ -471,7 +480,7 @@ export const RfqErrorMessageSchema = RfqKnownInboundMessageSchema.extend({
   request_type: z.string().optional(),
   rfq_id: RfqIdSchema.optional(),
   quote_id: RfqQuoteIdSchema.optional(),
-  code: RfqErrorCodeSchema,
+  code: RfqWireErrorCodeSchema,
   error: z.string(),
   request: z.unknown().optional(),
 }).transform((message) => ({

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -67,7 +67,7 @@ export enum RfqRequestedSizeUnit {
   Shares = 'shares',
 }
 
-export enum RfqErrorCode {
+export enum RfqKnownErrorCode {
   AddressMismatch = 'ADDRESS_MISMATCH',
   AllowanceValidationFailed = 'ALLOWANCE_VALIDATION_FAILED',
   BalanceValidationFailed = 'BALANCE_VALIDATION_FAILED',
@@ -102,19 +102,27 @@ export enum RfqErrorCode {
   UnknownRfq = 'UNKNOWN_RFQ',
 }
 
-export const RfqDirectionSchema = z.enum(RfqDirection);
-export const RfqSideSchema = z.literal(RfqSide.Yes);
-export const RfqConfirmationDecisionSchema = z.enum(RfqConfirmationDecision);
-export const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
-export const RfqRequestedSizeUnitSchema = z.enum(RfqRequestedSizeUnit);
-export const RfqErrorCodeSchema = z.enum(RfqErrorCode);
+/**
+ * An RFQ error code. Known codes are enumerated in {@link RfqKnownErrorCode};
+ * newly introduced codes flow through as plain strings so they can be handled
+ * before a client release that enumerates them.
+ */
+export type RfqErrorCode = RfqKnownErrorCode | (string & {});
 
-// Error codes evolve independently of released clients. Unknown codes remain
-// operation-level failures instead of invalidating a long-lived RFQ session.
-const RfqWireErrorCodeSchema = z.string().transform((value) => {
-  const parsed = RfqErrorCodeSchema.safeParse(value);
-  return parsed.success ? parsed.data : undefined;
-});
+/**
+ * @deprecated Use {@link RfqKnownErrorCode} instead. This alias will be
+ * removed at the end of the beta phase.
+ */
+export const RfqErrorCode = RfqKnownErrorCode;
+
+const RfqDirectionSchema = z.enum(RfqDirection);
+const RfqSideSchema = z.literal(RfqSide.Yes);
+const RfqConfirmationDecisionSchema = z.enum(RfqConfirmationDecision);
+const RfqExecutionStatusSchema = z.enum(RfqExecutionStatus);
+
+// Error codes evolve independently of released clients. Codes not yet
+// enumerated in RfqKnownErrorCode must still parse and flow through as-is.
+const RfqErrorCodeSchema = z.string().transform((value): RfqErrorCode => value);
 
 export type ComboMarket = {
   id: MarketId;
@@ -138,7 +146,7 @@ export type ComboMarketOutcomes = {
   no: ComboMarketOutcome;
 };
 
-export const ComboMarketSchema = z
+const ComboMarketSchema = z
   .object({
     id: MarketIdSchema,
     condition_id: CtfConditionIdSchema,
@@ -291,21 +299,19 @@ export const RfqKnownInboundMessageSchema = z.object({
   type: z.enum(RfqKnownInboundType),
 });
 
-export const RfqAuthResponseMessageSchema = RfqKnownInboundMessageSchema.extend(
-  {
-    type: z.literal(RfqKnownInboundType.Auth),
-    success: z.boolean(),
-    address: EvmAddressSchema.optional(),
-    role: z.string().optional(),
-    error: z.string().optional(),
-  },
-);
+const RfqAuthResponseMessageSchema = RfqKnownInboundMessageSchema.extend({
+  type: z.literal(RfqKnownInboundType.Auth),
+  success: z.boolean(),
+  address: EvmAddressSchema.optional(),
+  role: z.string().optional(),
+  error: z.string().optional(),
+});
 
 export type RfqAuthResponseMessage = z.infer<
   typeof RfqAuthResponseMessageSchema
 >;
 
-export const RfqQuoteRequestSchema = RfqKnownInboundMessageSchema.extend({
+const RfqQuoteRequestSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.QuoteRequest),
   rfq_id: RfqIdSchema,
   requestor_public_id: RfqRequestorPublicIdSchema,
@@ -349,7 +355,7 @@ export type RfqQuoteCancelMessage = {
   maker_address: EvmAddress;
 };
 
-export const RfqQuoteAckSchema = RfqKnownInboundMessageSchema.extend({
+const RfqQuoteAckSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.QuoteAck),
   rfq_id: RfqIdSchema,
   quote_id: RfqQuoteIdSchema,
@@ -361,7 +367,7 @@ export const RfqQuoteAckSchema = RfqKnownInboundMessageSchema.extend({
 
 export type RfqQuoteAck = z.infer<typeof RfqQuoteAckSchema>;
 
-export const RfqQuoteCancelAckSchema = RfqKnownInboundMessageSchema.extend({
+const RfqQuoteCancelAckSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.QuoteCancelAck),
   rfq_id: RfqIdSchema,
   quote_id: RfqQuoteIdSchema,
@@ -373,25 +379,23 @@ export const RfqQuoteCancelAckSchema = RfqKnownInboundMessageSchema.extend({
 
 export type RfqQuoteCancelAck = z.infer<typeof RfqQuoteCancelAckSchema>;
 
-export const RfqConfirmationRequestSchema = RfqKnownInboundMessageSchema.extend(
-  {
-    type: z.literal(RfqKnownInboundType.ConfirmationRequest),
-    rfq_id: RfqIdSchema,
-    quote_id: RfqQuoteIdSchema,
-    signer_address: EvmAddressSchema,
-    maker_address: EvmAddressSchema,
-    signature_type: SignatureTypeSchema,
-    leg_position_ids: z.array(PositionIdSchema),
-    condition_id: ComboConditionIdSchema,
-    yes_position_id: PositionIdSchema,
-    no_position_id: PositionIdSchema,
-    direction: RfqDirectionSchema,
-    side: RfqSideSchema,
-    fill_size_e6: E6BigIntStringToDecimalStringSchema,
-    price_e6: E6BigIntStringToDecimalStringSchema,
-    confirm_by: EpochMillisecondsSchema,
-  },
-).transform((message) => ({
+const RfqConfirmationRequestSchema = RfqKnownInboundMessageSchema.extend({
+  type: z.literal(RfqKnownInboundType.ConfirmationRequest),
+  rfq_id: RfqIdSchema,
+  quote_id: RfqQuoteIdSchema,
+  signer_address: EvmAddressSchema,
+  maker_address: EvmAddressSchema,
+  signature_type: SignatureTypeSchema,
+  leg_position_ids: z.array(PositionIdSchema),
+  condition_id: ComboConditionIdSchema,
+  yes_position_id: PositionIdSchema,
+  no_position_id: PositionIdSchema,
+  direction: RfqDirectionSchema,
+  side: RfqSideSchema,
+  fill_size_e6: E6BigIntStringToDecimalStringSchema,
+  price_e6: E6BigIntStringToDecimalStringSchema,
+  confirm_by: EpochMillisecondsSchema,
+}).transform((message) => ({
   conditionId: message.condition_id,
   confirmBy: message.confirm_by,
   direction: message.direction,
@@ -420,7 +424,7 @@ export type RfqConfirmationResponseMessage = {
   decision: RfqConfirmationDecision;
 };
 
-export const RfqConfirmationAckSchema = RfqKnownInboundMessageSchema.extend({
+const RfqConfirmationAckSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.ConfirmationAck),
   rfq_id: RfqIdSchema,
   quote_id: RfqQuoteIdSchema,
@@ -434,7 +438,7 @@ export const RfqConfirmationAckSchema = RfqKnownInboundMessageSchema.extend({
 
 export type RfqConfirmationAck = z.infer<typeof RfqConfirmationAckSchema>;
 
-export const RfqExecutionUpdateSchema = RfqKnownInboundMessageSchema.extend({
+const RfqExecutionUpdateSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.ExecutionUpdate),
   rfq_id: RfqIdSchema,
   status: RfqExecutionStatusSchema,
@@ -448,7 +452,7 @@ export const RfqExecutionUpdateSchema = RfqKnownInboundMessageSchema.extend({
 
 export type RfqExecutionUpdate = z.infer<typeof RfqExecutionUpdateSchema>;
 
-export const RfqTradeSchema = RfqKnownInboundMessageSchema.extend({
+const RfqTradeSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.Trade),
   rfq_id: RfqIdSchema,
   requester_id: RfqRequestorPublicIdSchema,
@@ -474,13 +478,13 @@ export const RfqTradeSchema = RfqKnownInboundMessageSchema.extend({
 
 export type RfqTrade = z.infer<typeof RfqTradeSchema>;
 
-export const RfqErrorMessageSchema = RfqKnownInboundMessageSchema.extend({
+const RfqErrorMessageSchema = RfqKnownInboundMessageSchema.extend({
   type: z.literal(RfqKnownInboundType.Error),
   error_id: z.string().optional(),
   request_type: z.string().optional(),
   rfq_id: RfqIdSchema.optional(),
   quote_id: RfqQuoteIdSchema.optional(),
-  code: RfqWireErrorCodeSchema,
+  code: RfqErrorCodeSchema,
   error: z.string(),
   request: z.unknown().optional(),
 }).transform((message) => ({

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -16,6 +16,7 @@ import type {
 import { PolymarketError } from '@polymarket/types';
 import type { BaseSecureClient } from '../clients';
 import {
+  ConnectionLostError,
   makeErrorGuard,
   SigningError,
   TimeoutError,
@@ -28,6 +29,7 @@ export {
   RfqDirection,
   RfqErrorCode,
   RfqExecutionStatus,
+  RfqKnownErrorCode,
   RfqRequestedSizeUnit,
   RfqSide,
 } from '@polymarket/bindings/rfq';
@@ -122,12 +124,14 @@ export class RfqQuoteRejectedError extends PolymarketError {
 }
 
 export type RfqQuoteError =
+  | ConnectionLostError
   | RfqQuoteRejectedError
   | SigningError
   | TimeoutError
   | TransportError
   | UserInputError;
 export const RfqQuoteError = makeErrorGuard(
+  ConnectionLostError,
   RfqQuoteRejectedError,
   SigningError,
   TimeoutError,
@@ -170,10 +174,12 @@ export class RfqCancelQuoteRejectedError extends PolymarketError {
 }
 
 export type RfqCancelQuoteError =
+  | ConnectionLostError
   | RfqCancelQuoteRejectedError
   | TimeoutError
   | TransportError;
 export const RfqCancelQuoteError = makeErrorGuard(
+  ConnectionLostError,
   RfqCancelQuoteRejectedError,
   TimeoutError,
   TransportError,
@@ -214,10 +220,12 @@ export class RfqConfirmationRejectedError extends PolymarketError {
 }
 
 export type RfqConfirmationError =
+  | ConnectionLostError
   | RfqConfirmationRejectedError
   | TimeoutError
   | TransportError;
 export const RfqConfirmationError = makeErrorGuard(
+  ConnectionLostError,
   RfqConfirmationRejectedError,
   TimeoutError,
   TransportError,
@@ -331,8 +339,11 @@ export interface RfqSession extends AsyncIterable<RfqEvent> {
   close(): Promise<void>;
 }
 
-export type OpenRfqSessionError = TransportError;
-export const OpenRfqSessionError = makeErrorGuard(TransportError);
+export type OpenRfqSessionError = ConnectionLostError | TransportError;
+export const OpenRfqSessionError = makeErrorGuard(
+  ConnectionLostError,
+  TransportError,
+);
 
 /**
  * Opens an RFQ event session.

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -33,6 +33,7 @@ export {
   RfqDirection,
   RfqErrorCode,
   RfqExecutionStatus,
+  RfqKnownErrorCode,
   RfqQuoteError,
   RfqQuoteRejectedError,
   RfqRequestedSizeUnit,

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -66,6 +66,61 @@ export class TransportError extends PolymarketError {
   }
 }
 
+/**
+ * WebSocket close codes defined by RFC 6455 and the IANA WebSocket Close Code
+ * Number registry. Codes 4000-4999 are reserved for application use and are
+ * intentionally not modeled here.
+ */
+export enum WebSocketKnownCloseCode {
+  NormalClosure = 1000,
+  GoingAway = 1001,
+  ProtocolError = 1002,
+  UnsupportedData = 1003,
+  /** Synthesized locally when the peer closed without a status code. */
+  NoStatusReceived = 1005,
+  /** Synthesized locally when the connection dropped without a close frame. */
+  AbnormalClosure = 1006,
+  InvalidFramePayload = 1007,
+  PolicyViolation = 1008,
+  MessageTooBig = 1009,
+  InternalError = 1011,
+  ServiceRestart = 1012,
+  TryAgainLater = 1013,
+}
+
+/**
+ * A WebSocket close code. Codes enumerated in
+ * {@link WebSocketKnownCloseCode} are defined by RFC 6455; other values, such
+ * as application-defined 4000-4999 codes, flow through as plain numbers.
+ */
+export type WebSocketCloseCode = WebSocketKnownCloseCode | (number & {});
+
+export type ConnectionLostErrorOptions = {
+  /** WebSocket close code reported for the lost connection. */
+  code: WebSocketCloseCode;
+  /** Close reason provided by the peer. Empty when none was sent. */
+  reason: string;
+};
+
+/**
+ * Error thrown when a live connection ends without the SDK requesting it.
+ */
+export class ConnectionLostError extends PolymarketError {
+  override name = 'ConnectionLostError' as const;
+
+  readonly code: WebSocketCloseCode;
+  readonly reason: string;
+
+  constructor(
+    message: string,
+    options: ErrorOptions & ConnectionLostErrorOptions,
+  ) {
+    super(message, options);
+    this.code = options.code;
+    this.reason = options.reason;
+  }
+}
+
 export type RequestRejectedErrorOptions = {
   status: number;
 };

--- a/packages/client/src/websockets/clob/market.ts
+++ b/packages/client/src/websockets/clob/market.ts
@@ -126,7 +126,7 @@ export class ClobMarketWebSocketManager
 
   #connect(): Promise<WebSocketConnectionResult> {
     return this.#connection.connect({
-      onClose: () => this.#onConnectionClose(),
+      onConnectionLost: () => this.#onConnectionLost(),
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: () => this.#onConnectionOpen(),
@@ -149,7 +149,7 @@ export class ClobMarketWebSocketManager
     }
   }
 
-  #onConnectionClose(): void {
+  #onConnectionLost(): void {
     if (this.#subscriptions.hasActiveSubscriptions()) {
       this.#scheduleReconnect();
     }

--- a/packages/client/src/websockets/clob/user.ts
+++ b/packages/client/src/websockets/clob/user.ts
@@ -124,7 +124,7 @@ export class ClobUserWebSocketManager
 
   #connect(): Promise<WebSocketConnectionResult> {
     return this.#connection.connect({
-      onClose: () => this.#onConnectionClose(),
+      onConnectionLost: () => this.#onConnectionLost(),
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: (credentials) => this.#onConnectionOpen(credentials),
@@ -148,7 +148,7 @@ export class ClobUserWebSocketManager
     }
   }
 
-  #onConnectionClose(): void {
+  #onConnectionLost(): void {
     if (this.#subscriptions.hasActiveSubscriptions()) {
       this.#scheduleReconnect();
     }

--- a/packages/client/src/websockets/lifecycle.test.ts
+++ b/packages/client/src/websockets/lifecycle.test.ts
@@ -39,7 +39,7 @@ describe('WebSocketConnection', () => {
 
     await connection.connect({
       headers: { 'x-preprod-access': 'token' },
-      onClose: () => undefined,
+      onConnectionLost: () => undefined,
       onError: () => undefined,
       onMessage: () => undefined,
       onOpen: () => undefined,

--- a/packages/client/src/websockets/lifecycle.ts
+++ b/packages/client/src/websockets/lifecycle.ts
@@ -2,7 +2,11 @@ import {
   setNonBlockingInterval,
   setNonBlockingTimeout,
 } from '@polymarket/types';
-import { TransportError } from '../errors';
+import {
+  TransportError,
+  type WebSocketCloseCode,
+  WebSocketKnownCloseCode,
+} from '../errors';
 
 export type WebSocketHeartbeat = {
   handleMessage(message: string): boolean;
@@ -20,9 +24,14 @@ export type ScheduleReconnectOptions = {
   reconnect: () => Promise<unknown>;
 };
 
+export type WebSocketCloseInfo = {
+  code: WebSocketCloseCode;
+  reason: string;
+};
+
 export type WebSocketConnectionOptions<TContext = undefined> = {
   headers?: Record<string, string>;
-  onClose: (event: CloseEvent) => void;
+  onConnectionLost: (info: WebSocketCloseInfo) => void;
   onError: () => void;
   onMessage: (message: unknown) => void;
   onOpen: (context: TContext) => void;
@@ -179,7 +188,10 @@ export class WebSocketConnection {
       socket.addEventListener('close', (event) => {
         if (this.#socket !== socket) return;
         this.#clearCurrentSocket();
-        options.onClose(event);
+        options.onConnectionLost({
+          code: event.code || WebSocketKnownCloseCode.NoStatusReceived,
+          reason: event.reason ?? '',
+        });
       });
       socket.addEventListener('error', () => options.onError());
     });

--- a/packages/client/src/websockets/lifecycle.ts
+++ b/packages/client/src/websockets/lifecycle.ts
@@ -22,7 +22,7 @@ export type ScheduleReconnectOptions = {
 
 export type WebSocketConnectionOptions<TContext = undefined> = {
   headers?: Record<string, string>;
-  onClose: () => void;
+  onClose: (event: CloseEvent) => void;
   onError: () => void;
   onMessage: (message: unknown) => void;
   onOpen: (context: TContext) => void;
@@ -176,10 +176,10 @@ export class WebSocketConnection {
         }
         options.onMessage(raw);
       });
-      socket.addEventListener('close', () => {
+      socket.addEventListener('close', (event) => {
         if (this.#socket !== socket) return;
         this.#clearCurrentSocket();
-        options.onClose();
+        options.onClose(event);
       });
       socket.addEventListener('error', () => options.onError());
     });

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -692,7 +692,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   async #connect(emitResync: boolean): Promise<void> {
     await this.#connection.connect({
-      onClose: () => this.#handleClose(),
+      onConnectionLost: () => this.#handleConnectionLost(),
       onError: () => undefined,
       onMessage: (message) => this.#handleMessage(message),
       onOpen: () => undefined,
@@ -876,7 +876,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     return true;
   }
 
-  #handleClose(): void {
+  #handleConnectionLost(): void {
     this.#rejectPending(new TransportError('Perps session connection closed.'));
     this.#rejectEventWaiters(
       new TransportError('Perps session connection closed.'),

--- a/packages/client/src/websockets/perps/subscription.ts
+++ b/packages/client/src/websockets/perps/subscription.ts
@@ -123,7 +123,7 @@ export class PerpsSubscriptionManager
 
   #connect(): Promise<WebSocketConnectionResult> {
     return this.#connection.connect({
-      onClose: () => this.#onConnectionClose(),
+      onConnectionLost: () => this.#onConnectionLost(),
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: () => this.#onConnectionOpen(),
@@ -143,7 +143,7 @@ export class PerpsSubscriptionManager
     this.#subscriptions.dispatch(parsed.data);
   }
 
-  #onConnectionClose(): void {
+  #onConnectionLost(): void {
     if (this.#subscriptions.hasActiveSubscriptions()) {
       this.#scheduleReconnect();
     }

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -24,10 +24,10 @@ import {
   RfqConfirmationRejectedError,
   RfqQuoteRejectedError,
 } from '../../actions/rfq';
-import { TransportError } from '../../errors';
+import { ConnectionLostError, TransportError } from '../../errors';
 import type { Signer } from '../../types';
 import type { AccountIdentity } from '../../wallet';
-import { WebSocketConnection } from '../lifecycle';
+import { type WebSocketCloseInfo, WebSocketConnection } from '../lifecycle';
 import {
   type RfqEventController,
   toConfirmationAck,
@@ -211,7 +211,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
     try {
       await this.#connection.connect({
         headers: this.#headers,
-        onClose: (event) => this.#handleClose(event),
+        onConnectionLost: (info) => this.#handleConnectionLost(info),
         onError: () => undefined,
         onMessage: (message) => this.#handleMessage(message),
         onOpen: () => this.#sendAuthMessage(),
@@ -333,13 +333,9 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
     );
   }
 
-  #handleClose(event: CloseEvent): void {
-    const suffix = event.reason === '' ? '' : `: ${event.reason}`;
+  #handleConnectionLost(info: WebSocketCloseInfo): void {
     void this.#fail(
-      new TransportError(
-        `RFQ quoter websocket closed with code ${event.code}${suffix}.`,
-        { cause: event },
-      ),
+      new ConnectionLostError('RFQ quoter connection lost.', info),
     );
   }
 

--- a/packages/client/src/websockets/rfq/quoter.ts
+++ b/packages/client/src/websockets/rfq/quoter.ts
@@ -211,7 +211,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
     try {
       await this.#connection.connect({
         headers: this.#headers,
-        onClose: () => this.#handleClose(),
+        onClose: (event) => this.#handleClose(event),
         onError: () => undefined,
         onMessage: (message) => this.#handleMessage(message),
         onOpen: () => this.#sendAuthMessage(),
@@ -243,7 +243,10 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
 
   async #shutdown(): Promise<void> {
     const error = new TransportError('RFQ quoter websocket closed.');
-    await this.#shutdownWithError(error);
+    this.#failPending(error);
+    this.#queue.end();
+    await this.#connection.close();
+    this.#onClose();
   }
 
   async #fail(error: Error): Promise<void> {
@@ -255,7 +258,7 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
 
   async #shutdownWithError(error: Error): Promise<void> {
     this.#failPending(error);
-    this.#queue.end();
+    this.#queue.end(error);
     await this.#connection.close();
     this.#onClose();
   }
@@ -330,9 +333,14 @@ class RfqWebSocketSession implements RfqSession, RfqEventController {
     );
   }
 
-  #handleClose(): void {
-    this.#onClose();
-    void this.close();
+  #handleClose(event: CloseEvent): void {
+    const suffix = event.reason === '' ? '' : `: ${event.reason}`;
+    void this.#fail(
+      new TransportError(
+        `RFQ quoter websocket closed with code ${event.code}${suffix}.`,
+        { cause: event },
+      ),
+    );
   }
 
   // Unsupported RFQ_ERROR request types are ignored for forward compatibility.

--- a/packages/client/src/websockets/rtds.ts
+++ b/packages/client/src/websockets/rtds.ts
@@ -135,7 +135,7 @@ export class RtdsWebSocketManager
 
   #connect(): Promise<WebSocketConnectionResult> {
     return this.#connection.connect({
-      onClose: () => this.#onConnectionClose(),
+      onConnectionLost: () => this.#onConnectionLost(),
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: () => this.#onConnectionOpen(),
@@ -155,7 +155,7 @@ export class RtdsWebSocketManager
     this.#subscriptions.dispatch(parsed.data);
   }
 
-  #onConnectionClose(): void {
+  #onConnectionLost(): void {
     if (this.#subscriptions.hasActiveSubscriptions()) {
       this.#scheduleReconnect();
     }

--- a/packages/client/src/websockets/sports.ts
+++ b/packages/client/src/websockets/sports.ts
@@ -106,7 +106,7 @@ export class SportsWebSocketManager
 
   #connect(): Promise<WebSocketConnectionResult> {
     return this.#connection.connect({
-      onClose: () => this.#onConnectionClose(),
+      onConnectionLost: () => this.#onConnectionLost(),
       onError: () => this.#onConnectionError(),
       onMessage: (message) => this.#onConnectionMessage(message),
       onOpen: () => this.#onConnectionOpen(),
@@ -125,7 +125,7 @@ export class SportsWebSocketManager
     this.#subscriptions.dispatch(parsed.data);
   }
 
-  #onConnectionClose(): void {
+  #onConnectionLost(): void {
     if (this.#subscriptions.hasActiveSubscriptions()) {
       this.#scheduleReconnect();
     }

--- a/packages/client/tests/integration/rfq-live.test.ts
+++ b/packages/client/tests/integration/rfq-live.test.ts
@@ -1,6 +1,6 @@
 import {
-  RfqErrorCode,
   RfqExecutionStatus,
+  RfqKnownErrorCode,
   RfqQuoteRejectedError,
 } from '@polymarket/client';
 import { describe, expect, it, runMeteredTests } from './fixtures';
@@ -49,8 +49,8 @@ describe('RFQ live quoting integration', () => {
 
                 if (
                   error instanceof RfqQuoteRejectedError &&
-                  (error.code === RfqErrorCode.SubmissionWindowClosed ||
-                    error.code === RfqErrorCode.UnknownRfq)
+                  (error.code === RfqKnownErrorCode.SubmissionWindowClosed ||
+                    error.code === RfqKnownErrorCode.UnknownRfq)
                 ) {
                   return;
                 }

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -1,9 +1,9 @@
 import {
+  ConnectionLostError,
   production,
-  RfqErrorCode,
+  RfqKnownErrorCode,
   SignatureType,
   TimeoutError,
-  TransportError,
   UserInputError,
 } from '@polymarket/client';
 import { ws } from 'msw';
@@ -691,7 +691,7 @@ describe('RFQ sessions', () => {
             const quote = event.quote({ price: 0.45 });
 
             await expect(quote).rejects.toMatchObject({
-              code: RfqErrorCode.QuoteValidationTimeoutInternal,
+              code: RfqKnownErrorCode.QuoteValidationTimeoutInternal,
               errorId: 'reqerr-1',
               message: 'quote validation timed out',
               name: 'RfqQuoteRejectedError',
@@ -752,7 +752,7 @@ describe('RFQ sessions', () => {
 
           if (requests === 1) {
             await expect(event.quote({ price: 0.45 })).rejects.toMatchObject({
-              code: undefined,
+              code: 'FUTURE_ERROR_CODE',
               message: 'future quote rejection',
               name: 'RfqQuoteRejectedError',
             });
@@ -1297,7 +1297,7 @@ describe('RFQ sessions', () => {
     });
   });
 
-  describe('when the connection closes before quote acknowledgement', () => {
+  describe('when the connection is lost before quote acknowledgement', () => {
     beforeEach(() => {
       server.resetHandlers();
       server.use(
@@ -1329,8 +1329,11 @@ describe('RFQ sessions', () => {
         for await (const event of session) {
           if (event.type === 'quote_request') {
             const quote = event.quote({ price: 0.45 });
+            // The server closes with a normal closure code (1000), but an
+            // unsolicited close is still a connection loss for the session:
+            // in-flight operations must not hang.
             const quoteRejection =
-              expect(quote).rejects.toBeInstanceOf(TransportError);
+              expect(quote).rejects.toBeInstanceOf(ConnectionLostError);
 
             await vi.waitFor(() => {
               expect(outboundFrames).toContainEqual(
@@ -1408,7 +1411,7 @@ describe('RFQ sessions', () => {
     });
   });
 
-  describe('when the connection closes before confirmation acknowledgement', () => {
+  describe('when the connection is lost before confirmation acknowledgement', () => {
     beforeEach(() => {
       server.resetHandlers();
       server.use(
@@ -1455,7 +1458,7 @@ describe('RFQ sessions', () => {
           if (event.type === 'confirmation_request') {
             const confirmation = event.confirm();
             const confirmationRejection =
-              expect(confirmation).rejects.toBeInstanceOf(TransportError);
+              expect(confirmation).rejects.toBeInstanceOf(ConnectionLostError);
 
             await vi.waitFor(() => {
               expect(outboundFrames).toContainEqual(

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -1,5 +1,6 @@
 import {
   production,
+  RfqErrorCode,
   SignatureType,
   TimeoutError,
   TransportError,
@@ -666,9 +667,9 @@ describe('RFQ sessions', () => {
               quoteAmounts(frame);
               socket.send(
                 rfqErrorMessage({
-                  code: 'SUBMISSION_WINDOW_CLOSED',
+                  code: 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
                   errorId: 'reqerr-1',
-                  error: 'submission window closed',
+                  error: 'quote validation timed out',
                   requestType: 'RFQ_QUOTE',
                   rfqId: RFQ_ID,
                 }),
@@ -690,9 +691,9 @@ describe('RFQ sessions', () => {
             const quote = event.quote({ price: 0.45 });
 
             await expect(quote).rejects.toMatchObject({
-              code: 'SUBMISSION_WINDOW_CLOSED',
+              code: RfqErrorCode.QuoteValidationTimeoutInternal,
               errorId: 'reqerr-1',
-              message: 'submission window closed',
+              message: 'quote validation timed out',
               name: 'RfqQuoteRejectedError',
               rfqId: event.rfqId,
             });
@@ -700,6 +701,67 @@ describe('RFQ sessions', () => {
             await session.close();
             break;
           }
+        }
+      } finally {
+        await secureClientWithDepositWallet.closeSubscriptions();
+      }
+    });
+  });
+
+  describe('when the server rejects a quote with a future error code', () => {
+    beforeEach(() => {
+      server.resetHandlers();
+      server.use(
+        rfq.addEventListener('connection', ({ client: socket }) => {
+          socket.addEventListener('message', (event) => {
+            const frame = recordOutboundFrame(event.data, outboundFrames);
+
+            if (frame.type === 'auth') {
+              socket.send(authAckMessage());
+              socket.send(quoteRequestMessage());
+              return;
+            }
+
+            if (frame.type === 'RFQ_QUOTE') {
+              quoteAmounts(frame);
+              socket.send(
+                rfqErrorMessage({
+                  code: 'FUTURE_ERROR_CODE',
+                  error: 'future quote rejection',
+                  requestType: 'RFQ_QUOTE',
+                  rfqId: RFQ_ID,
+                }),
+              );
+              socket.send(quoteRequestMessage());
+            }
+          });
+        }),
+      );
+    });
+
+    it('rejects only the quote and keeps the session open', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const session = await secureClientWithDepositWallet.openRfqSession();
+      let requests = 0;
+
+      try {
+        for await (const event of session) {
+          if (event.type !== 'quote_request') continue;
+          requests += 1;
+
+          if (requests === 1) {
+            await expect(event.quote({ price: 0.45 })).rejects.toMatchObject({
+              code: undefined,
+              message: 'future quote rejection',
+              name: 'RfqQuoteRejectedError',
+            });
+            continue;
+          }
+
+          expect(requests).toBe(2);
+          await session.close();
+          break;
         }
       } finally {
         await secureClientWithDepositWallet.closeSubscriptions();
@@ -1195,7 +1257,7 @@ describe('RFQ sessions', () => {
       );
     });
 
-    it('fails the session and ends the event stream', async ({
+    it('fails the session and surfaces the error through the event stream', async ({
       secureClientWithDepositWallet,
     }) => {
       const session = await secureClientWithDepositWallet.openRfqSession();
@@ -1218,13 +1280,17 @@ describe('RFQ sessions', () => {
           });
         }
 
-        let eventsAfterFailure = 0;
-        for await (const _event of session) {
-          eventsAfterFailure += 1;
+        async function consumeAfterFailure() {
+          for await (const _event of session) {
+            throw new Error('Expected the failed RFQ session to stay closed.');
+          }
         }
 
         expect(quoteFailed).toBe(true);
-        expect(eventsAfterFailure).toBe(0);
+        await expect(consumeAfterFailure()).rejects.toMatchObject({
+          message: 'Invalid RFQ quoter message.',
+          name: 'TransportError',
+        });
       } finally {
         await secureClientWithDepositWallet.closeSubscriptions();
       }


### PR DESCRIPTION
## Summary

- add `MAKER_QUOTE_LIMITED` and `QUOTE_VALIDATION_TIMEOUT_INTERNAL` to the RFQ error enum
- treat unknown future RFQ error codes as correlated operation failures instead of malformed websocket frames
- propagate genuine terminal websocket failures through the RFQ iterator, including close code and reason
- add schema and session regression coverage plus a patch changeset

## Context

A server error code added after the published SDK caused strict frame parsing to fail. The SDK then ended the event iterator and closed an otherwise healthy quoter session. Error-code deployment must not be coupled to an SDK release.

Known codes remain typed and semantically distinct. In particular, `MAKER_QUOTE_LIMITED` is not collapsed into `RATE_LIMITED`. Unknown future codes produce the existing typed operation rejection with `code` omitted, preserving the session and the server-provided message and error ID.

## Verification

Using Node `v24.16.0`:

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (228 tests)
- RFQ integration regressions added for the credential-backed CI suite

## Related PRs

- Gateway timeout classification: https://github.com/Polymarket/combos-rfq/pull/176
- Python SDK forward compatibility: https://github.com/Polymarket/py-sdk/pull/161

## Rollout

Publish this SDK so makers can receive the distinct `MAKER_QUOTE_LIMITED` response without terminating their sessions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RFQ WebSocket session lifecycle and error typing that makers depend on for quoting; behavior shifts from session-killing parse failures to operation-level rejections and explicit connection-loss errors.
> 
> **Overview**
> **RFQ quoter sessions** are hardened so server-side error and disconnect behavior no longer tears down healthy maker sessions when the SDK lags the gateway.
> 
> **Forward-compatible RFQ errors:** Known codes move to `RfqKnownErrorCode` (including `MAKER_QUOTE_LIMITED` and `QUOTE_VALIDATION_TIMEOUT_INTERNAL`). `RfqErrorCode` is now an open string union so inbound `RFQ_ERROR` frames with unknown `code` values still parse. Correlated quote/cancel/confirmation failures surface as the existing typed rejections with the server `code` and message; the **session and event iterator stay open**.
> 
> **Unsolicited WebSocket loss:** `WebSocketConnection` reports closes via `onConnectionLost` with `code` and `reason`. RFQ quoter maps that to a new **`ConnectionLostError`** (included in quote/cancel/confirmation/open-session error unions), fails pending work, and ends the async iterator with that error. Intentional `close()` still uses `TransportError` without treating it as connection loss.
> 
> Subscription managers (CLOB, RTDS, sports, perps) only rename handlers to `onConnectionLost`; reconnect behavior is unchanged. Perps still rejects pending with `TransportError` on disconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 749f1fcd7bb6979882112bb1c25f2106ef7dac22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->