### PR TITLE
fix(client): stop approving retired neg-risk adapter in trading setup

### DIFF
--- a/.changeset/remove-retired-neg-risk-approval.md
+++ b/.changeset/remove-retired-neg-risk-approval.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Remove the retired CLOB v1 Neg Risk Adapter from `setupTradingApprovals` and `prepareTradingApprovals`. The setup flow no longer grants a MAX collateral allowance or ERC-1155 approval-for-all to the retired adapter; all current exchanges, collateral adapters, and the auto-redeem operator remain approved.

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -24,11 +24,11 @@ const wallet = expectEvmAddress('0x0000000000000000000000000000000000000001');
 describe('prepareTradingApprovals', () => {
   it('submits every missing approval and waits after each EOA transaction', async () => {
     const { client } = createClient([
+      ...Array<HexString>(7).fill(FALSE_RESULT),
       ...Array<HexString>(8).fill(FALSE_RESULT),
-      ...Array<HexString>(9).fill(FALSE_RESULT),
     ]);
     const workflow = await prepareTradingApprovals(client);
-    const handles = Array.from({ length: 17 }, createTransactionHandle);
+    const handles = Array.from({ length: 15 }, createTransactionHandle);
     let result = await workflow.next();
 
     for (const handle of handles) {
@@ -47,8 +47,8 @@ describe('prepareTradingApprovals', () => {
 
   it('completes without transactions when approvals are already set', async () => {
     const { client, ethCallBatch } = createClient([
-      ...Array<HexString>(8).fill(MAX_UINT256_RESULT),
-      ...Array<HexString>(9).fill(TRUE_RESULT),
+      ...Array<HexString>(7).fill(MAX_UINT256_RESULT),
+      ...Array<HexString>(8).fill(TRUE_RESULT),
     ]);
 
     const workflow = await prepareTradingApprovals(client);
@@ -60,15 +60,15 @@ describe('prepareTradingApprovals', () => {
       value: undefined,
     });
     expect(ethCallBatch).toHaveBeenCalledTimes(1);
-    expect(ethCallBatch.mock.calls[0]?.[0]).toHaveLength(17);
+    expect(ethCallBatch.mock.calls[0]?.[0]).toHaveLength(15);
   });
 
   it('submits only missing approvals', async () => {
     const { client } = createClient([
-      ...Array<HexString>(7).fill(MAX_UINT256_RESULT),
+      ...Array<HexString>(6).fill(MAX_UINT256_RESULT),
       FALSE_RESULT,
       FALSE_RESULT,
-      ...Array<HexString>(8).fill(TRUE_RESULT),
+      ...Array<HexString>(7).fill(TRUE_RESULT),
     ]);
     const firstHandle = createTransactionHandle();
     const secondHandle = createTransactionHandle();

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -493,11 +493,6 @@ function getRequiredTradingApprovals(
       },
       {
         amount: MAX_UINT256,
-        spenderAddress: contracts.negRiskAdapter,
-        tokenAddress: contracts.collateralToken,
-      },
-      {
-        amount: MAX_UINT256,
         spenderAddress: contracts.collateralAdapter,
         tokenAddress: contracts.collateralToken,
       },
@@ -529,10 +524,6 @@ function getRequiredTradingApprovals(
       },
       {
         operatorAddress: contracts.negRiskExchange,
-        tokenAddress: contracts.conditionalTokens,
-      },
-      {
-        operatorAddress: contracts.negRiskAdapter,
         tokenAddress: contracts.conditionalTokens,
       },
       {


### PR DESCRIPTION
TypeScript counterpart of Polymarket/py-sdk#178.

`setupTradingApprovals` / `prepareTradingApprovals` still granted a MAX collateral allowance and ERC-1155 approval-for-all to the CLOB v1 Neg Risk Adapter (`0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296`), which was fully retired on July 17, 2026 at 00:00 UTC (see https://docs.polymarket.com/resources/contracts).

Changes:
- Remove the two approvals to `contracts.negRiskAdapter` from the required trading approvals (15 calls instead of 17).
- The environment contract entry is retained; position lifecycle reads that reference the legacy adapter are unchanged.
- Update approval-count and ordering expectations in `prepareTradingApprovals` unit tests.
- Add a patch changeset for `@polymarket/client`.

Verification:
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:client` (192 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to approval targets only; no auth or data-path changes, and remaining trading operators are still approved.
> 
> **Overview**
> Trading setup no longer requests approvals for the **retired CLOB v1 Neg Risk Adapter**. `getRequiredTradingApprovals` drops the MAX ERC-20 allowance and ERC-1155 approval-for-all entries that targeted `contracts.negRiskAdapter`, so `setupTradingApprovals` / `prepareTradingApprovals` perform **15** on-chain checks and optional txs instead of **17**. Active exchanges, collateral adapters, perps deposit, protocol router, exchange v3, and auto-redeem operator approvals are unchanged.
> 
> The `negRiskAdapter` contract address remains in environment config and is still referenced elsewhere (e.g. position lifecycle). Unit tests in `approvals.test.ts` were updated for the new counts and mock batch sizes. A patch changeset documents the `@polymarket/client` release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec12365f67e2d35934272899d5a29d3973d9fa99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->