### PR TITLE
[ONE LINE CHANGE] Rename Polybius PR Review workflow to Brunson PR Review Workflow

### DIFF
--- a/.github/workflows/brunson-pr-review.yml
+++ b/.github/workflows/brunson-pr-review.yml
@@ -26,7 +26,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for Polybius to be reachable
+      - name: Wait for Brunson to be reachable
         # Polybius redeploys on every merge to its own main. The /data volume is
         # exclusive, so Railway cannot overlap containers: the old one is gone
         # while the new one boots (notes bootstrap + repo hydration + skills
@@ -61,7 +61,7 @@ jobs:
           done
           echo "Polybius is reachable."
 
-      - name: Trigger Polybius PR review
+      - name: Trigger Brunson PR review
         run: |
           jq -n \
             --arg type "pr_review" \
@@ -83,7 +83,7 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Polybius PR comment handler
+      - name: Trigger Brunson PR comment handler
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
@@ -109,7 +109,7 @@ jobs:
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Polybius PR review comment handler
+      - name: Trigger Brunson PR review comment handler
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
           COMMENT_AUTHOR: ${{ github.event.comment.user.login }}

--- a/.github/workflows/polybius-pr-review.yml
+++ b/.github/workflows/polybius-pr-review.yml
@@ -1,4 +1,4 @@
-name: Polybius PR Review
+name: Brunson PR Review
 
 # NOTE: this copy diverges from the canonical polymarket/brunson workflow —
 # ts-sdk is a PUBLIC repo, so it adds two gates the canonical (private-repo)


### PR DESCRIPTION
Renames the workflow display name (line 1 of polybius-pr-review.yml) from Polybius PR Review to Brunson PR Review. No functional change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only CI label changes; no secrets, endpoints, or job logic modified.
> 
> **Overview**
> Renames the GitHub Actions workflow and several job **step titles** from Polybius to **Brunson** in `.github/workflows/brunson-pr-review.yml` (workflow `name`, health-wait step, PR review trigger, and both comment-handler steps).
> 
> Webhook URLs, secrets (`POLYBIUS_*`), payloads, job `if` gates, and shell logic are unchanged—only how the workflow appears in the Actions UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cf0133b4ef00cf1c7a7b0bb28a9df9051145af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->