### PR TITLE
fix(rfq): keep internal timeout code private

### DIFF
--- a/.changeset/clean-rfq-internal-code.md
+++ b/.changeset/clean-rfq-internal-code.md
@@ -1,0 +1,8 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Keep internal RFQ timeout classifications out of the known public error-code
+enum. Unknown server codes remain forward compatible and continue to surface on
+correlated RFQ operation errors without closing the session.

--- a/packages/bindings/src/rfq.test.ts
+++ b/packages/bindings/src/rfq.test.ts
@@ -33,12 +33,12 @@ describe('RFQ quoter inbound messages', () => {
       type: 'RFQ_ERROR',
       request_type: 'RFQ_QUOTE',
       rfq_id: 'rfq-1',
-      code: 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
-      error: 'quote validation timed out',
+      code: 'MAKER_QUOTE_LIMITED',
+      error: 'maker quote limited',
     });
 
     expect(message).toMatchObject({
-      code: RfqKnownErrorCode.QuoteValidationTimeoutInternal,
+      code: RfqKnownErrorCode.MakerQuoteLimited,
       type: 'rfq_error',
     });
   });

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -91,7 +91,6 @@ export enum RfqKnownErrorCode {
   PreExecutionBalanceReservationFailed = 'PRE_EXECUTION_BALANCE_RESERVATION_FAILED',
   QuoteMismatch = 'QUOTE_MISMATCH',
   QuoteUnavailable = 'QUOTE_UNAVAILABLE',
-  QuoteValidationTimeoutInternal = 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
   RateLimited = 'RATE_LIMITED',
   RequestFailed = 'REQUEST_FAILED',
   ServiceUnavailable = 'SERVICE_UNAVAILABLE',

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -667,9 +667,9 @@ describe('RFQ sessions', () => {
               quoteAmounts(frame);
               socket.send(
                 rfqErrorMessage({
-                  code: 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
+                  code: 'MAKER_QUOTE_LIMITED',
                   errorId: 'reqerr-1',
-                  error: 'quote validation timed out',
+                  error: 'maker quote limited',
                   requestType: 'RFQ_QUOTE',
                   rfqId: RFQ_ID,
                 }),
@@ -691,9 +691,9 @@ describe('RFQ sessions', () => {
             const quote = event.quote({ price: 0.45 });
 
             await expect(quote).rejects.toMatchObject({
-              code: RfqKnownErrorCode.QuoteValidationTimeoutInternal,
+              code: RfqKnownErrorCode.MakerQuoteLimited,
               errorId: 'reqerr-1',
-              message: 'quote validation timed out',
+              message: 'maker quote limited',
               name: 'RfqQuoteRejectedError',
               rfqId: event.rfqId,
             });


### PR DESCRIPTION
## Summary

- remove `QUOTE_VALIDATION_TIMEOUT_INTERNAL` from the known public RFQ error enum
- keep `MAKER_QUOTE_LIMITED` explicitly typed
- preserve forward-compatible handling for unknown server codes without closing the RFQ session

## Context

The gateway maps its internal quote-validation timeout to the public
`SERVICE_UNAVAILABLE` code in Polymarket/combos-rfq#176. The internal
classification should therefore not become part of the SDK's supported public
protocol surface.

This follows up on #198. An older gateway instance can still emit the internal
string during rollout; the open `RfqErrorCode` type continues to pass it
through as an unknown correlated operation error.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (241 tests)
- RFQ client integration regressions for known and unknown quote errors
