### PR TITLE
fix(client): make offset pagination clamp-safe at endpoint maximums

### DIFF
--- a/.changeset/offset-pagination-endpoint-maximums.md
+++ b/.changeset/offset-pagination-endpoint-maximums.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Offset pagination no longer silently truncates results when pageSize equals the endpoint maximum on activity, trades, positions, and closed positions. Page sizes above the endpoint maximum are now rejected with a UserInputError instead of returning a silently shrunken page.

--- a/packages/client/src/actions/activity.test.ts
+++ b/packages/client/src/actions/activity.test.ts
@@ -1,0 +1,90 @@
+import { HttpResponse, http } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { createPublicClient } from '../clients';
+import { forkEnvironmentConfig } from '../environments';
+import { UserInputError } from '../errors';
+import { listActivity } from './activity';
+
+const dataRoot = 'http://localhost:4017';
+const server = setupServer();
+const environment = forkEnvironmentConfig({
+  name: 'test',
+  data: { rest: dataRoot },
+});
+const client = createPublicClient({ environment });
+const user = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
+
+// The Data API clamps /activity limits at 500.
+const ACTIVITY_LIMIT_CLAMP = 500;
+
+function mockClampedActivityEndpoint(totalRows: number) {
+  const rows = Array.from({ length: totalRows }, (_, index) => ({
+    proxyWallet: user,
+    timestamp: 1_700_000_000 + index,
+    type: 'REWARD',
+    usdcSize: 1,
+    transactionHash: `0x${index.toString(16).padStart(64, '0')}`,
+  }));
+  const state = { requests: 0 };
+
+  server.use(
+    http.get(`${dataRoot}/activity`, ({ request }) => {
+      state.requests += 1;
+      const url = new URL(request.url);
+      const limit = Math.min(
+        Number(url.searchParams.get('limit')),
+        ACTIVITY_LIMIT_CLAMP,
+      );
+      const offset = Number(url.searchParams.get('offset'));
+
+      return HttpResponse.json(rows.slice(offset, offset + limit));
+    }),
+  );
+
+  return state;
+}
+
+describe('listActivity offset pagination against a clamping endpoint', () => {
+  beforeAll(() => {
+    server.listen({ onUnhandledRequest: 'error' });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('yields every row when pageSize equals the endpoint maximum', async () => {
+    mockClampedActivityEndpoint(501);
+    const items = [];
+
+    for await (const page of listActivity(client, { user, pageSize: 500 })) {
+      items.push(...page.items);
+    }
+
+    expect(items).toHaveLength(501);
+  });
+
+  it('rejects a pageSize above the endpoint maximum', () => {
+    expect(() => listActivity(client, { user, pageSize: 501 })).toThrow(
+      UserInputError,
+    );
+  });
+
+  it('terminates on a short page without an extra request', async () => {
+    const endpoint = mockClampedActivityEndpoint(5);
+    const pages = [];
+
+    for await (const page of listActivity(client, { user, pageSize: 10 })) {
+      pages.push(page);
+    }
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0]?.items).toHaveLength(5);
+    expect(endpoint.requests).toBe(1);
+  });
+});

