### PR TITLE
refactor(client): lift Exchange v3 order construction into the exchange module

### DIFF
--- a/.changeset/dev-424-exchange-v3-lift.md
+++ b/.changeset/dev-424-exchange-v3-lift.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Internal refactor: Exchange v3 order construction helpers now live in the exchange module. No behavior change.

--- a/packages/client/src/exchange.ts
+++ b/packages/client/src/exchange.ts
@@ -164,6 +164,57 @@ export function createExchangeOrderSignature(
 }
 
 /** @internal */
+export type CreateExchangeV3OrderDomainParams = {
+  chainId: number;
+  exchange: EvmAddress;
+};
+
+/** @internal */
+export function createExchangeV3OrderDomain(
+  params: CreateExchangeV3OrderDomainParams,
+): ExchangeOrderDomain {
+  return {
+    chainId: params.chainId,
+    exchange: params.exchange,
+    protocolVersion: ExchangeOrderProtocolVersion.V3,
+  };
+}
+
+/** @internal */
+export function calculateExchangeOrderMakerAmount(
+  side: OrderSide,
+  price: bigint,
+  size: bigint,
+): string {
+  if (side === OrderSide.SELL) return size.toString();
+
+  return ((price * size + 999_999n) / 1_000_000n).toString();
+}
+
+/** @internal */
+export function calculateExchangeOrderTakerAmount(
+  side: OrderSide,
+  price: bigint,
+  size: bigint,
+): string {
+  if (side === OrderSide.SELL) {
+    return ((price * size) / 1_000_000n).toString();
+  }
+
+  return size.toString();
+}
+
+/** @internal */
+export function generateExchangeOrderSalt(): bigint {
+  const bytes = new Uint8Array(8);
+  globalThis.crypto.getRandomValues(bytes);
+
+  return BigInt(
+    `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`,
+  );
+}
+
+/** @internal */
 export function createExchangeOrderMessage(
   order: ExchangeOrderInput,
 ): ExchangeOrderMessage {
@@ -280,7 +331,8 @@ function protocolVersionHash(
   );
 }
 
