### PR TITLE
test(client): skip failing Safe collateral return test

### DIFF
--- a/packages/client/tests/integration/collateral-return.test.ts
+++ b/packages/client/tests/integration/collateral-return.test.ts
@@ -135,7 +135,9 @@ describe('Collateral return', () => {
     300_000,
   );
 
-  it.runIf(runMeteredTests)(
+  // TODO(DEV-482): Re-enable after the Safe combo split no longer reverts
+  // during relayer delegatecall simulation.
+  it.skipIf(true)(
     'seeds and executes a collateral return for a Safe Wallet account',
     async ({
       builderAuthentication,


### PR DESCRIPTION
## Summary

- skip the metered Safe Wallet collateral-return execution test
- keep Deposit Wallet, Proxy Wallet, and Safe planning coverage enabled
- link the disabled case to [DEV-482](https://linear.app/polymarket/issue/DEV-482/investigate-safe-combo-split-relayer-simulation-revert-in-collateral)

## Why

The test currently fails while seeding returnable inventory. The Safe combo split is submitted to `relayer-v2` as a MultiSend delegatecall, and the relayer rejects it during gas-estimation simulation. The failure occurs before the collateral-return domain submission is reached.

This temporarily removes the known failing case from CI while DEV-482 tracks root-cause investigation and restoration of coverage.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:client:integration packages/client/tests/integration/collateral-return.test.ts` (4 passed, 5 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production or client runtime behavior is modified.
> 
> **Overview**
> **Temporarily disables** the metered integration test that seeds combo inventory and runs a full collateral return for **Safe Wallet** accounts.
> 
> The test is switched from `it.runIf(runMeteredTests)` to `it.skipIf(true)` with a **DEV-482** TODO noting the Safe combo split reverts during relayer MultiSend delegatecall simulation. **Deposit Wallet**, **Proxy Wallet**, and Safe **planning** tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83fbe14ff514901cf41247970f4a35120341f4d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->