--- a/packages/client/src/actions/activity.ts
+++ b/packages/client/src/actions/activity.ts
@@ -25,10 +25,11 @@ import {
 import { parseUserInput } from '../input';
 import {
   decodeOffsetCursor,
-  encodeOffsetCursor,
+  offsetRequestLimit,
   PageSizeSchema,
   type Paginated,
   paginate,
+  toOffsetPage,
 } from '../pagination';
 import { validateWith } from '../response';
 import { snakeCase, toDataSearchParams, toSearchParams } from './params';
@@ -37,10 +38,12 @@ export { ComboActivityType } from '@polymarket/bindings/data';
 
 const TradeFilterTypeSchema = z.enum(['CASH', 'TOKENS']);
 
+const TRADES_MAX_PAGE_SIZE = 10_000;
+
 const ListTradesRequestSchema = z
   .object({
     cursor: PaginationCursorSchema.optional(),
-    pageSize: PageSizeSchema.default(20),
+    pageSize: PageSizeSchema.max(TRADES_MAX_PAGE_SIZE).default(20),
     takerOnly: z.boolean().optional(),
     filterType: TradeFilterTypeSchema.optional(),
     filterAmount: z.number().optional(),
@@ -133,35 +136,24 @@ export function listTrades(
       .get('/trades', {
         params: toDataSearchParams({
           ...params,
-          limit: decoded.pageSize + 1,
+          limit: offsetRequestLimit(decoded.pageSize, TRADES_MAX_PAGE_SIZE),
           offset: decoded.offset,
         }),
       })
       .andThen(validateWith(ListTradesResponseSchema))
-      .map((trades) => {
-        const hasMore = trades.length > decoded.pageSize;
-
-        return {
-          items: trades.slice(0, decoded.pageSize),
-          hasMore,
-          nextCursor: hasMore
-            ? encodeOffsetCursor({
-                offset: decoded.offset + decoded.pageSize,
-                pageSize: decoded.pageSize,
-              })
-            : undefined,
-        };
-      });
+      .map((trades) => toOffsetPage(trades, decoded, TRADES_MAX_PAGE_SIZE));
   }, cursor);
 }
 
 const ActivitySortBySchema = z.enum(['TIMESTAMP', 'TOKENS', 'CASH']);
 const SortDirectionSchema = z.enum(['ASC', 'DESC']);
 
+const ACTIVITY_MAX_PAGE_SIZE = 500;
+
 const ListActivityRequestSchema = z
   .object({
     cursor: PaginationCursorSchema.optional(),
-    pageSize: PageSizeSchema.default(20),
+    pageSize: PageSizeSchema.max(ACTIVITY_MAX_PAGE_SIZE).default(20),
     user: z.string(),
     market: z.array(z.string()).optional(),
     eventId: z.array(z.number().int()).optional(),
@@ -247,25 +239,14 @@ export function listActivity(
       .get('/activity', {
         params: toDataSearchParams({
           ...params,
-          limit: decoded.pageSize + 1,
+          limit: offsetRequestLimit(decoded.pageSize, ACTIVITY_MAX_PAGE_SIZE),
           offset: decoded.offset,
         }),
       })
       .andThen(validateWith(ListActivityResponseSchema))
-      .map((activity) => {
-        const hasMore = activity.length > decoded.pageSize;
-
-        return {
-          items: activity.slice(0, decoded.pageSize),
-          hasMore,
-          nextCursor: hasMore
-            ? encodeOffsetCursor({
-                offset: decoded.offset + decoded.pageSize,
-                pageSize: decoded.pageSize,
-              })
-            : undefined,
-        };
-      });
+      .map((activity) =>
+        toOffsetPage(activity, decoded, ACTIVITY_MAX_PAGE_SIZE),
+      );
   }, cursor);
 }
 

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -29,10 +29,11 @@ import {
 import { parseUserInput } from '../input';
 import {
   decodeOffsetCursor,
-  encodeOffsetCursor,
+  offsetRequestLimit,
   PageSizeSchema,
   type Paginated,
   paginate,
+  toOffsetPage,
 } from '../pagination';
 import { readBlob, validateWith } from '../response';
 import { snakeCase, toDataSearchParams, toSearchParams } from './params';
@@ -64,6 +65,8 @@ const PositionSortBySchema = z.enum([
 
 const PositionSortDirectionSchema = z.enum(['ASC', 'DESC']);
 
+const POSITIONS_MAX_PAGE_SIZE = 500;
+
 const ListPositionsRequestSchema = z
   .object({
     cursor: PaginationCursorSchema.optional(),
@@ -73,7 +76,7 @@ const ListPositionsRequestSchema = z
     sizeThreshold: z.number().optional(),
     redeemable: z.boolean().optional(),
     mergeable: z.boolean().optional(),
-    pageSize: PageSizeSchema.default(20),
+    pageSize: PageSizeSchema.max(POSITIONS_MAX_PAGE_SIZE).default(20),
     sortBy: PositionSortBySchema.optional(),
     sortDirection: PositionSortDirectionSchema.optional(),
     title: z.string().max(100).optional(),
@@ -153,25 +156,14 @@ export function listPositions(
       .get('/positions', {
         params: toDataSearchParams({
           ...params,
-          limit: decoded.pageSize + 1,
+          limit: offsetRequestLimit(decoded.pageSize, POSITIONS_MAX_PAGE_SIZE),
           offset: decoded.offset,
         }),
       })
       .andThen(validateWith(ListPositionsResponseSchema))
-      .map((positions) => {
-        const hasMore = positions.length > decoded.pageSize;
-
-        return {
-          items: positions.slice(0, decoded.pageSize),
-          hasMore,
-          nextCursor: hasMore
-            ? encodeOffsetCursor({
-                offset: decoded.offset + decoded.pageSize,
-                pageSize: decoded.pageSize,
-              })
-            : undefined,
-        };
-      });
+      .map((positions) =>
+        toOffsetPage(positions, decoded, POSITIONS_MAX_PAGE_SIZE),
+      );
   }, cursor);
 }
 
@@ -183,6 +175,8 @@ const ClosedPositionSortBySchema = z.enum([
   'TIMESTAMP',
 ]);
 
+const CLOSED_POSITIONS_MAX_PAGE_SIZE = 50;
+
 const ListClosedPositionsRequestSchema = z
   .object({
     cursor: PaginationCursorSchema.optional(),
@@ -190,7 +184,7 @@ const ListClosedPositionsRequestSchema = z
     market: z.array(z.string()).optional(),
     title: z.string().max(100).optional(),
     eventId: z.array(z.number().int()).optional(),
-    pageSize: PageSizeSchema.default(20),
+    pageSize: PageSizeSchema.max(CLOSED_POSITIONS_MAX_PAGE_SIZE).default(20),
     sortBy: ClosedPositionSortBySchema.optional(),
     sortDirection: PositionSortDirectionSchema.optional(),
   })
@@ -271,25 +265,17 @@ export function listClosedPositions(
       .get('/closed-positions', {
         params: toDataSearchParams({
           ...params,
-          limit: decoded.pageSize + 1,
+          limit: offsetRequestLimit(
+            decoded.pageSize,
+            CLOSED_POSITIONS_MAX_PAGE_SIZE,
+          ),
           offset: decoded.offset,
         }),
       })
       .andThen(validateWith(ListClosedPositionsResponseSchema))
-      .map((positions) => {
-        const hasMore = positions.length > decoded.pageSize;
-
-        return {
-          items: positions.slice(0, decoded.pageSize),
-          hasMore,
-          nextCursor: hasMore
-            ? encodeOffsetCursor({
-                offset: decoded.offset + decoded.pageSize,
-                pageSize: decoded.pageSize,
-              })
-            : undefined,
-        };
-      });
+      .map((positions) =>
+        toOffsetPage(positions, decoded, CLOSED_POSITIONS_MAX_PAGE_SIZE),
+      );
   }, cursor);
 }
 

--- a/packages/client/src/pagination.ts
+++ b/packages/client/src/pagination.ts
@@ -86,6 +86,47 @@ export function paginate<T, TError>(
   return createPaginator();
 }
 
+/**
+ * Computes the `limit` for an offset lookahead request. Requests one extra row
+ * to detect a following page, capped at the endpoint's maximum limit so the
+ * lookahead row is never clamped away.
+ *
+ * @internal
+ */
+export function offsetRequestLimit(pageSize: number, maxLimit: number): number {
+  return Math.min(pageSize + 1, maxLimit);
+}
+
+/**
+ * Builds a `Page` from the rows of an offset lookahead request. When the
+ * request limit was capped at the endpoint's maximum limit, a full page is
+ * treated as potentially non-terminal; the following request may yield a
+ * final empty page.
+ *
+ * @internal
+ */
+export function toOffsetPage<T>(
+  rows: T[],
+  state: OffsetCursorState,
+  maxLimit: number,
+): Page<T[]> {
+  const hasMore =
+    state.pageSize < maxLimit
+      ? rows.length > state.pageSize
+      : rows.length >= state.pageSize;
+
+  return {
+    items: rows.slice(0, state.pageSize),
+    hasMore,
+    nextCursor: hasMore
+      ? encodeOffsetCursor({
+          offset: state.offset + state.pageSize,
+          pageSize: state.pageSize,
+        })
+      : undefined,
+  };
+}
+
 /** @internal */
 export function encodeOffsetCursor(state: OffsetCursorState): PaginationCursor {
   return toPaginationCursor(


### PR DESCRIPTION
Fixes DEV-471. Offset-paginated Data API actions (activity, trades, positions, closed positions) requested pageSize + 1 rows to detect a next page, but the API clamps limit at per-endpoint maxima, so a pageSize equal to the maximum silently dropped remaining rows, and a pageSize above it skipped rows.

Page sizes are now capped in the request schemas (UserInputError above the maximum), and the lookahead is clamp-safe: at the maximum, a full page is treated as potentially non-terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pagination semantics for list endpoints; incorrect hasMore logic could cause missed rows or extra API calls, though behavior is covered by new tests and is a targeted bugfix.
> 
> **Overview**
> Fixes offset pagination for **activity**, **trades**, **positions**, and **closed positions** when the Data API caps `limit` per route. The client used `pageSize + 1` for lookahead; at the API max that extra row was clamped away, so a full max-sized page looked terminal and **remaining rows were dropped**. Oversized `pageSize` values could also be clamped without surfacing an error.
> 
> **`offsetRequestLimit`** and **`toOffsetPage`** in `pagination.ts` centralize clamp-safe lookahead (`min(pageSize + 1, maxLimit)`) and **`hasMore`** when `pageSize` equals the endpoint max (full page may still have a next page). Each list action gets a **`PageSizeSchema.max(...)`** cap (500 activity/positions, 50 closed positions, 10k trades); above the max throws **`UserInputError`**.
> 
> MSW tests for **`listActivity`** cover full iteration at max page size, rejection above max, and stopping on a short page without an extra request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13fad0abaea66f72bd0a5c5ac4a0db8eb61d608d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->