### PR TITLE
fix(client): strengthen CLOB price read types

### DIFF
--- a/.changeset/dev-416-price-decimalstrings.md
+++ b/.changeset/dev-416-price-decimalstrings.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Return branded decimal string types from CLOB price read helpers instead of widening validated decimal strings to plain strings.

--- a/.changeset/dev-417-fetchprices-tokenid-keys.md
+++ b/.changeset/dev-417-fetchprices-tokenid-keys.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Strengthen the `fetchPrices` result type so price lookups are keyed by `TokenId` with partial `OrderSide` records containing decimal strings.

--- a/.changeset/dev-417-fetchprices-tokenid-keys.md
+++ b/.changeset/dev-417-fetchprices-tokenid-keys.md
@@ -3,4 +3,4 @@
 "@polymarket/client": patch
 ---
 
-Strengthen the `fetchPrices` result type so price lookups are keyed by `TokenId` with partial `OrderSide` records containing decimal strings.
+Strengthen CLOB batch price read result types so midpoint, price, and spread lookups are keyed by `TokenId`. `fetchPrices` now returns partial `OrderSide` records containing decimal strings, while `fetchMidpoints` and `fetchSpreads` return token ID keyed decimal strings.

--- a/packages/bindings/src/clob/market-data.test.ts
+++ b/packages/bindings/src/clob/market-data.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { OrderSide, TokenIdSchema } from '../shared';
+import { PricesSchema } from './market-data';
+
+describe('PricesSchema', () => {
+  it('parses prices keyed by token ID with partial side records', () => {
+    const tokenId = TokenIdSchema.parse(
+      '8501497159083948713316135768103773293754490207922884688769443031624417212426',
+    );
+
+    const prices = PricesSchema.parse({
+      [tokenId]: {
+        [OrderSide.BUY]: '0.52',
+      },
+    });
+
+    expect(prices[tokenId]?.[OrderSide.BUY]).toBe('0.52');
+    expect(prices[tokenId]?.[OrderSide.SELL]).toBeUndefined();
+  });
+
+  it('rejects unknown side keys', () => {
+    const tokenId = TokenIdSchema.parse(
+      '8501497159083948713316135768103773293754490207922884688769443031624417212426',
+    );
+
+    expect(() =>
+      PricesSchema.parse({
+        [tokenId]: {
+          HOLD: '0.52',
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/bindings/src/clob/market-data.test.ts
+++ b/packages/bindings/src/clob/market-data.test.ts
@@ -1,12 +1,25 @@
 import { describe, expect, it } from 'vitest';
 import { OrderSide, TokenIdSchema } from '../shared';
-import { PricesSchema } from './market-data';
+import { MidpointsSchema, PricesSchema, SpreadsSchema } from './market-data';
+
+const TOKEN_ID =
+  '8501497159083948713316135768103773293754490207922884688769443031624417212426';
+
+describe('MidpointsSchema', () => {
+  it('parses midpoint prices keyed by token ID', () => {
+    const tokenId = TokenIdSchema.parse(TOKEN_ID);
+
+    const midpoints = MidpointsSchema.parse({
+      [tokenId]: '0.53',
+    });
+
+    expect(midpoints[tokenId]).toBe('0.53');
+  });
+});
 
 describe('PricesSchema', () => {
   it('parses prices keyed by token ID with partial side records', () => {
-    const tokenId = TokenIdSchema.parse(
-      '8501497159083948713316135768103773293754490207922884688769443031624417212426',
-    );
+    const tokenId = TokenIdSchema.parse(TOKEN_ID);
 
     const prices = PricesSchema.parse({
       [tokenId]: {
@@ -19,9 +32,7 @@ describe('PricesSchema', () => {
   });
 
   it('rejects unknown side keys', () => {
-    const tokenId = TokenIdSchema.parse(
-      '8501497159083948713316135768103773293754490207922884688769443031624417212426',
-    );
+    const tokenId = TokenIdSchema.parse(TOKEN_ID);
 
     expect(() =>
       PricesSchema.parse({
@@ -30,5 +41,17 @@ describe('PricesSchema', () => {
         },
       }),
     ).toThrow();
+  });
+});
+
+describe('SpreadsSchema', () => {
+  it('parses spreads keyed by token ID', () => {
+    const tokenId = TokenIdSchema.parse(TOKEN_ID);
+
+    const spreads = SpreadsSchema.parse({
+      [tokenId]: '0.02',
+    });
+
+    expect(spreads[tokenId]).toBe('0.02');
   });
 });

--- a/packages/bindings/src/clob/market-data.ts
+++ b/packages/bindings/src/clob/market-data.ts
@@ -21,7 +21,7 @@ export const MidpointSchema = z.object({
 });
 export type Midpoint = z.infer<typeof MidpointSchema>;
 
-export const MidpointsSchema = z.record(z.string(), DecimalStringSchema);
+export const MidpointsSchema = z.record(TokenIdSchema, DecimalStringSchema);
 export type Midpoints = z.infer<typeof MidpointsSchema>;
 
 export const PriceSchema = z.object({
@@ -43,7 +43,7 @@ export const SpreadSchema = z.object({
 });
 export type Spread = z.infer<typeof SpreadSchema>;
 
-export const SpreadsSchema = z.record(z.string(), DecimalStringSchema);
+export const SpreadsSchema = z.record(TokenIdSchema, DecimalStringSchema);
 export type Spreads = z.infer<typeof SpreadsSchema>;
 
 export const LastTradePriceSchema = z.object({

--- a/packages/bindings/src/clob/market-data.ts
+++ b/packages/bindings/src/clob/market-data.ts
@@ -29,13 +29,13 @@ export const PriceSchema = z.object({
 });
 export type Price = z.infer<typeof PriceSchema>;
 
-const PricesBySideSchema = z.record(
+const PricesBySideSchema = z.partialRecord(
   OrderSideSchema,
-  DecimalStringSchema.optional(),
+  DecimalStringSchema,
 );
 export type PricesBySide = z.infer<typeof PricesBySideSchema>;
 
-export const PricesSchema = z.record(z.string(), PricesBySideSchema);
+export const PricesSchema = z.record(TokenIdSchema, PricesBySideSchema);
 export type Prices = z.infer<typeof PricesSchema>;
 
 export const SpreadSchema = z.object({

--- a/packages/client/src/actions/clob.test-d.ts
+++ b/packages/client/src/actions/clob.test-d.ts
@@ -12,6 +12,14 @@ import type {
 } from './index';
 
 describe('public CLOB price read types', () => {
+  it('models batch price reads as token ID keyed decimal records', () => {
+    expectTypeOf<Midpoints>().toEqualTypeOf<Record<TokenId, DecimalString>>();
+    expectTypeOf<Prices>().toEqualTypeOf<
+      Record<TokenId, Partial<Record<OrderSide, DecimalString>>>
+    >();
+    expectTypeOf<Spreads>().toEqualTypeOf<Record<TokenId, DecimalString>>();
+  });
+
   it('preserves branded decimal action return types', () => {
     expectTypeOf<ReturnType<typeof fetchMidpoint>>().toEqualTypeOf<
       Promise<DecimalString>
@@ -47,12 +55,6 @@ describe('public CLOB price read types', () => {
     >();
     expectTypeOf<ReturnType<typeof actions.fetchSpreads>>().toEqualTypeOf<
       Promise<Spreads>
-    >();
-  });
-
-  it('models fetchPrices results as token ID keyed partial side records', () => {
-    expectTypeOf<Prices>().toEqualTypeOf<
-      Record<TokenId, Partial<Record<OrderSide, DecimalString>>>
     >();
   });
 

--- a/packages/client/src/actions/clob.test-d.ts
+++ b/packages/client/src/actions/clob.test-d.ts
@@ -1,0 +1,51 @@
+import type { DecimalString } from '@polymarket/bindings';
+import type { Midpoints, Spreads } from '@polymarket/bindings/clob';
+import { describe, expectTypeOf, it } from 'vitest';
+import type { DataActions } from '../decorators';
+import type {
+  fetchMidpoint,
+  fetchMidpoints,
+  fetchPrice,
+  fetchSpread,
+  fetchSpreads,
+} from './index';
+
+describe('public CLOB price read types', () => {
+  it('preserves branded decimal action return types', () => {
+    expectTypeOf<ReturnType<typeof fetchMidpoint>>().toEqualTypeOf<
+      Promise<DecimalString>
+    >();
+    expectTypeOf<ReturnType<typeof fetchMidpoints>>().toEqualTypeOf<
+      Promise<Midpoints>
+    >();
+    expectTypeOf<ReturnType<typeof fetchPrice>>().toEqualTypeOf<
+      Promise<DecimalString>
+    >();
+    expectTypeOf<ReturnType<typeof fetchSpread>>().toEqualTypeOf<
+      Promise<DecimalString>
+    >();
+    expectTypeOf<ReturnType<typeof fetchSpreads>>().toEqualTypeOf<
+      Promise<Spreads>
+    >();
+  });
+
+  it('preserves branded decimal decorator return types', () => {
+    const actions = {} as DataActions;
+
+    expectTypeOf<ReturnType<typeof actions.fetchMidpoint>>().toEqualTypeOf<
+      Promise<DecimalString>
+    >();
+    expectTypeOf<ReturnType<typeof actions.fetchMidpoints>>().toEqualTypeOf<
+      Promise<Midpoints>
+    >();
+    expectTypeOf<ReturnType<typeof actions.fetchPrice>>().toEqualTypeOf<
+      Promise<DecimalString>
+    >();
+    expectTypeOf<ReturnType<typeof actions.fetchSpread>>().toEqualTypeOf<
+      Promise<DecimalString>
+    >();
+    expectTypeOf<ReturnType<typeof actions.fetchSpreads>>().toEqualTypeOf<
+      Promise<Spreads>
+    >();
+  });
+});

--- a/packages/client/src/actions/clob.test-d.ts
+++ b/packages/client/src/actions/clob.test-d.ts
@@ -1,11 +1,12 @@
-import type { DecimalString } from '@polymarket/bindings';
-import type { Midpoints, Spreads } from '@polymarket/bindings/clob';
+import type { DecimalString, OrderSide, TokenId } from '@polymarket/bindings';
+import type { Midpoints, Prices, Spreads } from '@polymarket/bindings/clob';
 import { describe, expectTypeOf, it } from 'vitest';
 import type { DataActions } from '../decorators';
 import type {
   fetchMidpoint,
   fetchMidpoints,
   fetchPrice,
+  fetchPrices,
   fetchSpread,
   fetchSpreads,
 } from './index';
@@ -46,6 +47,23 @@ describe('public CLOB price read types', () => {
     >();
     expectTypeOf<ReturnType<typeof actions.fetchSpreads>>().toEqualTypeOf<
       Promise<Spreads>
+    >();
+  });
+
+  it('models fetchPrices results as token ID keyed partial side records', () => {
+    expectTypeOf<Prices>().toEqualTypeOf<
+      Record<TokenId, Partial<Record<OrderSide, DecimalString>>>
+    >();
+  });
+
+  it('preserves fetchPrices return type on actions and decorators', () => {
+    const actions = {} as DataActions;
+
+    expectTypeOf<ReturnType<typeof fetchPrices>>().toEqualTypeOf<
+      Promise<Prices>
+    >();
+    expectTypeOf<ReturnType<typeof actions.fetchPrices>>().toEqualTypeOf<
+      Promise<Prices>
     >();
   });
 });

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -2,6 +2,7 @@ import {
   BuilderCodeSchema,
   type CtfConditionId,
   CtfConditionIdSchema,
+  type DecimalString,
   OrderSideSchema,
   PaginationCursorSchema,
   type TickSizeValue,
@@ -24,6 +25,7 @@ import {
   type MarketInfo,
   type MarketReward,
   MidpointSchema,
+  type Midpoints,
   MidpointsSchema,
   type OrderBook,
   OrderBooksSchema,
@@ -37,6 +39,7 @@ import {
   PricesSchema,
   ResolveConditionByTokenResponseSchema,
   SpreadSchema,
+  type Spreads,
   SpreadsSchema,
 } from '@polymarket/bindings/clob';
 import { unwrap } from '@polymarket/types';
@@ -76,7 +79,7 @@ export const FetchMidpointError = makeErrorGuard(
 );
 
 /**
- * Fetches the midpoint price for a token.
+ * Fetches the midpoint price for a token as a decimal string.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -98,7 +101,7 @@ export const FetchMidpointError = makeErrorGuard(
 export async function fetchMidpoint(
   client: BaseClient,
   request: FetchMidpointRequest,
-): Promise<string> {
+): Promise<DecimalString> {
   const params = parseUserInput(request, FetchMidpointRequestSchema);
   const response = await unwrap(
     client.clob
@@ -136,7 +139,7 @@ export const FetchMidpointsError = makeErrorGuard(
 );
 
 /**
- * Fetches midpoint prices for multiple tokens.
+ * Fetches midpoint prices for multiple tokens as decimal strings.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -160,7 +163,7 @@ export const FetchMidpointsError = makeErrorGuard(
 export async function fetchMidpoints(
   client: BaseClient,
   request: FetchMidpointsRequest,
-): Promise<Record<string, string>> {
+): Promise<Midpoints> {
   const params = parseUserInput(request, FetchMidpointsRequestSchema);
 
   return unwrap(
@@ -446,7 +449,7 @@ export const FetchPriceError = makeErrorGuard(
 );
 
 /**
- * Fetches the current quoted price for a token and side.
+ * Fetches the current quoted price for a token and side as a decimal string.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -469,7 +472,7 @@ export const FetchPriceError = makeErrorGuard(
 export async function fetchPrice(
   client: BaseClient,
   request: FetchPriceRequest,
-): Promise<string> {
+): Promise<DecimalString> {
   const params = parseUserInput(request, FetchPriceRequestSchema);
   const response = await unwrap(
     client.clob
@@ -682,7 +685,7 @@ export const FetchSpreadError = makeErrorGuard(
 );
 
 /**
- * Fetches the spread for a token.
+ * Fetches the spread for a token as a decimal string.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -704,7 +707,7 @@ export const FetchSpreadError = makeErrorGuard(
 export async function fetchSpread(
   client: BaseClient,
   request: FetchSpreadRequest,
-): Promise<string> {
+): Promise<DecimalString> {
   const params = parseUserInput(request, FetchSpreadRequestSchema);
   const response = await unwrap(
     client.clob
@@ -742,7 +745,7 @@ export const FetchSpreadsError = makeErrorGuard(
 );
 
 /**
- * Fetches spreads for multiple tokens.
+ * Fetches spreads for multiple tokens as decimal strings.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -766,7 +769,7 @@ export const FetchSpreadsError = makeErrorGuard(
 export async function fetchSpreads(
   client: BaseClient,
   request: FetchSpreadsRequest,
-): Promise<Record<string, string>> {
+): Promise<Spreads> {
   const params = parseUserInput(request, FetchSpreadsRequestSchema);
 
   return unwrap(

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -511,7 +511,7 @@ export const FetchPricesError = makeErrorGuard(
 );
 
 /**
- * Fetches quoted prices for multiple tokens.
+ * Fetches quoted prices for multiple tokens as a token ID keyed lookup.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -139,7 +139,7 @@ export const FetchMidpointsError = makeErrorGuard(
 );
 
 /**
- * Fetches midpoint prices for multiple tokens as decimal strings.
+ * Fetches midpoint prices for multiple tokens as a token ID keyed lookup.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -745,7 +745,7 @@ export const FetchSpreadsError = makeErrorGuard(
 );
 
 /**
- * Fetches spreads for multiple tokens as decimal strings.
+ * Fetches spreads for multiple tokens as a token ID keyed lookup.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -83,7 +83,7 @@ export type DataActions = {
    */
   fetchMidpoint(request: FetchMidpointRequest): Promise<DecimalString>;
   /**
-   * Fetches midpoint prices for multiple tokens as decimal strings.
+   * Fetches midpoint prices for multiple tokens as a token ID keyed lookup.
    *
    * @throws {@link FetchMidpointsError}
    * Thrown on failure.
@@ -155,7 +155,7 @@ export type DataActions = {
    */
   fetchSpread(request: FetchSpreadRequest): Promise<DecimalString>;
   /**
-   * Fetches spreads for multiple tokens as decimal strings.
+   * Fetches spreads for multiple tokens as a token ID keyed lookup.
    *
    * @throws {@link FetchSpreadsError}
    * Thrown on failure.

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -1,9 +1,12 @@
+import type { DecimalString } from '@polymarket/bindings';
 import type {
   LastTradePrice,
   LastTradePriceForToken,
+  Midpoints,
   OrderBook,
   PriceHistoryPoint,
   Prices,
+  Spreads,
 } from '@polymarket/bindings/clob';
 import type {
   LiveVolume,
@@ -68,7 +71,7 @@ export type DataActions = {
     request: FetchEventLiveVolumeRequest,
   ): Promise<LiveVolume[]>;
   /**
-   * Fetches the midpoint price for a token.
+   * Fetches the midpoint price for a token as a decimal string.
    *
    * @throws {@link FetchMidpointError}
    * Thrown on failure.
@@ -78,9 +81,9 @@ export type DataActions = {
    * const midpoint = await client.fetchMidpoint({ tokenId: '123' });
    * ```
    */
-  fetchMidpoint(request: FetchMidpointRequest): Promise<string>;
+  fetchMidpoint(request: FetchMidpointRequest): Promise<DecimalString>;
   /**
-   * Fetches midpoint prices for multiple tokens.
+   * Fetches midpoint prices for multiple tokens as decimal strings.
    *
    * @throws {@link FetchMidpointsError}
    * Thrown on failure.
@@ -90,11 +93,9 @@ export type DataActions = {
    * const midpoints = await client.fetchMidpoints([{ tokenId: '123' }]);
    * ```
    */
-  fetchMidpoints(
-    request: FetchMidpointsRequest,
-  ): Promise<Record<string, string>>;
+  fetchMidpoints(request: FetchMidpointsRequest): Promise<Midpoints>;
   /**
-   * Fetches the current quoted price for a token and side.
+   * Fetches the current quoted price for a token and side as a decimal string.
    *
    * @throws {@link FetchPriceError}
    * Thrown on failure.
@@ -104,7 +105,7 @@ export type DataActions = {
    * const price = await client.fetchPrice({ tokenId: '123', side: OrderSide.BUY });
    * ```
    */
-  fetchPrice(request: FetchPriceRequest): Promise<string>;
+  fetchPrice(request: FetchPriceRequest): Promise<DecimalString>;
   /**
    * Fetches quoted prices for multiple tokens.
    *
@@ -142,7 +143,7 @@ export type DataActions = {
    */
   fetchOrderBooks(request: FetchOrderBooksRequest): Promise<OrderBook[]>;
   /**
-   * Fetches the spread for a token.
+   * Fetches the spread for a token as a decimal string.
    *
    * @throws {@link FetchSpreadError}
    * Thrown on failure.
@@ -152,9 +153,9 @@ export type DataActions = {
    * const spread = await client.fetchSpread({ tokenId: '123' });
    * ```
    */
-  fetchSpread(request: FetchSpreadRequest): Promise<string>;
+  fetchSpread(request: FetchSpreadRequest): Promise<DecimalString>;
   /**
-   * Fetches spreads for multiple tokens.
+   * Fetches spreads for multiple tokens as decimal strings.
    *
    * @throws {@link FetchSpreadsError}
    * Thrown on failure.
@@ -164,7 +165,7 @@ export type DataActions = {
    * const spreads = await client.fetchSpreads([{ tokenId: '123' }]);
    * ```
    */
-  fetchSpreads(request: FetchSpreadsRequest): Promise<Record<string, string>>;
+  fetchSpreads(request: FetchSpreadsRequest): Promise<Spreads>;
   /**
    * Fetches the last traded price for a token.
    *

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -107,7 +107,7 @@ export type DataActions = {
    */
   fetchPrice(request: FetchPriceRequest): Promise<DecimalString>;
   /**
-   * Fetches quoted prices for multiple tokens.
+   * Fetches quoted prices for multiple tokens as a token ID keyed lookup.
    *
    * @throws {@link FetchPricesError}
    * Thrown on failure.

--- a/packages/client/tests/integration/clob.test.ts
+++ b/packages/client/tests/integration/clob.test.ts
@@ -62,6 +62,7 @@ describe('CLOB', () => {
 
       const result = await publicClient.fetchMidpoints([{ tokenId }]);
 
+      expect(Object.keys(result)).toContain(tokenId);
       expect(result[tokenId]).toEqual(expect.any(String));
     });
   });
@@ -118,6 +119,7 @@ describe('CLOB', () => {
 
       const result = await publicClient.fetchSpreads([{ tokenId }]);
 
+      expect(Object.keys(result)).toContain(tokenId);
       expect(result[tokenId]).toEqual(expect.any(String));
     });
   });

--- a/packages/client/tests/integration/clob.test.ts
+++ b/packages/client/tests/integration/clob.test.ts
@@ -1,11 +1,11 @@
-import { OrderSide } from '@polymarket/bindings';
+import { OrderSide, type TokenId } from '@polymarket/bindings';
 import { PriceHistoryInterval } from '@polymarket/bindings/clob';
 import type { PublicClient } from '@polymarket/client';
 import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from './fixtures';
 import { expectPageWindow } from './helpers';
 
-let liquidClobTokenIdPromise: Promise<string> | undefined;
+let liquidClobTokenIdPromise: Promise<TokenId> | undefined;
 
 describe('CLOB', () => {
   describe('fetchOrderBook', () => {
@@ -94,7 +94,9 @@ describe('CLOB', () => {
         },
       ]);
 
+      expect(Object.keys(result)).toContain(tokenId);
       expect(result[tokenId]?.BUY).toEqual(expect.any(String));
+      expect(result[tokenId]?.SELL).toBeUndefined();
     });
   });
 
@@ -230,7 +232,7 @@ describe('CLOB', () => {
 
 async function selectLiquidClobTokenId(
   publicClient: PublicClient,
-): Promise<string> {
+): Promise<TokenId> {
   liquidClobTokenIdPromise ??= findLiquidClobTokenId(publicClient);
 
   return liquidClobTokenIdPromise;


### PR DESCRIPTION
## Summary
- return branded DecimalString values from single CLOB price read helpers
- type CLOB batch price maps with TokenId keys: Midpoints, Prices, and Spreads
- preserve partial OrderSide records for fetchPrices results
- add binding runtime coverage, client action/decorator type coverage, integration assertions, and changesets for DEV-416 and DEV-417

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test:bindings
- pnpm test:client
- pnpm build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public TypeScript return types change from `string` and loose records to branded `DecimalString` and `TokenId`-keyed maps, which can break downstream consumers at compile time even though runtime parsing behavior is largely unchanged.
> 
> **Overview**
> Tightens **CLOB price read** typings across `@polymarket/bindings` and `@polymarket/client` so validated API data is not widened to plain `string` maps at the boundary.
> 
> **Bindings:** `MidpointsSchema`, `PricesSchema`, and `SpreadsSchema` now key results by `TokenId` instead of arbitrary strings. Batch `fetchPrices` shapes are modeled as **partial** `OrderSide` → `DecimalString` records (only requested sides present), with runtime tests for valid parses and rejection of unknown side keys.
> 
> **Client:** Single-token helpers (`fetchMidpoint`, `fetchPrice`, `fetchSpread`) return `DecimalString`; batch helpers return `Midpoints`, `Prices`, and `Spreads`. The `DataActions` decorator surface matches those types. New compile-time tests lock the public API; integration tests assert token-keyed batch results and that unrequested sell sides stay absent on `fetchPrices`.
> 
> Patch changesets cover DEV-416 (branded decimals) and DEV-417 (token-keyed batch maps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d5a5a84f7dc8051f60f94e59e5d28dec9387d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->