### PR TITLE
feat: add chainlink TWAP realtime subscriptions

### DIFF
--- a/.changeset/bright-tigers-stream.md
+++ b/.changeset/bright-tigers-stream.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Add typed 30-second and 60-second Chainlink TWAP realtime subscriptions.

--- a/.changeset/bright-tigers-stream.md
+++ b/.changeset/bright-tigers-stream.md
@@ -1,6 +1,6 @@
 ---
-"@polymarket/bindings": patch
-"@polymarket/client": patch
+"@polymarket/bindings": minor
+"@polymarket/client": minor
 ---
 
 Add typed 30-second and 60-second Chainlink TWAP realtime subscriptions.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@polymarket/examples": "0.0.0",
+    "@polymarket/bindings": "0.2.0",
+    "@polymarket/client": "0.2.0",
+    "@polymarket/types": "0.1.0"
+  },
+  "changesets": []
+}

--- a/examples/scripts/src/public-streams.ts
+++ b/examples/scripts/src/public-streams.ts
@@ -7,6 +7,11 @@ const stream = await client.subscribe([
     topic: 'prices.crypto.chainlink',
   },
   {
+    topic: 'prices.crypto.chainlink.twap',
+    windowSeconds: 30,
+    symbols: ['btc/usd'],
+  },
+  {
     topic: 'sports',
   },
 ]);
