### PR TITLE
chore(ci): enable Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# The root pnpm workspace manifest and lockfile cover the SDK packages and
+# examples. Group routine updates to keep the review queue small.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Enable weekly, capped Dependabot updates for the root pnpm workspace and GitHub Actions. Routine minor and patch bumps are grouped to keep review volume manageable.

Related to ISVBE-262.

## Validation

- Parsed `.github/dependabot.yml` as YAML and checked the expected ecosystems, schedules, caps, cooldowns, and commit prefixes.
- `pnpm lint`
- `pnpm typecheck`
