### PR TITLE
fix(bindings): normalize empty-string decimals on websocket market and user events

### DIFF
--- a/.changeset/dev-415-ws-empty-string-decimals.md
+++ b/.changeset/dev-415-ws-empty-string-decimals.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Normalize empty-string optional decimal fields on streamed market and trade events to null (for example a trade's `feeRateBps` and a price change's `bestBid`/`bestAsk`), so consumers never receive `''` where a decimal string or null is expected.

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -450,6 +450,16 @@ export function emptyStringToNull(value: unknown): unknown {
   return value === '' ? null : value;
 }
 
+/**
+ * Optional decimal field whose upstream serialization uses an empty string
+ * for missing values. Normalizes `''` to `null` so consumers never receive
+ * an empty `DecimalString`; populated values parse as `DecimalStringSchema`.
+ */
+export const OptionalDecimalStringSchema = z.preprocess(
+  emptyStringToNull,
+  DecimalStringSchema.nullish(),
+);
+
 function toEvmAddress(value: string): EvmAddress {
   return expectEvmAddress(value);
 }

--- a/packages/bindings/src/subscriptions/clob.test.ts
+++ b/packages/bindings/src/subscriptions/clob.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { TradeStatus, UserEventSchema } from './clob';
+import { MarketEventSchema, TradeStatus, UserEventSchema } from './clob';
 
 describe('UserEventSchema', () => {
   it('accepts short trade statuses from the user websocket and normalizes them', () => {
@@ -60,5 +60,110 @@ describe('UserEventSchema', () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  it('normalizes empty-string fee_rate_bps to null on trades and maker orders', () => {
+    const result = UserEventSchema.safeParse({
+      asset_id: '1',
+      event_type: 'trade',
+      fee_rate_bps: '',
+      id: 'trade-3',
+      last_update: '1710000000',
+      maker_address: '0x0000000000000000000000000000000000000001',
+      maker_orders: [
+        {
+          asset_id: '1',
+          fee_rate_bps: '',
+          matched_amount: '10',
+          order_id: 'order-4',
+          owner: 'owner-2',
+          price: '0.5',
+          side: 'SELL',
+        },
+      ],
+      market: 'market-1',
+      match_time: '1710000000',
+      owner: 'owner-1',
+      price: '0.5',
+      side: 'BUY',
+      size: '1',
+      status: 'CONFIRMED',
+      taker_order_id: 'order-3',
+      timestamp: '1710000000002',
+      trade_owner: 'owner-1',
+      type: 'TRADE',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (!result.success) {
+      throw result.error;
+    }
+
+    expect(result.data).toMatchObject({
+      payload: {
+        feeRateBps: null,
+        makerOrders: [{ feeRateBps: null }],
+      },
+    });
+  });
+});
+
+describe('MarketEventSchema', () => {
+  it('normalizes empty-string best_bid and best_ask to null on price changes', () => {
+    const result = MarketEventSchema.safeParse({
+      event_type: 'price_change',
+      market: 'market-1',
+      price_changes: [
+        {
+          asset_id: '1',
+          best_ask: '',
+          best_bid: '',
+          hash: 'hash-1',
+          price: '0.5',
+          side: 'BUY',
+          size: '10',
+        },
+      ],
+      timestamp: '1710000000000',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (!result.success) {
+      throw result.error;
+    }
+
+    expect(result.data).toMatchObject({
+      payload: {
+        priceChanges: [{ bestAsk: null, bestBid: null }],
+      },
+    });
+  });
+
+  it('keeps populated best_bid_ask decimals intact', () => {
+    const result = MarketEventSchema.safeParse({
+      asset_id: '1',
+      best_ask: '0.51',
+      best_bid: '0.49',
+      event_type: 'best_bid_ask',
+      market: 'market-1',
+      spread: '',
+      timestamp: '1710000000000',
+    });
+
+    expect(result.success).toBe(true);
+
+    if (!result.success) {
+      throw result.error;
+    }
+
+    expect(result.data).toMatchObject({
+      payload: {
+        bestAsk: '0.51',
+        bestBid: '0.49',
+        spread: null,
+      },
+    });
   });
 });

--- a/packages/bindings/src/subscriptions/clob.ts
+++ b/packages/bindings/src/subscriptions/clob.ts
@@ -4,12 +4,22 @@ import {
   DecimalStringSchema,
   EpochMillisecondsStringSchema,
   EpochMillisecondsToIsoDateTimeStringSchema,
+  emptyStringToNull,
   type OrderSide,
   OrderSideSchema,
   OrderTypeSchema,
   TokenIdSchema,
   toIsoDateTimeString,
 } from '../shared';
+
+// The websocket serializes absent optional decimals as an empty string (for
+// example `fee_rate_bps` on a trade with no fee, or `best_bid`/`best_ask` when
+// there is none). Normalize to null so consumers never see '' as a
+// DecimalString, matching the maker-order normalization in `clob/account.ts`.
+const OptionalDecimalStringSchema = z.preprocess(
+  emptyStringToNull,
+  DecimalStringSchema.nullish(),
+);
 
 const NormalizedOrderSideSchema: z.ZodType<OrderSide> = z.preprocess(
   (value) => (typeof value === 'string' ? value.toUpperCase() : value),
@@ -79,10 +89,10 @@ export const MarketBookEventSchema = z
     asks: z.array(OrderBookLevelSchema),
     hash: z.string().nullish(),
     timestamp: EpochMillisecondsStringSchema.nullish(),
-    min_order_size: DecimalStringSchema.nullish(),
-    tick_size: DecimalStringSchema.nullish(),
+    min_order_size: OptionalDecimalStringSchema,
+    tick_size: OptionalDecimalStringSchema,
     neg_risk: z.boolean().nullish(),
-    last_trade_price: DecimalStringSchema.nullish(),
+    last_trade_price: OptionalDecimalStringSchema,
   })
   .transform(
     ({
@@ -119,8 +129,8 @@ const PriceChangeSchema = z
     size: DecimalStringSchema,
     side: NormalizedOrderSideSchema,
     hash: z.string().nullish(),
-    best_bid: DecimalStringSchema.nullish(),
-    best_ask: DecimalStringSchema.nullish(),
+    best_bid: OptionalDecimalStringSchema,
+    best_ask: OptionalDecimalStringSchema,
   })
   .transform(({ asset_id, best_bid, best_ask, ...rest }) => ({
     ...rest,
@@ -160,8 +170,8 @@ export const MarketLastTradePriceEventSchema = z
     market: z.string(),
     asset_id: TokenIdSchema,
     price: DecimalStringSchema,
-    size: DecimalStringSchema.nullish(),
-    fee_rate_bps: DecimalStringSchema.nullish(),
+    size: OptionalDecimalStringSchema,
+    fee_rate_bps: OptionalDecimalStringSchema,
     side: NormalizedOrderSideSchema,
     timestamp: EpochMillisecondsStringSchema.nullish(),
     transaction_hash: z.string().nullish(),
@@ -191,7 +201,7 @@ export const MarketTickSizeChangeEventSchema = z
     event_type: z.literal('tick_size_change'),
     market: z.string(),
     asset_id: TokenIdSchema,
-    old_tick_size: DecimalStringSchema.nullish(),
+    old_tick_size: OptionalDecimalStringSchema,
     new_tick_size: DecimalStringSchema,
     timestamp: EpochMillisecondsStringSchema.nullish(),
   })
@@ -220,9 +230,9 @@ export const MarketBestBidAskEventSchema = z
     event_type: z.literal('best_bid_ask'),
     market: z.string(),
     asset_id: TokenIdSchema,
-    best_bid: DecimalStringSchema.nullish(),
-    best_ask: DecimalStringSchema.nullish(),
-    spread: DecimalStringSchema.nullish(),
+    best_bid: OptionalDecimalStringSchema,
+    best_ask: OptionalDecimalStringSchema,
+    spread: OptionalDecimalStringSchema,
     timestamp: EpochMillisecondsStringSchema.nullish(),
   })
   .transform(({ event_type, asset_id, best_bid, best_ask, ...rest }) => {
@@ -268,11 +278,11 @@ export const NewMarketEventSchema = z
     active: z.boolean().nullish(),
     clob_token_ids: z.array(z.string()).nullish(),
     sports_market_type: z.string().nullish(),
-    line: DecimalStringSchema.nullish(),
+    line: OptionalDecimalStringSchema,
     game_start_time: EpochMillisecondsToIsoDateTimeStringSchema.nullish(),
-    order_price_min_tick_size: DecimalStringSchema.nullish(),
+    order_price_min_tick_size: OptionalDecimalStringSchema,
     group_item_title: z.string().nullish(),
-    taker_base_fee: DecimalStringSchema.nullish(),
+    taker_base_fee: OptionalDecimalStringSchema,
     fees_enabled: z.boolean().nullish(),
     fee_schedule: z.unknown().nullish(),
   })
@@ -429,7 +439,7 @@ const TradeMakerOrderSchema = z
     maker_address: z.string().nullish(),
     matched_amount: DecimalStringSchema,
     price: DecimalStringSchema,
-    fee_rate_bps: DecimalStringSchema.nullish(),
+    fee_rate_bps: OptionalDecimalStringSchema,
     asset_id: TokenIdSchema,
     outcome: z.string().nullish(),
     outcome_index: z.number().int().nullish(),
@@ -467,7 +477,7 @@ export const UserTradeEventSchema = z
     asset_id: TokenIdSchema,
     side: NormalizedOrderSideSchema,
     size: DecimalStringSchema,
-    fee_rate_bps: DecimalStringSchema.nullish(),
+    fee_rate_bps: OptionalDecimalStringSchema,
     price: DecimalStringSchema,
     status: TradeStatusSchema,
     match_time: EpochSecondsStringToIsoDateTimeStringSchema.nullish(),

--- a/packages/bindings/src/subscriptions/clob.ts
+++ b/packages/bindings/src/subscriptions/clob.ts
@@ -4,7 +4,7 @@ import {
   DecimalStringSchema,
   EpochMillisecondsStringSchema,
   EpochMillisecondsToIsoDateTimeStringSchema,
-  emptyStringToNull,
+  OptionalDecimalStringSchema,
   type OrderSide,
   OrderSideSchema,
   OrderTypeSchema,
@@ -14,12 +14,8 @@ import {
 
 // The websocket serializes absent optional decimals as an empty string (for
 // example `fee_rate_bps` on a trade with no fee, or `best_bid`/`best_ask` when
-// there is none). Normalize to null so consumers never see '' as a
-// DecimalString, matching the maker-order normalization in `clob/account.ts`.
-const OptionalDecimalStringSchema = z.preprocess(
-  emptyStringToNull,
-  DecimalStringSchema.nullish(),
-);
+// there is none), so optional decimal fields in these schemas use the
+// ''-normalizing OptionalDecimalStringSchema.
 
 const NormalizedOrderSideSchema: z.ZodType<OrderSide> = z.preprocess(
   (value) => (typeof value === 'string' ? value.toUpperCase() : value),


### PR DESCRIPTION
## Problem

The websocket serializes absent optional decimals as an empty string, e.g. `fee_rate_bps` on a trade with no fee, or `best_bid`/`best_ask` on a price change. The CLOB subscription schemas type these fields as `DecimalStringSchema.nullish()`, but `DecimalStringSchema` is a pass-through brand with no emptiness check, so `""` parses successfully and leaks to consumers as an empty `DecimalString`. That violates the declared `DecimalString | null | undefined` contract: `Number("")` yields `0`, `parseFloat("")` yields `NaN`, and `Decimal()`/`BigNumber()` constructors throw.

This is the TypeScript counterpart of the Python SDK fix in Polymarket/py-sdk#159 (reported in Polymarket/py-sdk#155, where the same wire values crashed parsing). #120 already normalized the REST maker-order `fee_rate_bps` with `emptyStringToNull`; the websocket schemas were not in that fix's scope.

## Change

- Add `OptionalDecimalStringSchema` (`z.preprocess(emptyStringToNull, DecimalStringSchema.nullish())`) to `packages/bindings/src/shared.ts` as a public export, alongside the existing `Optional*Schema` helpers and reusing the `emptyStringToNull` idiom from `clob/account.ts`.
- Point all 16 optional decimal fields in the CLOB websocket schemas (`packages/bindings/src/subscriptions/clob.ts`) at it: `fee_rate_bps` on user trades and maker orders, `best_bid`/`best_ask` on price changes, `best_bid`/`best_ask`/`spread` on best_bid_ask, `last_trade_price`/`min_order_size`/`tick_size` on book, `size`/`fee_rate_bps` on last_trade_price, `old_tick_size` on tick_size_change, and `line`/`order_price_min_tick_size`/`taker_base_fee` on new_market.
- Required decimals are unchanged.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm build` all clean
- Full suite green: `pnpm test` (bindings 43, client 186, types typecheck)
- New tests: empty-string `fee_rate_bps` on a user trade and its maker orders normalizes to `null`; empty-string `best_bid`/`best_ask` on a price change normalizes to `null`; populated `best_bid_ask` decimals pass through intact while an empty `spread` normalizes