### PR TITLE
fix(bindings): add failed withdrawal status and pass unknown statuses through as strings

### DIFF
--- a/.changeset/dev-460-withdrawal-status-forward-compat.md
+++ b/.changeset/dev-460-withdrawal-status-forward-compat.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Accept withdrawal statuses introduced after a client release instead of failing the response parse. Known statuses now live in the `PerpsKnownWithdrawalStatus` enum, which adds the `failed` status the withdrawal contract already includes, and `PerpsWithdrawalStatus` is widened so unrecognized statuses flow through as plain strings.

--- a/packages/bindings/src/perps/common.ts
+++ b/packages/bindings/src/perps/common.ts
@@ -189,13 +189,30 @@ export enum PerpsDepositStatus {
 }
 
 /**
+ * Known withdrawal statuses.
+ *
+ * The service evolves this set independently of released clients, so
+ * withdrawal parsing accepts unknown statuses as plain strings; see
+ * {@link PerpsWithdrawalStatus}.
+ *
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
-export enum PerpsWithdrawalStatus {
+export enum PerpsKnownWithdrawalStatus {
   Pending = 'pending',
   Confirmed = 'confirmed',
   Removed = 'removed',
+  Failed = 'failed',
 }
+
+/**
+ * A withdrawal status. Known statuses are enumerated in
+ * {@link PerpsKnownWithdrawalStatus}; newly introduced statuses flow through
+ * as plain strings so they can be handled before a client release that
+ * enumerates them.
+ *
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export type PerpsWithdrawalStatus = PerpsKnownWithdrawalStatus | (string & {});
 
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.
@@ -260,7 +277,9 @@ export const PerpsDepositStatusSchema = z.enum(PerpsDepositStatus);
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
-export const PerpsWithdrawalStatusSchema = z.enum(PerpsWithdrawalStatus);
+export const PerpsWithdrawalStatusSchema = z
+  .string()
+  .transform((value): PerpsWithdrawalStatus => value);
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */

--- a/packages/bindings/src/perps/funds.test.ts
+++ b/packages/bindings/src/perps/funds.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { PerpsKnownWithdrawalStatus } from './common';
 import {
   PerpsDepositUpdateSchema,
   PerpsWithdrawalSchema,
@@ -38,6 +39,24 @@ describe('PerpsWithdrawalSchema', () => {
     });
 
     expect(withdrawal.hash).toBeUndefined();
+  });
+
+  it('parses failed withdrawals', () => {
+    const withdrawal = PerpsWithdrawalSchema.parse({
+      ...baseWithdrawal,
+      status: 'failed',
+    });
+
+    expect(withdrawal.status).toBe(PerpsKnownWithdrawalStatus.Failed);
+  });
+
+  it('passes unknown withdrawal statuses through as strings', () => {
+    const withdrawal = PerpsWithdrawalSchema.parse({
+      ...baseWithdrawal,
+      status: 'not-a-status-yet',
+    });
+
+    expect(withdrawal.status).toBe('not-a-status-yet');
   });
 });
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -13,10 +13,10 @@ export {
   PerpsInstrumentType,
   PerpsInternalTransferDirection,
   PerpsKlineInterval,
+  PerpsKnownWithdrawalStatus,
   PerpsOrderStatus,
   PerpsSide,
   PerpsTimeInForce,
-  PerpsWithdrawalStatus,
 } from '@polymarket/bindings/perps';
 export type * from '@polymarket/bindings/relayer';
 export * from './abis';


### PR DESCRIPTION
## Summary

- add `failed` to the known perps withdrawal statuses
- rename the enum to `PerpsKnownWithdrawalStatus` and widen `PerpsWithdrawalStatus` to `PerpsKnownWithdrawalStatus | (string & {})`, following the `RfqKnownErrorCode` / `CollateralReturnKnownOperationKind` pattern
- parse withdrawal statuses with a string passthrough schema so statuses introduced after a client release flow through as plain strings instead of failing the response parse
- add schema regression coverage plus a patch changeset

Closes DEV-460.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public bindings/client exports and parsing behavior for withdrawal payloads; low runtime risk but consumers importing `PerpsWithdrawalStatus` as an enum need to switch to `PerpsKnownWithdrawalStatus`.
> 
> **Overview**
> **Perps withdrawal responses no longer fail when the API returns `failed` or a status the client does not yet enumerate.**
> 
> The strict withdrawal status enum is split into **`PerpsKnownWithdrawalStatus`** (adds **`failed`**) and a widened **`PerpsWithdrawalStatus`** type so unknown values stay as plain strings. **`PerpsWithdrawalStatusSchema`** now accepts any string instead of rejecting with Zod, matching the existing RFQ “known enum + open string” pattern.
> 
> **`@polymarket/client`** re-exports **`PerpsKnownWithdrawalStatus`** in place of the old enum export name; **`PerpsWithdrawalStatus`** remains available as a type via perps type exports. Regression tests cover **`failed`** and passthrough of future status strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b13de264fc8fb131b228093abb74007cd5fdc30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->