### PR TITLE
fix(rfq): drop unreleased QUOTE_VALIDATION_TIMEOUT_INTERNAL error code

### DIFF
--- a/.changeset/drop-internal-rfq-timeout-code.md
+++ b/.changeset/drop-internal-rfq-timeout-code.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Remove the unreleased `QUOTE_VALIDATION_TIMEOUT_INTERNAL` member from `RfqKnownErrorCode`. The gateway now reports quote-validation timeouts as `SERVICE_UNAVAILABLE`; gateways still emitting the internal code during rollout flow through the open `RfqErrorCode` type as plain strings.

--- a/packages/bindings/src/rfq.test.ts
+++ b/packages/bindings/src/rfq.test.ts
@@ -33,12 +33,12 @@ describe('RFQ quoter inbound messages', () => {
       type: 'RFQ_ERROR',
       request_type: 'RFQ_QUOTE',
       rfq_id: 'rfq-1',
-      code: 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
-      error: 'quote validation timed out',
+      code: 'MAKER_QUOTE_LIMITED',
+      error: 'maker quote limited',
     });
 
     expect(message).toMatchObject({
-      code: RfqKnownErrorCode.QuoteValidationTimeoutInternal,
+      code: RfqKnownErrorCode.MakerQuoteLimited,
       type: 'rfq_error',
     });
   });

--- a/packages/bindings/src/rfq.ts
+++ b/packages/bindings/src/rfq.ts
@@ -91,7 +91,6 @@ export enum RfqKnownErrorCode {
   PreExecutionBalanceReservationFailed = 'PRE_EXECUTION_BALANCE_RESERVATION_FAILED',
   QuoteMismatch = 'QUOTE_MISMATCH',
   QuoteUnavailable = 'QUOTE_UNAVAILABLE',
-  QuoteValidationTimeoutInternal = 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
   RateLimited = 'RATE_LIMITED',
   RequestFailed = 'REQUEST_FAILED',
   ServiceUnavailable = 'SERVICE_UNAVAILABLE',

--- a/packages/client/tests/integration/rfq.test.ts
+++ b/packages/client/tests/integration/rfq.test.ts
@@ -667,9 +667,9 @@ describe('RFQ sessions', () => {
               quoteAmounts(frame);
               socket.send(
                 rfqErrorMessage({
-                  code: 'QUOTE_VALIDATION_TIMEOUT_INTERNAL',
+                  code: 'MAKER_QUOTE_LIMITED',
                   errorId: 'reqerr-1',
-                  error: 'quote validation timed out',
+                  error: 'maker quote limited',
                   requestType: 'RFQ_QUOTE',
                   rfqId: RFQ_ID,
                 }),
@@ -691,9 +691,9 @@ describe('RFQ sessions', () => {
             const quote = event.quote({ price: 0.45 });
 
             await expect(quote).rejects.toMatchObject({
-              code: RfqKnownErrorCode.QuoteValidationTimeoutInternal,
+              code: RfqKnownErrorCode.MakerQuoteLimited,
               errorId: 'reqerr-1',
-              message: 'quote validation timed out',
+              message: 'maker quote limited',
               name: 'RfqQuoteRejectedError',
               rfqId: event.rfqId,
             });


### PR DESCRIPTION
## Summary

- remove `QUOTE_VALIDATION_TIMEOUT_INTERNAL` from `RfqKnownErrorCode` before it ships in a release
- repoint the known-code regression tests at `MAKER_QUOTE_LIMITED`

## Context

Polymarket/combos-rfq#176 now classifies quote-validation timeouts as `SERVICE_UNAVAILABLE` on the public wire. The `_INTERNAL` code was a leaked internal classification and should not be enshrined in the public enum. The member added in #198 has not been published to npm, so this is not a breaking change.

Gateways still emitting the code during rollout are covered by the open `RfqErrorCode` contract: the code flows through rejection errors as a plain string and does not close quoter sessions.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm build`
- `pnpm test` (bindings 49, client 190)
- Credential-backed RFQ integration suite left to CI; local runs are currently rate limited on the auth endpoint (same failures on unmodified main)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Enum and test-only cleanup for a never-published error code; runtime behavior for unknown codes is unchanged via the open `RfqErrorCode` type.
> 
> **Overview**
> Removes **`QUOTE_VALIDATION_TIMEOUT_INTERNAL`** from **`RfqKnownErrorCode`** before it ships in a public release. Quote-validation timeouts on the wire are **`SERVICE_UNAVAILABLE`** per gateway changes; the internal code was never meant to be part of the public enum.
> 
> Bindings and client tests that asserted the removed known code now use **`MAKER_QUOTE_LIMITED`** for the same “known RFQ error code” coverage. **`RfqErrorCode`** remains an open string union, so gateways still sending the old code during rollout surface it on rejections without closing sessions.
> 
> Patch changesets for **`@polymarket/bindings`** and **`@polymarket/client`** document the enum trim (unreleased member only—not a published breaking change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04ca4cee547056f13adba9ed289d3fac3611caae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->