-function encodeExchangeOrderSide(side: OrderSide | 0 | 1): 0 | 1 {
+/** @internal */
+export function encodeExchangeOrderSide(side: OrderSide | 0 | 1): 0 | 1 {
   if (side === 0 || side === 1) return side;
 
   return side === OrderSide.BUY ? 0 : 1;

--- a/packages/client/src/exchange.ts
+++ b/packages/client/src/exchange.ts
@@ -180,7 +180,13 @@ export function createExchangeV3OrderDomain(
   };
 }
 
-/** @internal */
+/**
+ * Amount the order owner gives, in e6 base units: `price * size` collateral
+ * rounded up for a BUY, the outcome-token `size` for a SELL. `price` and
+ * `size` are both e6-scaled.
+ *
+ * @internal
+ */
 export function calculateExchangeOrderMakerAmount(
   side: OrderSide,
   price: bigint,
@@ -191,7 +197,14 @@ export function calculateExchangeOrderMakerAmount(
   return ((price * size + 999_999n) / 1_000_000n).toString();
 }
 
-/** @internal */
+/**
+ * Amount the order owner receives, in e6 base units: the outcome-token
+ * `size` for a BUY, `price * size` collateral rounded down for a SELL.
+ * Rounding always favors the counterparty. `price` and `size` are both
+ * e6-scaled.
+ *
+ * @internal
+ */
 export function calculateExchangeOrderTakerAmount(
   side: OrderSide,
   price: bigint,

--- a/packages/client/src/websockets/rfq/signing.ts
+++ b/packages/client/src/websockets/rfq/signing.ts
@@ -1,11 +1,19 @@
-import { OrderSide, type PositionId, toBaseUnits } from '@polymarket/bindings';
+import {
+  type OrderSide,
+  type PositionId,
+  toBaseUnits,
+} from '@polymarket/bindings';
 import type { RfqSignedOrder } from '@polymarket/bindings/combos';
 import type { EvmAddress, EvmSignature, HexString } from '@polymarket/types';
 import { SigningError } from '../../errors';
 import {
+  calculateExchangeOrderMakerAmount,
+  calculateExchangeOrderTakerAmount,
   createExchangeOrderSignature,
   createExchangeOrderTypedDataPayload,
-  ExchangeOrderProtocolVersion,
+  createExchangeV3OrderDomain,
+  encodeExchangeOrderSide,
+  generateExchangeOrderSalt,
 } from '../../exchange';
 import type { Signer } from '../../types';
 import type { AccountIdentity } from '../../wallet';
@@ -29,19 +37,31 @@ export async function signRfqQuoteOrder(
   params: SignRfqQuoteOrderParams,
 ): Promise<RfqSignedOrder> {
   const identity = resolveOrderIdentity(params.account);
+  const domain = createExchangeV3OrderDomain({
+    chainId: params.chainId,
+    exchange: params.exchange,
+  });
   const order: Omit<RfqSignedOrder, 'signature'> = {
     builder: BYTES32_ZERO,
     maker: identity.maker,
     makerAmount: toBaseUnits(
-      makerAmount(params.orderSide, params.orderPrice, params.size),
+      calculateExchangeOrderMakerAmount(
+        params.orderSide,
+        params.orderPrice,
+        params.size,
+      ),
     ),
     metadata: BYTES32_ZERO,
-    salt: generateOrderSalt().toString(),
-    side: encodeOrderSide(params.orderSide),
+    salt: generateExchangeOrderSalt().toString(),
+    side: encodeExchangeOrderSide(params.orderSide),
     signatureType: identity.signatureType,
     signer: identity.signer,
     takerAmount: toBaseUnits(
-      takerAmount(params.orderSide, params.orderPrice, params.size),
+      calculateExchangeOrderTakerAmount(
+        params.orderSide,
+        params.orderPrice,
+        params.size,
+      ),
     ),
     timestamp: Math.floor(Date.now() / 1000).toString(),
     tokenId: params.tokenId,
@@ -50,10 +70,7 @@ export async function signRfqQuoteOrder(
   let signature: EvmSignature;
   try {
     signature = await params.signer.signTypedData(
-      createExchangeOrderTypedDataPayload({
-        domain: createRfqExchangeDomain(params),
-        order,
-      }),
+      createExchangeOrderTypedDataPayload({ domain, order }),
     );
   } catch (error) {
     throw SigningError.fromError(error, 'Could not sign the RFQ quote order.');
@@ -61,45 +78,6 @@ export async function signRfqQuoteOrder(
 
   return {
     ...order,
-    signature: createExchangeOrderSignature({
-      domain: createRfqExchangeDomain(params),
-      order,
-      signature,
-    }),
+    signature: createExchangeOrderSignature({ domain, order, signature }),
   };
-}
-
-function createRfqExchangeDomain(params: SignRfqQuoteOrderParams) {
-  return {
-    chainId: params.chainId,
-    exchange: params.exchange,
-    protocolVersion: ExchangeOrderProtocolVersion.V3,
-  };
-}
-
-function makerAmount(side: OrderSide, price: bigint, size: bigint): string {
-  if (side === OrderSide.SELL) return size.toString();
-
-  return ((price * size + 999_999n) / 1_000_000n).toString();
-}
-
-function takerAmount(side: OrderSide, price: bigint, size: bigint): string {
-  if (side === OrderSide.SELL) {
-    return ((price * size) / 1_000_000n).toString();
-  }
-
-  return size.toString();
-}
-
-function encodeOrderSide(side: OrderSide): 0 | 1 {
-  return side === OrderSide.BUY ? 0 : 1;
-}
-
-function generateOrderSalt(): bigint {
-  const bytes = new Uint8Array(8);
-  globalThis.crypto.getRandomValues(bytes);
-
-  return BigInt(
-    `0x${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`,
-  );
 }


### PR DESCRIPTION
Prerequisite refactor for DEV-424. Moves the Exchange v3 domain helper, maker/taker amount math, salt generation, and side encoding from `websockets/rfq/signing.ts` into `src/exchange.ts`, leaving the RFQ signing module as a thin call site. Pure move-and-rename; no behavior change, maker-side RFQ tests stay green.

Linear: DEV-424

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure move-and-rename refactor; order math and signing flow are unchanged and RFQ tests are expected to stay green.
> 
> **Overview**
> **Moves Exchange v3 order-building helpers** from `websockets/rfq/signing.ts` into `exchange.ts` so RFQ signing stays a thin orchestration layer (DEV-424 prerequisite).
> 
> New `@internal` exports in `exchange.ts`: `createExchangeV3OrderDomain`, `calculateExchangeOrderMakerAmount`, `calculateExchangeOrderTakerAmount`, `generateExchangeOrderSalt`, and a public `encodeExchangeOrderSide` (previously private). `signRfqQuoteOrder` now imports these instead of local duplicates; the old private helpers (`createRfqExchangeDomain`, `makerAmount`, `takerAmount`, etc.) are removed.
> 
> Documented as a patch-level internal refactor with **no intended behavior change**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b5c7d129178f2dd8f72fa49333ae7a256bb935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->