### PR TITLE
ci: enable Dependabot version updates (ISVBE-262)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "America/New_York"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 3
     # Wait before adopting freshly-published releases (supply-chain buffer).
     # Applies to version updates only; security fixes are never delayed.
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,20 @@ updates:
     commit-message:
       prefix: "chore(ci)"
     groups:
-      github-actions:
+      # Routine action bumps in one PR, to cut noise.
+      github-actions-minor-and-patch:
+        applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Major action bumps in their own PR for migration-note review
+      # (kept grouped so they stay within the open-PR limit, but separate
+      # from routine bumps since majors can change runner/input contracts).
+      github-actions-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+# Dependabot configuration for ts-sdk (pnpm workspace monorepo).
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # npm (pnpm) — the root workspace plus every package under packages/* and the
+  # example projects under examples/*. Dependabot's npm ecosystem reads the
+  # pnpm-lock.yaml workspace lockfile.
+  - package-ecosystem: "npm"
+    directories:
+      - "/"
+      - "/packages/*"
+      - "/examples/*"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 10
+    # Wait before adopting freshly-published releases (supply-chain buffer).
+    # Applies to version updates only; security fixes are never delayed.
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # One PR per directory for all backward-compatible version bumps, to cut noise.
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      # One PR per directory for security fixes once an advisory has a fix available.
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    # Major-version bumps are left ungrouped so each gets its own PR and review.
+
+  # GitHub Actions used by the CI workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
### TL;DR
Add Dependabot version updates to ts-sdk (the repo had no dependency automation). Covers npm across the pnpm workspace and GitHub Actions, with the actions group split into minor/patch and majors so action majors open their own review PR. Part of ISVBE-262.

### What changed
- **`.github/dependabot.yml`** (new): `npm` ecosystem across the pnpm workspace (`/`, `/packages/*`, `/examples/*`, reading `pnpm-lock.yaml`) and `github-actions`. npm minor/patch grouped per directory with majors left ungrouped; `github-actions` split into `github-actions-minor-and-patch` and `github-actions-major`.

_Not in scope: no code changes. Complements the existing `dependency-review.yml` (PR-time advisory) with proactive scheduled updates._

### Review & risk
Config-only, no code. The only behaviour change is Dependabot's own: it opens scheduled update PRs that still run full CI before merge. 7-day cooldown on version updates (security fixes never delayed), weekly Monday 09:00 America/New_York. Reversible (revert the file).

### Verified
`ruby -ryaml -e "YAML.load_file('.github/dependabot.yml')"` parses clean. After merge, GitHub validates the config under Insights → Dependency graph → Dependabot. Reuse: mirrors the Dependabot house pattern (us-backend #138) with the two-group GitHub Actions split adopted across the ISVBE-262 repos (py-sdk #163, go-markets #496).

<details><summary><b>Context</b> (optional depth)</summary>

The two-group actions split came out of a Cursor Bugbot flag on py-sdk #163 ("major CI updates grouped") plus a design consult. The conclusion was that a separate majors group is cleaner: action majors (e.g. `actions/checkout` v4 to v5) can change runner or input contracts, so they deserve their own PR rather than hiding in the routine bump.

ts-sdk has no PR template of its own, so this body uses the us-backend template as the house fallback.

</details>

---
- [x] A human read this diff and confirms it matches the intent above
- [x] The `.proto` change and its regenerated `gen/proto/` are in the same commit (N/A, ts-sdk is TypeScript, no proto)
- [x] Authored/assisted by an agent: Claude Code (Claude Opus 4.8)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change; behavior is limited to Dependabot opening update PRs that still go through existing CI before merge.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so the repo gets scheduled dependency update PRs (it previously had PR-time `dependency-review` only, no proactive bumps).
> 
> **npm (pnpm):** watches `/`, `/packages/*`, and `/examples/*` weekly (Monday 09:00 ET), with a 7-day cooldown on version updates, grouped minor/patch and security PRs per directory, and **ungrouped majors** for separate review. **GitHub Actions:** same schedule with grouped minor/patch vs **major** bumps in distinct PRs, plus `chore(deps)` / `chore(ci)` commit prefixes and open-PR limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8d89ed42ccbd6b20056937a6cfad59ea3bc89f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->