@@ -20,6 +25,12 @@ for await (const event of stream) {
     case 'prices.crypto.chainlink':
       console.log(
         `${new Date(event.payload.timestamp).toLocaleString()} - Chainlink price update: ${event.payload.value} ${event.payload.symbol}`,
+      );
+      break;
+
+    case 'prices.crypto.chainlink.twap':
+      console.log(
+        `${new Date(event.payload.timestamp).toLocaleString()} - Chainlink ${event.payload.windowSeconds}s TWAP update: ${event.payload.value} ${event.payload.symbol}`,
       );
       break;
 

--- a/packages/bindings/src/subscriptions/rtds.test.ts
+++ b/packages/bindings/src/subscriptions/rtds.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CryptoPricesChainlinkTwapEventSchema,
+  RealtimeEventSchema,
+} from './rtds';
+
+const observationTimestamp = 1_772_752_581_815;
+const publicationTimestamp = 1_772_752_582_004;
+
+const rawTwapEvent = {
+  connection_id: 'connection-1234567890',
+  type: 'update',
+  timestamp: publicationTimestamp,
+  payload: {
+    symbol: 'btc/usd',
+    value: 65_000.5,
+    full_accuracy_value: '65000500000000000000000',
+    timestamp: observationTimestamp,
+  },
+} as const;
+
+describe('CryptoPricesChainlinkTwapEventSchema', () => {
+  it.each([
+    ['crypto_prices_twap_thirty', 30],
+    ['crypto_prices_twap_sixty', 60],
+  ] as const)('normalizes the %s wire topic and its window', (rawTopic, windowSeconds) => {
+    const parsed = RealtimeEventSchema.parse({
+      ...rawTwapEvent,
+      topic: rawTopic,
+      payload: {
+        ...rawTwapEvent.payload,
+        window_s: windowSeconds,
+      },
+    });
+
+    expect(parsed).toEqual({
+      topic: 'prices.crypto.chainlink.twap',
+      type: 'update',
+      timestamp: publicationTimestamp,
+      payload: {
+        symbol: 'btc/usd',
+        value: '65000.5',
+        timestamp: observationTimestamp,
+        windowSeconds,
+      },
+    });
+  });
+
+  it.each([
+    ['crypto_prices_twap_thirty', 60],
+    ['crypto_prices_twap_sixty', 30],
+  ] as const)('rejects a %s frame whose payload claims window %i', (rawTopic, windowSeconds) => {
+    const parsed = CryptoPricesChainlinkTwapEventSchema.safeParse({
+      ...rawTwapEvent,
+      topic: rawTopic,
+      payload: {
+        ...rawTwapEvent.payload,
+        window_s: windowSeconds,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('normalizes the exact E18 value instead of the rounded display float', () => {
+    const parsed = CryptoPricesChainlinkTwapEventSchema.safeParse({
+      ...rawTwapEvent,
+      topic: 'crypto_prices_twap_thirty',
+      payload: {
+        ...rawTwapEvent.payload,
+        value: 65_000.12345678901,
+        full_accuracy_value: '65000123456789012345678',
+        window_s: 30,
+      },
+    });
+
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.payload.value).toBe('65000.123456789012345678');
+    }
+  });
+
+  it.each([
+    ['0', '0'],
+    ['1', '0.000000000000000001'],
+    ['-1', '-0.000000000000000001'],
+    ['1000000000000000000', '1'],
+    ['-1000000000000000000', '-1'],
+    ['1230000000000000000', '1.23'],
+  ] as const)('normalizes the E18 boundary value %s', (rawValue, expected) => {
+    const parsed = CryptoPricesChainlinkTwapEventSchema.parse({
+      ...rawTwapEvent,
+      topic: 'crypto_prices_twap_thirty',
+      payload: {
+        ...rawTwapEvent.payload,
+        full_accuracy_value: rawValue,
+        window_s: 30,
+      },
+    });
+
+    expect(parsed.payload.value).toBe(expected);
+  });
+
+  it('rejects a frame without the exact price', () => {
+    const { full_accuracy_value: _, ...payload } = rawTwapEvent.payload;
+    const parsed = CryptoPricesChainlinkTwapEventSchema.safeParse({
+      ...rawTwapEvent,
+      topic: 'crypto_prices_twap_thirty',
+      payload: { ...payload, window_s: 30 },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('rejects a non-integer exact price without throwing', () => {
+    const parsed = CryptoPricesChainlinkTwapEventSchema.safeParse({
+      ...rawTwapEvent,
+      topic: 'crypto_prices_twap_thirty',
+      payload: {
+        ...rawTwapEvent.payload,
+        full_accuracy_value: '1.2',
+        window_s: 30,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/bindings/src/subscriptions/rtds.ts
+++ b/packages/bindings/src/subscriptions/rtds.ts
@@ -10,6 +10,7 @@ import {
   DecimalishSchema,
   DecimalStringSchema,
   EpochMillisecondsSchema,
+  toDecimalString,
 } from '../shared';
 
 const CommentRemovedPayloadSchema = z.object({
@@ -78,9 +79,14 @@ export type PriceUpdatePayload = z.infer<typeof PriceUpdatePayloadSchema>;
 
 const CRYPTO_PRICES_BINANCE_TOPIC = 'prices.crypto.binance' as const;
 const CRYPTO_PRICES_CHAINLINK_TOPIC = 'prices.crypto.chainlink' as const;
+const CRYPTO_PRICES_CHAINLINK_TWAP_TOPIC =
+  'prices.crypto.chainlink.twap' as const;
 
 export type CryptoPricesBinanceTopic = typeof CRYPTO_PRICES_BINANCE_TOPIC;
 export type CryptoPricesChainlinkTopic = typeof CRYPTO_PRICES_CHAINLINK_TOPIC;
+export type CryptoPricesChainlinkTwapTopic =
+  typeof CRYPTO_PRICES_CHAINLINK_TWAP_TOPIC;
+export type CryptoPricesChainlinkTwapWindowSeconds = 30 | 60;
 export type CryptoPricesTopic =
   | CryptoPricesBinanceTopic
   | CryptoPricesChainlinkTopic;
@@ -88,6 +94,12 @@ export type CryptoPricesTopic =
 const RawCryptoPricesBinanceTopicSchema = z.literal('crypto_prices');
 const RawCryptoPricesChainlinkTopicSchema = z.literal(
   'crypto_prices_chainlink',
+);
+const RawCryptoPricesChainlinkTwapThirtyTopicSchema = z.literal(
+  'crypto_prices_twap_thirty',
+);
+const RawCryptoPricesChainlinkTwapSixtyTopicSchema = z.literal(
+  'crypto_prices_twap_sixty',
 );
 
 const CryptoPricesBinanceTopicSchema: z.ZodType<CryptoPricesBinanceTopic> =
@@ -98,6 +110,16 @@ const CryptoPricesBinanceTopicSchema: z.ZodType<CryptoPricesBinanceTopic> =
 const CryptoPricesChainlinkTopicSchema: z.ZodType<CryptoPricesChainlinkTopic> =
   RawCryptoPricesChainlinkTopicSchema.transform(() => {
     return CRYPTO_PRICES_CHAINLINK_TOPIC;
+  });
+
+const CryptoPricesChainlinkTwapThirtyTopicSchema =
+  RawCryptoPricesChainlinkTwapThirtyTopicSchema.transform(() => {
+    return CRYPTO_PRICES_CHAINLINK_TWAP_TOPIC;
+  });
+
+const CryptoPricesChainlinkTwapSixtyTopicSchema =
+  RawCryptoPricesChainlinkTwapSixtyTopicSchema.transform(() => {
+    return CRYPTO_PRICES_CHAINLINK_TWAP_TOPIC;
   });
 
 export const CryptoPricesBinanceEventSchema = z.object({
@@ -122,9 +144,88 @@ export type CryptoPricesChainlinkEvent = z.infer<
   typeof CryptoPricesChainlinkEventSchema
 >;
 
+const CHAINLINK_PRICE_SCALE = 1_000_000_000_000_000_000n;
+
+function chainlinkE18PriceToDecimalString(value: string) {
+  const scaledValue = BigInt(value);
+  const isNegative = scaledValue < 0n;
+  const absoluteValue = isNegative ? -scaledValue : scaledValue;
+  const whole = absoluteValue / CHAINLINK_PRICE_SCALE;
+  const fraction = (absoluteValue % CHAINLINK_PRICE_SCALE)
+    .toString()
+    .padStart(18, '0')
+    .replace(/0+$/, '');
+
+  return toDecimalString(
+    `${isNegative ? '-' : ''}${whole}${fraction === '' ? '' : `.${fraction}`}`,
+  );
+}
+
+// Chainlink publishes a float for display convenience and the exact
+// BenchmarkPrice as a signed E18 integer. Normalize from the exact field.
+const ChainlinkFullAccuracyPriceSchema = z
+  .string()
+  .regex(/^-?\d+$/)
+  .transform(chainlinkE18PriceToDecimalString);
+
+const CryptoPricesChainlinkTwapPayloadBaseSchema = z.object({
+  symbol: z.string(),
+  value: DecimalishSchema,
+  full_accuracy_value: ChainlinkFullAccuracyPriceSchema,
+  timestamp: EpochMillisecondsSchema,
+});
+
+function cryptoPricesChainlinkTwapPayloadSchema<
+  const TWindowSeconds extends CryptoPricesChainlinkTwapWindowSeconds,
+>(windowSeconds: TWindowSeconds) {
+  return CryptoPricesChainlinkTwapPayloadBaseSchema.extend({
+    window_s: z.literal(windowSeconds),
+  }).transform((payload) => {
+    return {
+      symbol: payload.symbol,
+      timestamp: payload.timestamp,
+      value: payload.full_accuracy_value,
+      windowSeconds: payload.window_s,
+    };
+  });
+}
+
+export const CryptoPricesChainlinkTwapThirtyEventSchema = z.object({
+  topic: CryptoPricesChainlinkTwapThirtyTopicSchema,
+  type: z.literal('update'),
+  timestamp: EpochMillisecondsSchema,
+  payload: cryptoPricesChainlinkTwapPayloadSchema(30),
+});
+
+export type CryptoPricesChainlinkTwapThirtyEvent = z.infer<
+  typeof CryptoPricesChainlinkTwapThirtyEventSchema
+>;
+
+export const CryptoPricesChainlinkTwapSixtyEventSchema = z.object({
+  topic: CryptoPricesChainlinkTwapSixtyTopicSchema,
+  type: z.literal('update'),
+  timestamp: EpochMillisecondsSchema,
+  payload: cryptoPricesChainlinkTwapPayloadSchema(60),
+});
+
+export type CryptoPricesChainlinkTwapSixtyEvent = z.infer<
+  typeof CryptoPricesChainlinkTwapSixtyEventSchema
+>;
+
+export const CryptoPricesChainlinkTwapEventSchema = z.union([
+  CryptoPricesChainlinkTwapThirtyEventSchema,
+  CryptoPricesChainlinkTwapSixtyEventSchema,
+]);
+
+export type CryptoPricesChainlinkTwapEvent = z.infer<
+  typeof CryptoPricesChainlinkTwapEventSchema
+>;
+
 export const CryptoPricesEventSchema = z.discriminatedUnion('topic', [
   CryptoPricesBinanceEventSchema,
   CryptoPricesChainlinkEventSchema,
+  CryptoPricesChainlinkTwapThirtyEventSchema,
+  CryptoPricesChainlinkTwapSixtyEventSchema,
 ]);
 
 export type CryptoPricesEvent = z.infer<typeof CryptoPricesEventSchema>;

--- a/packages/client/src/actions/subscriptions.test-d.ts
+++ b/packages/client/src/actions/subscriptions.test-d.ts
@@ -1,6 +1,9 @@
 import type {
   CryptoPricesBinanceEvent,
   CryptoPricesChainlinkEvent,
+  CryptoPricesChainlinkTwapEvent,
+  CryptoPricesChainlinkTwapSixtyEvent,
+  CryptoPricesChainlinkTwapThirtyEvent,
   CustomMarketEvent,
   MarketEvent,
   SportsEvent,
@@ -8,14 +11,32 @@ import type {
   UserEvent,
 } from '@polymarket/bindings/subscriptions';
 import { describe, expectTypeOf, it } from 'vitest';
-import { createPublicClient } from '../index';
+import type { TransportError, UserInputError } from '../errors';
+import {
+  createPublicClient,
+  type CryptoPricesChainlinkTwapEvent as RootCryptoPricesChainlinkTwapEvent,
+  type CryptoPricesChainlinkTwapSubscription as RootCryptoPricesChainlinkTwapSubscription,
+  type CryptoPricesChainlinkTwapWindowSeconds as RootCryptoPricesChainlinkTwapWindowSeconds,
+} from '../index';
 import type {
   EquityPricesEvent,
   EventForSubscriptionSpecs,
+  SubscribeError,
   SubscriptionHandle,
 } from './subscriptions';
 
 describe('EventForSubscriptionSpecs', () => {
+  it('exports the TWAP public surface from the package root', () => {
+    expectTypeOf<RootCryptoPricesChainlinkTwapSubscription>().toMatchTypeOf<{
+      topic: 'prices.crypto.chainlink.twap';
+      windowSeconds: 30 | 60;
+    }>();
+    expectTypeOf<RootCryptoPricesChainlinkTwapEvent>().toEqualTypeOf<CryptoPricesChainlinkTwapEvent>();
+    expectTypeOf<RootCryptoPricesChainlinkTwapWindowSeconds>().toEqualTypeOf<
+      30 | 60
+    >();
+  });
+
   it('narrows a standard market spec to standard market events', () => {
     type MarketOnly = EventForSubscriptionSpecs<
       readonly [{ topic: 'market'; tokenIds: readonly string[] }]
@@ -79,6 +100,57 @@ describe('EventForSubscriptionSpecs', () => {
     expectTypeOf<ChainlinkOnly>().toEqualTypeOf<CryptoPricesChainlinkEvent>();
   });
 
+  it('narrows each Chainlink TWAP window to its exact event type', () => {
+    type ThirtySecondTwap = EventForSubscriptionSpecs<
+      readonly [{ topic: 'prices.crypto.chainlink.twap'; windowSeconds: 30 }]
+    >;
+    type SixtySecondTwap = EventForSubscriptionSpecs<
+      readonly [{ topic: 'prices.crypto.chainlink.twap'; windowSeconds: 60 }]
+    >;
+
+    expectTypeOf<ThirtySecondTwap>().toEqualTypeOf<CryptoPricesChainlinkTwapThirtyEvent>();
+    expectTypeOf<SixtySecondTwap>().toEqualTypeOf<CryptoPricesChainlinkTwapSixtyEvent>();
+  });
+
+  it('keeps both TWAP event variants when the window is dynamic', () => {
+    type DynamicTwap = EventForSubscriptionSpecs<
+      readonly [
+        {
+          topic: 'prices.crypto.chainlink.twap';
+          windowSeconds: 30 | 60;
+        },
+      ]
+    >;
+
+    expectTypeOf<DynamicTwap>().toEqualTypeOf<CryptoPricesChainlinkTwapEvent>();
+  });
+
+  it('unions exact events when subscribing to both TWAP windows', () => {
+    type BothWindows = EventForSubscriptionSpecs<
+      readonly [
+        { topic: 'prices.crypto.chainlink.twap'; windowSeconds: 30 },
+        { topic: 'prices.crypto.chainlink.twap'; windowSeconds: 60 },
+      ]
+    >;
+
+    expectTypeOf<BothWindows>().toEqualTypeOf<
+      CryptoPricesChainlinkTwapThirtyEvent | CryptoPricesChainlinkTwapSixtyEvent
+    >();
+  });
+
+  it('unions spot and exact-window TWAP events', () => {
+    type SpotAndTwap = EventForSubscriptionSpecs<
+      readonly [
+        { topic: 'prices.crypto.chainlink' },
+        { topic: 'prices.crypto.chainlink.twap'; windowSeconds: 60 },
+      ]
+    >;
+
+    expectTypeOf<SpotAndTwap>().toEqualTypeOf<
+      CryptoPricesChainlinkEvent | CryptoPricesChainlinkTwapSixtyEvent
+    >();
+  });
+
   it('maps equity prices to the equity event union', () => {
     type EquityOnly = EventForSubscriptionSpecs<
       readonly [{ topic: 'prices.equity.pyth'; symbol: string }]
@@ -94,6 +166,14 @@ describe('EventForSubscriptionSpecs', () => {
       ]
     >;
     expectTypeOf<Mixed>().toEqualTypeOf<StandardMarketEvent | SportsEvent>();
+  });
+});
+
+describe('SubscribeError', () => {
+  it('includes invalid input and transport failures', () => {
+    expectTypeOf<SubscribeError>().toEqualTypeOf<
+      UserInputError | TransportError
+    >();
   });
 });
 
@@ -118,6 +198,35 @@ describe('PublicClient.subscribe', () => {
     expectTypeOf(pending).resolves.toEqualTypeOf<
       SubscriptionHandle<MarketEvent>
     >();
+  });
+
+  it('infers the exact TWAP event from the requested window', async () => {
+    const client = createPublicClient();
+
+    const pending = client.subscribe([
+      {
+        topic: 'prices.crypto.chainlink.twap',
+        windowSeconds: 30,
+        symbols: ['btc/usd'],
+      },
+    ]);
+    expectTypeOf(pending).resolves.toEqualTypeOf<
+      SubscriptionHandle<CryptoPricesChainlinkTwapThirtyEvent>
+    >();
+  });
+
+  it('requires a supported TWAP window', () => {
+    const client = createPublicClient();
+
+    // @ts-expect-error TWAP subscriptions require an explicit window.
+    client.subscribe([{ topic: 'prices.crypto.chainlink.twap' }]);
+    client.subscribe([
+      {
+        topic: 'prices.crypto.chainlink.twap',
+        // @ts-expect-error Only the published 30s and 60s feeds are supported.
+        windowSeconds: 45,
+      },
+    ]);
   });
 
   it('excludes secure-only events from a public subscription', async () => {

--- a/packages/client/src/actions/subscriptions.test.ts
+++ b/packages/client/src/actions/subscriptions.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TransportError, UserInputError } from '../errors';
+import { createPublicClient, SubscribeError } from '../index';
+
+describe('SubscribeError', () => {
+  it('recognizes every documented subscription error', () => {
+    expect(SubscribeError.isError(new UserInputError('invalid window'))).toBe(
+      true,
+    );
+    expect(
+      SubscribeError.isError(new TransportError('connection failed')),
+    ).toBe(true);
+    expect(SubscribeError.isError(new Error('unexpected'))).toBe(false);
+  });
+});
+
+describe('PublicClient.subscribe', () => {
+  it('validates a batch before opening any subscriptions', async () => {
+    const client = createPublicClient();
+    const subscribe = vi.spyOn(client.webSockets.rtds, 'subscribe');
+
+    const error = await client
+      .subscribe([
+        { topic: 'prices.crypto.chainlink' },
+        {
+          topic: 'prices.crypto.chainlink.twap',
+          windowSeconds: 45,
+        } as never,
+      ])
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(UserInputError);
+    expect(error).toHaveProperty(
+      'message',
+      'TWAP window must be 30 or 60 seconds, received 45.',
+    );
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+});

--- a/packages/client/src/actions/subscriptions.ts
+++ b/packages/client/src/actions/subscriptions.ts
@@ -3,6 +3,11 @@ import type {
   CommentsEvent,
   CryptoPricesBinanceEvent,
   CryptoPricesChainlinkEvent,
+  CryptoPricesChainlinkTwapEvent,
+  CryptoPricesChainlinkTwapSixtyEvent,
+  CryptoPricesChainlinkTwapThirtyEvent,
+  CryptoPricesChainlinkTwapTopic,
+  CryptoPricesChainlinkTwapWindowSeconds,
   CryptoPricesEvent,
   CryptoPricesTopic,
   CustomMarketEvent,
@@ -27,13 +32,18 @@ import type {
   BasePublicClient,
   BaseSecureClient,
 } from '../clients';
-import type { TransportError } from '../errors';
+import { makeErrorGuard, TransportError, UserInputError } from '../errors';
+import { validateTwapSubscriptionWindow } from '../subscription-validation';
 
 // Event types — re-exported from bindings for consumer convenience.
 export type {
   CommentsEvent,
   CryptoPricesBinanceEvent,
   CryptoPricesChainlinkEvent,
+  CryptoPricesChainlinkTwapEvent,
+  CryptoPricesChainlinkTwapSixtyEvent,
+  CryptoPricesChainlinkTwapThirtyEvent,
+  CryptoPricesChainlinkTwapWindowSeconds,
   CryptoPricesEvent,
   CustomMarketEvent,
   EquityPricesEvent,
@@ -103,6 +113,14 @@ export type CommentsSubscription = {
 
 export type CryptoPricesSubscription = {
   topic: CryptoPricesTopic;
+  symbols?: readonly string[];
+};
+
+export type CryptoPricesChainlinkTwapSubscription = {
+  topic: CryptoPricesChainlinkTwapTopic;
+  /** Averaging window used to calculate each TWAP price. */
+  windowSeconds: CryptoPricesChainlinkTwapWindowSeconds;
+  /** Lowercase slash-delimited symbols, such as `btc/usd`. */
   symbols?: readonly string[];
 };
 
@@ -177,6 +195,7 @@ export type PublicSubscriptionSpec =
   | SportsSubscription
   | CommentsSubscription
   | CryptoPricesSubscription
+  | CryptoPricesChainlinkTwapSubscription
   | EquityPricesSubscription
   | PerpsMarketDataSubscription;
 
@@ -211,6 +230,7 @@ type EventByTopic = {
   comments: CommentsEvent;
   'prices.crypto.binance': CryptoPricesBinanceEvent;
   'prices.crypto.chainlink': CryptoPricesChainlinkEvent;
+  'prices.crypto.chainlink.twap': CryptoPricesChainlinkTwapEvent;
   'prices.equity.pyth': EquityPricesEvent;
   'perps.trades': PerpsTradeEvent;
   'perps.bbo': PerpsBboEvent;
@@ -227,12 +247,22 @@ type EventForMarketSubscription<TSpec extends MarketSubscription> =
       : StandardMarketEvent
     : StandardMarketEvent;
 
+type EventForCryptoPricesChainlinkTwapSubscription<
+  TSpec extends CryptoPricesChainlinkTwapSubscription,
+> = TSpec extends { windowSeconds: 30 }
+  ? CryptoPricesChainlinkTwapThirtyEvent
+  : TSpec extends { windowSeconds: 60 }
+    ? CryptoPricesChainlinkTwapSixtyEvent
+    : CryptoPricesChainlinkTwapEvent;
+
 export type EventForSubscriptionSpec<TSpec extends SecureSubscriptionSpec> =
   TSpec extends MarketSubscription
     ? EventForMarketSubscription<TSpec>
-    : TSpec extends { topic: infer TTopic extends keyof EventByTopic }
-      ? EventByTopic[TTopic]
-      : never;
+    : TSpec extends CryptoPricesChainlinkTwapSubscription
+      ? EventForCryptoPricesChainlinkTwapSubscription<TSpec>
+      : TSpec extends { topic: infer TTopic extends keyof EventByTopic }
+        ? EventByTopic[TTopic]
+        : never;
 
 export type EventForSubscriptionSpecs<
   TSubscriptions extends readonly SecureSubscriptionSpec[],
@@ -247,7 +277,8 @@ export type SubscriptionHandle<TEvent> = {
   close(): Promise<void>;
 } & AsyncIterable<TEvent>;
 
-export type SubscribeError = TransportError;
+export type SubscribeError = TransportError | UserInputError;
+export const SubscribeError = makeErrorGuard(TransportError, UserInputError);
 
 /**
  * Starts one or more realtime subscriptions on this client.
@@ -256,7 +287,8 @@ export type SubscribeError = TransportError;
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
  * @throws {@link SubscribeError}
- * Thrown when the realtime subscription cannot be established or fails.
+ * Thrown when a TWAP subscription requests an unsupported window or the
+ * realtime connection fails.
  *
  * @example
  * ```ts
@@ -285,6 +317,10 @@ export async function subscribe(
   client: BaseClient,
   subscriptions: readonly SecureSubscriptionSpec[],
 ): Promise<SubscriptionHandle<unknown>> {
+  for (const subscription of subscriptions) {
+    validateTwapSubscriptionWindow(subscription);
+  }
+
   const handles = await Promise.all(
     subscriptions.map((spec) => subscribeOne(client, spec)),
   );
@@ -303,6 +339,7 @@ function subscribeOne(
     case 'comments':
     case 'prices.crypto.binance':
     case 'prices.crypto.chainlink':
+    case 'prices.crypto.chainlink.twap':
     case 'prices.equity.pyth':
       return client.webSockets.rtds.subscribe(spec);
     case 'perps.trades':

--- a/packages/client/src/decorators/subscriptions.ts
+++ b/packages/client/src/decorators/subscriptions.ts
@@ -11,12 +11,22 @@ import type {
   BaseSecureClient,
 } from '../clients';
 
+export type {
+  CryptoPricesChainlinkTwapEvent,
+  CryptoPricesChainlinkTwapSixtyEvent,
+  CryptoPricesChainlinkTwapSubscription,
+  CryptoPricesChainlinkTwapThirtyEvent,
+  CryptoPricesChainlinkTwapWindowSeconds,
+} from '../actions';
+export { SubscribeError } from '../actions';
+
 export type PublicSubscriptionsActions = {
   /**
    * Starts one or more realtime subscriptions on this client.
    *
    * @throws {@link SubscribeError}
-   * Thrown when the realtime subscription cannot be established or fails.
+   * Thrown when a TWAP subscription requests an unsupported window or the
+   * realtime connection fails.
    *
    * @example
    * ```ts
@@ -39,7 +49,8 @@ export type SecureSubscriptionsActions = {
    * Starts one or more realtime subscriptions on this client.
    *
    * @throws {@link SubscribeError}
-   * Thrown when the realtime subscription cannot be established or fails.
+   * Thrown when a TWAP subscription requests an unsupported window or the
+   * realtime connection fails.
    *
    * @example
    * ```ts

--- a/packages/client/src/subscription-validation.ts
+++ b/packages/client/src/subscription-validation.ts
@@ -1,0 +1,20 @@
+import { UserInputError } from './errors';
+
+type SubscriptionLike = {
+  topic: string;
+  windowSeconds?: unknown;
+};
+
+export function validateTwapSubscriptionWindow(
+  subscription: SubscriptionLike,
+): void {
+  if (
+    subscription.topic === 'prices.crypto.chainlink.twap' &&
+    subscription.windowSeconds !== 30 &&
+    subscription.windowSeconds !== 60
+  ) {
+    throw new UserInputError(
+      `TWAP window must be 30 or 60 seconds, received ${String(subscription.windowSeconds)}.`,
+    );
+  }
+}

--- a/packages/client/src/websockets/rtds.test.ts
+++ b/packages/client/src/websockets/rtds.test.ts
@@ -10,6 +10,7 @@ import {
   vi,
 } from 'vitest';
 import { production } from '../environments';
+import { UserInputError } from '../errors';
 import { RtdsWebSocketManager } from './rtds';
 import {
   captureConnection,
@@ -21,6 +22,27 @@ import {
 const rtds = ws.link(production.rtds.ws);
 const server = setupServer();
 const manager = new RtdsWebSocketManager({ url: production.rtds.ws });
+
+type RawTwapTopic = 'crypto_prices_twap_thirty' | 'crypto_prices_twap_sixty';
+
+function twapFrame(options: {
+  symbol?: string;
+  topic: RawTwapTopic;
+  windowSeconds: 30 | 60;
+}): unknown {
+  return {
+    payload: {
+      symbol: options.symbol ?? 'btc/usd',
+      value: 65_000.12345678901,
+      full_accuracy_value: '65000123456789012345678',
+      timestamp: 1_772_752_581_815,
+      window_s: options.windowSeconds,
+    },
+    timestamp: 1_772_752_582_004,
+    topic: options.topic,
+    type: 'update',
+  };
+}
 
 describe('RtdsWebSocketManager', () => {
   beforeAll(() => {
@@ -81,6 +103,224 @@ describe('RtdsWebSocketManager', () => {
         type: 'update',
       },
     });
+  });
+
+  it('routes and isolates both Chainlink TWAP windows', async () => {
+    const connection = captureConnection(server, rtds);
+    const frames = collectFrames(server, rtds);
+
+    const thirtySecondHandle = await manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 30,
+      symbols: ['btc/usd'],
+    });
+    const sixtySecondHandle = await manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 60,
+      symbols: ['btc/usd'],
+    });
+
+    await vi.waitFor(() => {
+      expect(frames).toEqual([
+        {
+          action: 'subscribe',
+          subscriptions: [
+            { topic: 'crypto_prices_twap_thirty', type: 'update' },
+          ],
+        },
+        {
+          action: 'subscribe',
+          subscriptions: [
+            { topic: 'crypto_prices_twap_sixty', type: 'update' },
+          ],
+        },
+      ]);
+    });
+
+    const thirtySecondNext = waitForNextEvent(thirtySecondHandle);
+    const sixtySecondNext = waitForNextEvent(sixtySecondHandle);
+
+    await connection.send(
+      twapFrame({
+        topic: 'crypto_prices_twap_thirty',
+        windowSeconds: 30,
+      }),
+    );
+    await expect(thirtySecondNext).resolves.toMatchObject({
+      done: false,
+      value: {
+        payload: {
+          symbol: 'btc/usd',
+          value: '65000.123456789012345678',
+          windowSeconds: 30,
+        },
+        topic: 'prices.crypto.chainlink.twap',
+        type: 'update',
+      },
+    });
+
+    await connection.send(
+      twapFrame({
+        topic: 'crypto_prices_twap_sixty',
+        windowSeconds: 60,
+      }),
+    );
+    await expect(sixtySecondNext).resolves.toMatchObject({
+      done: false,
+      value: {
+        payload: {
+          symbol: 'btc/usd',
+          value: '65000.123456789012345678',
+          windowSeconds: 60,
+        },
+        topic: 'prices.crypto.chainlink.twap',
+        type: 'update',
+      },
+    });
+
+    frames.length = 0;
+    await thirtySecondHandle.close();
+    expect(frames).toEqual([
+      {
+        action: 'unsubscribe',
+        subscriptions: [{ topic: 'crypto_prices_twap_thirty', type: 'update' }],
+      },
+    ]);
+
+    frames.length = 0;
+    await sixtySecondHandle.close();
+    expect(frames).toEqual([
+      {
+        action: 'unsubscribe',
+        subscriptions: [{ topic: 'crypto_prices_twap_sixty', type: 'update' }],
+      },
+    ]);
+  });
+
+  it('shares a TWAP window while filtering symbols independently', async () => {
+    const connection = captureConnection(server, rtds);
+    const frames = collectFrames(server, rtds);
+
+    const btcHandle = await manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 30,
+      symbols: ['btc/usd'],
+    });
+    const ethHandle = await manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 30,
+      symbols: ['eth/usd'],
+    });
+
+    await vi.waitFor(() => {
+      expect(frames).toEqual([
+        {
+          action: 'subscribe',
+          subscriptions: [
+            { topic: 'crypto_prices_twap_thirty', type: 'update' },
+          ],
+        },
+      ]);
+    });
+
+    const btcNext = waitForNextEvent(btcHandle);
+    const ethNext = waitForNextEvent(ethHandle);
+    await connection.send(
+      twapFrame({
+        symbol: 'btc/usd',
+        topic: 'crypto_prices_twap_thirty',
+        windowSeconds: 30,
+      }),
+    );
+    await connection.send(
+      twapFrame({
+        symbol: 'eth/usd',
+        topic: 'crypto_prices_twap_thirty',
+        windowSeconds: 30,
+      }),
+    );
+
+    await expect(btcNext).resolves.toMatchObject({
+      value: { payload: { symbol: 'btc/usd', windowSeconds: 30 } },
+    });
+    await expect(ethNext).resolves.toMatchObject({
+      value: { payload: { symbol: 'eth/usd', windowSeconds: 30 } },
+    });
+
+    frames.length = 0;
+    await btcHandle.close();
+    expect(frames).toEqual([]);
+
+    await ethHandle.close();
+    expect(frames).toEqual([
+      {
+        action: 'unsubscribe',
+        subscriptions: [{ topic: 'crypto_prices_twap_thirty', type: 'update' }],
+      },
+    ]);
+  });
+
+  it('drops mismatched TWAP frames without closing the shared socket', async () => {
+    await expectDropsUnknownFrame({
+      expectedEvent: {
+        payload: { symbol: 'btc/usd', windowSeconds: 30 },
+        topic: 'prices.crypto.chainlink.twap',
+        type: 'update',
+      },
+      link: rtds,
+      server,
+      subscribe: async () => {
+        const observedManager = new RtdsWebSocketManager({
+          url: production.rtds.ws,
+        });
+        const events = await observedManager.subscribe({
+          topic: 'prices.crypto.chainlink.twap',
+          windowSeconds: 30,
+          symbols: ['btc/usd'],
+        });
+        return { close: () => observedManager.close(), events };
+      },
+      unknownFrame: twapFrame({
+        topic: 'crypto_prices_twap_thirty',
+        windowSeconds: 60,
+      }),
+      validFrame: twapFrame({
+        topic: 'crypto_prices_twap_thirty',
+        windowSeconds: 30,
+      }),
+    });
+  });
+
+  it('rejects an invalid runtime window without poisoning later subscriptions', async () => {
+    const frames = collectFrames(server, rtds);
+
+    const invalidSubscription = manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 45,
+    } as never);
+
+    await expect(invalidSubscription).rejects.toBeInstanceOf(UserInputError);
+    await expect(invalidSubscription).rejects.toThrow(
+      'TWAP window must be 30 or 60 seconds, received 45.',
+    );
+
+    const handle = await manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 30,
+    });
+
+    await vi.waitFor(() => {
+      expect(frames).toEqual([
+        {
+          action: 'subscribe',
+          subscriptions: [
+            { topic: 'crypto_prices_twap_thirty', type: 'update' },
+          ],
+        },
+      ]);
+    });
+
+    await handle.close();
   });
 
   it('drops unknown frames without closing the shared socket', async () => {
@@ -278,6 +518,102 @@ describe('RtdsWebSocketManager', () => {
         topic: 'prices.crypto.binance',
         type: 'update',
       },
+    });
+  });
+
+  it('reconnects and resubscribes both TWAP windows', {
+    timeout: 5_000,
+  }, async () => {
+    const connectionFrames: unknown[][] = [];
+    let firstClient: { close: () => void } | undefined;
+    let secondClient: { send: (data: string) => void } | undefined;
+
+    server.use(
+      rtds.addEventListener('connection', ({ client }) => {
+        const frames: unknown[] = [];
+        connectionFrames.push(frames);
+        if (connectionFrames.length === 1) firstClient = client;
+        if (connectionFrames.length === 2) secondClient = client;
+        client.addEventListener('message', (event) => {
+          frames.push(JSON.parse(String(event.data)));
+        });
+      }),
+    );
+
+    vi.useFakeTimers();
+
+    const thirtySecondHandle = await manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 30,
+      symbols: ['btc/usd'],
+    });
+    await manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 30,
+      symbols: ['eth/usd'],
+    });
+    const sixtySecondHandle = await manager.subscribe({
+      topic: 'prices.crypto.chainlink.twap',
+      windowSeconds: 60,
+      symbols: ['btc/usd'],
+    });
+
+    await vi.waitFor(() => {
+      expect(connectionFrames[0] ?? []).toEqual([
+        {
+          action: 'subscribe',
+          subscriptions: [
+            { topic: 'crypto_prices_twap_thirty', type: 'update' },
+          ],
+        },
+        {
+          action: 'subscribe',
+          subscriptions: [
+            { topic: 'crypto_prices_twap_sixty', type: 'update' },
+          ],
+        },
+      ]);
+    });
+
+    firstClient?.close();
+    await vi.advanceTimersToNextTimer();
+
+    await vi.waitFor(() => {
+      expect(connectionFrames[1] ?? []).toEqual([
+        {
+          action: 'subscribe',
+          subscriptions: [
+            { topic: 'crypto_prices_twap_thirty', type: 'update' },
+            { topic: 'crypto_prices_twap_sixty', type: 'update' },
+          ],
+        },
+      ]);
+    });
+
+    const thirtySecondNext = waitForNextEvent(thirtySecondHandle);
+    const sixtySecondNext = waitForNextEvent(sixtySecondHandle);
+    secondClient?.send(
+      JSON.stringify(
+        twapFrame({
+          topic: 'crypto_prices_twap_thirty',
+          windowSeconds: 30,
+        }),
+      ),
+    );
+    secondClient?.send(
+      JSON.stringify(
+        twapFrame({
+          topic: 'crypto_prices_twap_sixty',
+          windowSeconds: 60,
+        }),
+      ),
+    );
+
+    await expect(thirtySecondNext).resolves.toMatchObject({
+      value: { payload: { symbol: 'btc/usd', windowSeconds: 30 } },
+    });
+    await expect(sixtySecondNext).resolves.toMatchObject({
+      value: { payload: { symbol: 'btc/usd', windowSeconds: 60 } },
     });
   });
 });

--- a/packages/client/src/websockets/rtds.ts
+++ b/packages/client/src/websockets/rtds.ts
@@ -1,5 +1,6 @@
 import {
   type CommentsEvent,
+  type CryptoPricesChainlinkTwapWindowSeconds,
   type CryptoPricesEvent,
   type EquityPricesEvent,
   RealtimeEventSchema,
@@ -7,10 +8,12 @@ import {
 import { invariant } from '@polymarket/types';
 import type {
   CommentsSubscription,
+  CryptoPricesChainlinkTwapSubscription,
   CryptoPricesSubscription,
   EquityPricesSubscription,
   SubscriptionHandle,
 } from '../actions/subscriptions';
+import { validateTwapSubscriptionWindow } from '../subscription-validation';
 import { createSubscriptionHandle } from './handle';
 import { RtdsWebSocketHeartbeat } from './heartbeat';
 import {
@@ -28,6 +31,7 @@ import type { WebSocketSubscriptionManager } from './types';
 type RtdsSpec =
   | CommentsSubscription
   | CryptoPricesSubscription
+  | CryptoPricesChainlinkTwapSubscription
   | EquityPricesSubscription;
 
 type RtdsEvent = CommentsEvent | CryptoPricesEvent | EquityPricesEvent;
@@ -78,6 +82,7 @@ export class RtdsWebSocketManager
   async subscribe(
     subscription: RtdsSpec,
   ): Promise<SubscriptionHandle<RtdsEvent>> {
+    validateTwapSubscriptionWindow(subscription);
     const { change, entry } = this.#subscriptions.add(subscription, {
       matches: matcherFor(subscription),
     });
@@ -268,6 +273,16 @@ function serverSubscriptionsFor(
       // with a different filter replaces the first. Subscribe broadly and
       // filter client-side — see docs/api-boundary-notes.md.
       return [serverSubscription('crypto_prices_chainlink', 'update')];
+    case 'prices.crypto.chainlink.twap':
+      // Each TWAP window is a distinct RTDS topic. Subscribe broadly within
+      // the requested window and narrow symbols client-side so subscribers for
+      // the same window can safely share a socket.
+      return [
+        serverSubscription(
+          twapServerTopic(subscription.windowSeconds),
+          'update',
+        ),
+      ];
     case 'prices.equity.pyth':
       // Same per-topic replace-on-resubscribe constraint as crypto_prices. A
       // single unfiltered subscribe covers every active equity symbol; the
@@ -276,6 +291,21 @@ function serverSubscriptionsFor(
     default: {
       const neverSpec: never = subscription;
       invariant(false, `Unknown RTDS topic: ${String(neverSpec)}`);
+    }
+  }
+}
+
+function twapServerTopic(
+  windowSeconds: CryptoPricesChainlinkTwapWindowSeconds,
+): string {
+  switch (windowSeconds) {
+    case 30:
+      return 'crypto_prices_twap_thirty';
+    case 60:
+      return 'crypto_prices_twap_sixty';
+    default: {
+      const neverWindow: never = windowSeconds;
+      invariant(false, `Unknown TWAP window: ${String(neverWindow)}`);
     }
   }
 }
@@ -342,6 +372,13 @@ function matcherFor(subscription: RtdsSpec): (event: RtdsEvent) => boolean {
     case 'prices.crypto.chainlink':
       return (event) =>
         event.topic === 'prices.crypto.chainlink' &&
+        (subscription.symbols === undefined ||
+          subscription.symbols.length === 0 ||
+          subscription.symbols.includes(event.payload.symbol));
+    case 'prices.crypto.chainlink.twap':
+      return (event) =>
+        event.topic === 'prices.crypto.chainlink.twap' &&
+        event.payload.windowSeconds === subscription.windowSeconds &&
         (subscription.symbols === undefined ||
           subscription.symbols.length === 0 ||
           subscription.symbols.includes(event.payload.symbol));

--- a/packages/client/src/websockets/types.ts
+++ b/packages/client/src/websockets/types.ts
@@ -9,6 +9,7 @@ import type {
 } from '@polymarket/bindings/subscriptions';
 import type {
   CommentsSubscription,
+  CryptoPricesChainlinkTwapSubscription,
   CryptoPricesSubscription,
   EquityPricesSubscription,
   MarketSubscription,
@@ -72,7 +73,10 @@ export type PublicWebSocketManagers = {
     SportsEvent
   >;
   readonly rtds: WebSocketSubscriptionManager<
-    CommentsSubscription | CryptoPricesSubscription | EquityPricesSubscription,
+    | CommentsSubscription
+    | CryptoPricesSubscription
+    | CryptoPricesChainlinkTwapSubscription
+    | EquityPricesSubscription,
     CommentsEvent | CryptoPricesEvent | EquityPricesEvent
   >;
   /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New realtime price path with strict parsing and validation; incorrect E18 or window/topic mismatch handling could affect consumers relying on TWAP values, but changes are additive with broad test coverage.
> 
> **Overview**
> Adds **typed realtime subscriptions** for Chainlink crypto TWAP at **30s and 60s** via `prices.crypto.chainlink.twap` with required `windowSeconds` and optional `symbols`.
> 
> **Bindings** map wire topics `crypto_prices_twap_thirty` / `crypto_prices_twap_sixty` to a normalized client topic, validate `window_s` against the wire topic, and expose TWAP prices as decimal strings from **`full_accuracy_value`** (E18) instead of the display float.
> 
> **Client** validates TWAP windows before opening sockets (batch subscribe fails fast with `UserInputError`), routes RTDS subscribe/unsubscribe per window, filters by window and symbol client-side (shared socket per window), and narrows streamed event types by literal `windowSeconds`. `SubscribeError` now includes `UserInputError`; TWAP types are exported from the package root. Example and tests cover parsing, WebSocket behavior, and reconnect resubscribe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2cd497085a69de1c3a115cfb640c94eb3dfd031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->