### PR TITLE
fix(client): cap pageSize per gamma endpoint and tolerate clamped pagination probes

### DIFF
--- a/.changeset/dev-475-gamma-page-size-caps.md
+++ b/.changeset/dev-475-gamma-page-size-caps.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Fix silent pagination truncation on the remaining offset-paginated list methods, matching the fix already applied to data-backed methods. The upstream service silently clamps `limit` per endpoint, so a `pageSize` at or above the cap made the look-ahead probe come back clamped and pagination stopped after the first page without an error. `pageSize` is now validated against each endpoint's cap (`listTags`, `listComments`, `listCommentsByUserAddress`, `listTeams`, `listMarketClarifications` 99; `listSeries` 49) and rejects invalid values with `UserInputError`. The `hasMore` probe on these methods is also clamp-tolerant now: a full page continues pagination instead of relying on the extra probe row, at the cost of one extra empty-page request when the total count is an exact multiple of `pageSize`.

--- a/packages/client/src/actions/comments.ts
+++ b/packages/client/src/actions/comments.ts
@@ -34,7 +34,8 @@ import { snakeCase, toSearchParams } from './params';
 const ListCommentsRequestSchema = z.object({
   ascending: z.boolean().optional(),
   cursor: PaginationCursorSchema.optional(),
-  pageSize: PageSizeSchema.default(20),
+  // Upstream caps limit at 100 and the probe requests pageSize + 1.
+  pageSize: PageSizeSchema.max(99).default(20),
   getPositions: z.boolean().optional(),
   holdersOnly: z.boolean().optional(),
   order: z.string().optional(),
@@ -52,7 +53,8 @@ const ListCommentsByUserAddressRequestSchema = z.object({
   ascending: z.boolean().optional(),
   cursor: PaginationCursorSchema.optional(),
   order: z.string().optional(),
-  pageSize: PageSizeSchema.default(20),
+  // Upstream caps limit at 100 and the probe requests pageSize + 1.
+  pageSize: PageSizeSchema.max(99).default(20),
 });
 
 export type ListCommentsRequest = z.input<typeof ListCommentsRequestSchema>;
@@ -147,7 +149,7 @@ export function listComments(
       })
       .andThen(validateWith(ListCommentsResponseSchema))
       .map((comments) => {
-        const hasMore = comments.length > decoded.pageSize;
+        const hasMore = comments.length >= decoded.pageSize;
 
         return {
           items: comments.slice(0, decoded.pageSize),
@@ -296,7 +298,7 @@ export function listCommentsByUserAddress(
       })
       .andThen(validateWith(ListCommentsResponseSchema))
       .map((comments) => {
-        const hasMore = comments.length > decoded.pageSize;
+        const hasMore = comments.length >= decoded.pageSize;
 
         return {
           items: comments.slice(0, decoded.pageSize),

--- a/packages/client/src/actions/market-clarifications.ts
+++ b/packages/client/src/actions/market-clarifications.ts
@@ -40,7 +40,8 @@ const ListMarketClarificationsRequestSchema = z.object({
   order: z.string().optional(),
   ascending: z.boolean().optional(),
   cursor: PaginationCursorSchema.optional(),
-  pageSize: PageSizeSchema.default(20),
+  // Upstream caps limit at 100 and the probe requests pageSize + 1.
+  pageSize: PageSizeSchema.max(99).default(20),
 });
 
 export type ListMarketClarificationsRequest = z.input<
@@ -124,7 +125,7 @@ export function listMarketClarifications(
       })
       .andThen(validateWith(ListMarketClarificationsResponseSchema))
       .map((clarifications) => {
-        const hasMore = clarifications.length > decoded.pageSize;
+        const hasMore = clarifications.length >= decoded.pageSize;
 
         return {
           items: clarifications.slice(0, decoded.pageSize),

--- a/packages/client/src/actions/series.ts
+++ b/packages/client/src/actions/series.ts
@@ -33,7 +33,8 @@ const ListSeriesRequestSchema = z.object({
   excludeEvents: z.boolean().optional(),
   locale: z.string().optional(),
   order: z.string().optional(),
-  pageSize: PageSizeSchema.default(20),
+  // Upstream caps limit at 50 and the probe requests pageSize + 1.
+  pageSize: PageSizeSchema.max(49).default(20),
   recurrence: z.enum(['daily', 'weekly', 'monthly']).optional(),
   slug: z.array(z.string()).optional(),
 });
@@ -123,7 +124,7 @@ export function listSeries(
       })
       .andThen(validateWith(ListSeriesResponseSchema))
       .map((series) => {
-        const hasMore = series.length > decoded.pageSize;
+        const hasMore = series.length >= decoded.pageSize;
 
         return {
           items: series.slice(0, decoded.pageSize),

--- a/packages/client/src/actions/tags.ts
+++ b/packages/client/src/actions/tags.ts
@@ -36,7 +36,8 @@ const ListTagsRequestSchema = z.object({
   isCarousel: z.boolean().optional(),
   locale: z.string().optional(),
   order: z.string().optional(),
-  pageSize: PageSizeSchema.default(20),
+  // Upstream caps limit at 100 and the probe requests pageSize + 1.
+  pageSize: PageSizeSchema.max(99).default(20),
 });
 
 const FetchTagRequestSchema = z.union([
@@ -161,7 +162,7 @@ export function listTags(
       })
       .andThen(validateWith(ListTagsResponseSchema))
       .map((tags) => {
-        const hasMore = tags.length > decoded.pageSize;
+        const hasMore = tags.length >= decoded.pageSize;
 
         return {
           items: tags.slice(0, decoded.pageSize),

--- a/packages/client/src/actions/teams.ts
+++ b/packages/client/src/actions/teams.ts
@@ -28,7 +28,8 @@ const ListTeamsRequestSchema = z.object({
   league: z.array(z.string()).optional(),
   name: z.array(z.string()).optional(),
   order: z.string().optional(),
-  pageSize: PageSizeSchema.default(20),
+  // Upstream caps limit at 100 and the probe requests pageSize + 1.
+  pageSize: PageSizeSchema.max(99).default(20),
   providerId: z.array(z.number().int()).optional(),
 });
 
@@ -111,7 +112,7 @@ export function listTeams(
       })
       .andThen(validateWith(ListTeamsResponseSchema))
       .map((teams) => {
-        const hasMore = teams.length > decoded.pageSize;
+        const hasMore = teams.length >= decoded.pageSize;
 
         return {
           items: teams.slice(0, decoded.pageSize),

--- a/packages/client/tests/integration/comments.test.ts
+++ b/packages/client/tests/integration/comments.test.ts
@@ -22,7 +22,7 @@ describe('Comments', () => {
       const paginator = publicClient.listComments({
         parentEntityId: commentEvent.id,
         parentEntityType: CommentParentEntityType.Event,
-        pageSize: 100,
+        pageSize: 99,
       });
       const firstPage = await paginator.firstPage();
 

--- a/packages/client/tests/integration/series.test.ts
+++ b/packages/client/tests/integration/series.test.ts
@@ -5,7 +5,7 @@ describe('Series', () => {
   describe('listSeries', () => {
     it('fetches series', async ({ publicClient }) => {
       const paginator = publicClient.listSeries({
-        pageSize: 100,
+        pageSize: 49,
       });
       const result = await paginator.firstPage().then(expectNonEmptyPage);
 

--- a/packages/client/tests/integration/tags.test.ts
+++ b/packages/client/tests/integration/tags.test.ts
@@ -11,14 +11,14 @@ describe('Tags', () => {
     it('fetches tags', async ({ publicClient }) => {
       const result = await publicClient
         .listTags({
-          pageSize: 100,
+          pageSize: 99,
         })
         .firstPage()
         .then(expectNonEmptyPage);
 
       expect(result.items.length).toBeGreaterThan(0);
       await expectPageWindow(
-        publicClient.listTags({ pageSize: 100 }),
+        publicClient.listTags({ pageSize: 99 }),
         result,
         99,
       );

--- a/packages/client/tests/integration/teams.test.ts
+++ b/packages/client/tests/integration/teams.test.ts
@@ -5,7 +5,7 @@ describe('Teams', () => {
   describe('listTeams', () => {
     it('fetches teams', async ({ publicClient }) => {
       const paginator = publicClient.listTeams({
-        pageSize: 100,
+        pageSize: 99,
       });
       const result = await paginator.firstPage().then(expectNonEmptyPage);
 


### PR DESCRIPTION
Follow-up to #240: applies the same silent-truncation fix to the Gamma-backed offset-probe methods (DEV-475).

## Problem

Every Gamma list endpoint silently clamps `?limit` at the query layer; past-cap limits never 400. Same failure mode as #240: a `pageSize` at or above the cap made the `pageSize + 1` probe come back clamped, the SDK saw a full page, and pagination stopped after the first page without an error. Unlike the data service there is no strict-400 change planned upstream, and the caps have already drifted once (markets-tooling #1501 lowered them in May 2026), so clamp tolerance matters here long-term.

## Changes

- Cap `pageSize` in the request schemas one below each endpoint's server-side limit cap (probe headroom), rejecting invalid values with `UserInputError`:
  - `listTags`, `listComments`, `listCommentsByUserAddress`, `listTeams`, `listMarketClarifications`: 99 (server cap 100)
  - `listSeries`: 49 (server cap 50) — `pageSize: 50` truncated silently before this change
- Make the `hasMore` probe clamp-tolerant on these six call sites (`>=` instead of `>`), matching #240. Costs one extra empty-page request when the total is an exact multiple of `pageSize`.

Caps verified against the Gamma limit clamp helper and per-endpoint constants on current markets-tooling `main` (`model.AppendArgs`, `model/constants.go`); the by-user comments route clamps at the same 100 cap as `/comments`. `listMarkets` / `listEvents` are cursor-based and unaffected; search is page-based and out of scope.

Independent of #240 (no overlapping files); mergeable in either order.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm test` (244 unit tests)
- Live integration: tags, comments, series, teams, market-clarifications suites pass; the series and teams walks now page far past the old truncation point

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pagination behavior across six public list methods; fixes data completeness but alters `pageSize` validation (breaking for callers passing 100+) and may add one redundant request per full walk.
> 
> **Overview**
> Fixes **silent first-page-only pagination** on the remaining Gamma offset-paginated list APIs when upstream silently clamps `limit` (same pattern as the earlier data-service fix).
> 
> **`pageSize` validation** now enforces per-endpoint maximums one below the server cap so the `pageSize + 1` probe can work: **99** for `listTags`, `listComments`, `listCommentsByUserAddress`, `listTeams`, and `listMarketClarifications` (cap 100), and **49** for `listSeries` (cap 50). Values above those limits fail at input with **`UserInputError`** instead of truncating quietly.
> 
> **`hasMore` detection** on those six call sites switches from `length > pageSize` to **`length >= pageSize`**, so a full page still advances when the extra probe row is clamped away. Totals that are an exact multiple of `pageSize` may incur **one extra empty request** at the end.
> 
> Integration tests use the new caps (`99` / `49`) for pagination walks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b7e03ff11a0470077d3d1b4fc1db0111b7f2f49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->