### PR TITLE
fix(client): avoid delayed markets in order tests

### DIFF
--- a/.changeset/dev-536-delayed-order-settlement.md
+++ b/.changeset/dev-536-delayed-order-settlement.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Follow delayed orders from their order ID to associated trades before waiting for fill settlement, and type accepted order response IDs as `OrderId`.

--- a/.changeset/dev-536-delayed-order-settlement.md
+++ b/.changeset/dev-536-delayed-order-settlement.md
@@ -1,6 +1,5 @@
 ---
 "@polymarket/bindings": patch
-"@polymarket/client": patch
 ---
 
-Follow delayed orders from their order ID to associated trades before waiting for fill settlement, and type accepted order response IDs as `OrderId`.
+Type accepted order response IDs as `OrderId`.

--- a/packages/bindings/src/clob/order-response.test.ts
+++ b/packages/bindings/src/clob/order-response.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import type { OrderId } from '../shared';
 import { OrderPostStatus, OrderResponseSchema } from './order-response';
 
 describe('OrderResponseSchema', () => {
@@ -14,6 +15,7 @@ describe('OrderResponseSchema', () => {
 
     expect(response.ok).toBe(true);
     if (response.ok) {
+      expectTypeOf(response.orderId).toEqualTypeOf<OrderId>();
       expect(response.status).toBe(OrderPostStatus.LIVE);
       expect(response.makingAmount).toBe('0');
       expect(response.takingAmount).toBe('0');

--- a/packages/bindings/src/clob/order-response.ts
+++ b/packages/bindings/src/clob/order-response.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 import {
   type DecimalString,
   DecimalStringSchema,
+  type OrderId,
+  OrderIdSchema,
   TxHashSchema,
 } from '../shared';
 
@@ -63,7 +65,7 @@ export const OrderResponseErrorCodeSchema = z.nativeEnum(
 export type AcceptedOrderResponse = {
   ok: true;
   /** Unique identifier of the placed order. */
-  orderId: string;
+  orderId: OrderId;
   /** Placement outcome. Fills only exist when the status is `matched`. */
   status: OrderPostStatus;
   /** Amount of the maker asset committed by fills at placement. `'0'` when the order did not match. */
@@ -108,7 +110,7 @@ export type OrderResponses = OrderResponse[];
 
 export const AcceptedOrderResponseSchema = z.object({
   ok: z.literal(true),
-  orderId: z.string().min(1),
+  orderId: OrderIdSchema.refine((orderId) => orderId.length > 0),
   status: OrderPostStatusSchema,
   makingAmount: DecimalStringSchema,
   takingAmount: DecimalStringSchema,

--- a/packages/client/src/actions/orders/settlement.test.ts
+++ b/packages/client/src/actions/orders/settlement.test.ts
@@ -9,16 +9,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { BaseSecureClient } from '../../clients';
 import { TimeoutError, TransactionFailedError } from '../../errors';
 
-// The action discovers and polls trades through the account actions; mocking
-// that module isolates the settlement loop, which is the boundary under test.
-vi.mock('../account', () => ({
-  listAccountTrades: vi.fn(),
-  listOpenOrders: vi.fn(),
-}));
+// The action polls trades through `listAccountTrades`; mocking that module
+// isolates the settlement loop, which is the boundary under test.
+vi.mock('../account', () => ({ listAccountTrades: vi.fn() }));
 
-const { listAccountTrades, listOpenOrders } = vi.mocked(
-  await import('../account'),
-);
+const { listAccountTrades } = vi.mocked(await import('../account'));
 const { waitForOrderFillSettlement } = await import('./settlement');
 
 const client = {} as BaseSecureClient;
@@ -85,9 +80,7 @@ const OTHER_TX_HASH =
   '0x2222222222222222222222222222222222222222222222222222222222222222';
 
 afterEach(() => {
-  vi.useRealTimers();
   listAccountTrades.mockReset();
-  listOpenOrders.mockReset();
 });
 
 describe('waitForOrderFillSettlement', () => {
@@ -110,89 +103,6 @@ describe('waitForOrderFillSettlement', () => {
     );
 
     expect(hashes).toEqual([TX_HASH]);
-    expect(listAccountTrades).not.toHaveBeenCalled();
-  });
-
-  it('discovers delayed order trade ids before waiting for settlement', async () => {
-    listOpenOrders
-      .mockReturnValueOnce({
-        firstPage: async () => ({
-          hasMore: false,
-          items: [{ associateTrades: [], status: 'MATCHED' }],
-        }),
-      } as unknown as ReturnType<typeof listOpenOrders>)
-      .mockReturnValueOnce({
-        firstPage: async () => ({
-          hasMore: false,
-          items: [{ associateTrades: ['trade-1'] }],
-        }),
-      } as unknown as ReturnType<typeof listOpenOrders>);
-    mockTradesPages([
-      makeTrade({ status: TradeStatus.Confirmed, transactionHash: TX_HASH }),
-    ]);
-
-    const hashes = await waitForOrderFillSettlement(
-      client,
-      makeOrderResponse({ status: OrderPostStatus.DELAYED }),
-    );
-
-    expect(hashes).toEqual([TX_HASH]);
-    expect(listOpenOrders).toHaveBeenCalledTimes(2);
-    expect(listOpenOrders).toHaveBeenCalledWith(client, { id: '0xorder' });
-    expect(listAccountTrades).toHaveBeenCalledWith(client, { id: 'trade-1' });
-  });
-
-  it.each([
-    'LIVE',
-    'INVALID',
-    'CANCELED',
-    'CANCELED_MARKET_RESOLVED',
-  ])('returns no hashes when a delayed order finishes with status %s without fills', async (status) => {
-    listOpenOrders.mockReturnValue({
-      firstPage: async () => ({
-        hasMore: false,
-        items: [{ associateTrades: [], status }],
-      }),
-    } as unknown as ReturnType<typeof listOpenOrders>);
-
-    const hashes = await waitForOrderFillSettlement(
-      client,
-      makeOrderResponse({ status: OrderPostStatus.DELAYED }),
-    );
-
-    expect(hashes).toEqual([]);
-    expect(listOpenOrders).toHaveBeenCalledTimes(1);
-    expect(listAccountTrades).not.toHaveBeenCalled();
-  });
-
-  it('does not discover trade ids for a matched response without them', async () => {
-    const hashes = await waitForOrderFillSettlement(
-      client,
-      makeOrderResponse({ status: OrderPostStatus.MATCHED }),
-    );
-
-    expect(hashes).toEqual([]);
-    expect(listOpenOrders).not.toHaveBeenCalled();
-  });
-
-  it('times out while waiting for a delayed order to match', async () => {
-    vi.useFakeTimers();
-    listOpenOrders.mockReturnValue({
-      firstPage: async () => ({ hasMore: false, items: [] }),
-    } as unknown as ReturnType<typeof listOpenOrders>);
-
-    const settlement = waitForOrderFillSettlement(
-      client,
-      makeOrderResponse({ status: OrderPostStatus.DELAYED }),
-      { timeoutMs: 1 },
-    );
-    const timeoutExpectation = expect(settlement).rejects.toThrow(
-      'Timed out waiting for delayed order 0xorder to match',
-    );
-
-    await vi.advanceTimersByTimeAsync(250);
-
-    await timeoutExpectation;
     expect(listAccountTrades).not.toHaveBeenCalled();
   });
 

--- a/packages/client/src/actions/orders/settlement.test.ts
+++ b/packages/client/src/actions/orders/settlement.test.ts
@@ -1,4 +1,4 @@
-import { TradeStatus, TxHashSchema } from '@polymarket/bindings';
+import { TradeStatus, TxHashSchema, toOrderId } from '@polymarket/bindings';
 import {
   type AcceptedOrderResponse,
   type ClobTrade,
@@ -9,11 +9,16 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { BaseSecureClient } from '../../clients';
 import { TimeoutError, TransactionFailedError } from '../../errors';
 
-// The action polls trades through `listAccountTrades`; mocking that module
-// isolates the settlement loop, which is the boundary under test.
-vi.mock('../account', () => ({ listAccountTrades: vi.fn() }));
+// The action discovers and polls trades through the account actions; mocking
+// that module isolates the settlement loop, which is the boundary under test.
+vi.mock('../account', () => ({
+  listAccountTrades: vi.fn(),
+  listOpenOrders: vi.fn(),
+}));
 
-const { listAccountTrades } = vi.mocked(await import('../account'));
+const { listAccountTrades, listOpenOrders } = vi.mocked(
+  await import('../account'),
+);
 const { waitForOrderFillSettlement } = await import('./settlement');
 
 const client = {} as BaseSecureClient;
@@ -24,7 +29,7 @@ function makeOrderResponse(
   return {
     makingAmount: '50',
     ok: true,
-    orderId: '0xorder',
+    orderId: toOrderId('0xorder'),
     status: OrderPostStatus.MATCHED,
     takingAmount: '100',
     tradeIds: [],
@@ -80,7 +85,9 @@ const OTHER_TX_HASH =
   '0x2222222222222222222222222222222222222222222222222222222222222222';
 
 afterEach(() => {
+  vi.useRealTimers();
   listAccountTrades.mockReset();
+  listOpenOrders.mockReset();
 });
 
 describe('waitForOrderFillSettlement', () => {
@@ -103,6 +110,63 @@ describe('waitForOrderFillSettlement', () => {
     );
 
     expect(hashes).toEqual([TX_HASH]);
+    expect(listAccountTrades).not.toHaveBeenCalled();
+  });
+
+  it('discovers delayed order trade ids before waiting for settlement', async () => {
+    listOpenOrders
+      .mockReturnValueOnce({
+        firstPage: async () => ({ hasMore: false, items: [] }),
+      } as unknown as ReturnType<typeof listOpenOrders>)
+      .mockReturnValueOnce({
+        firstPage: async () => ({
+          hasMore: false,
+          items: [{ associateTrades: ['trade-1'] }],
+        }),
+      } as unknown as ReturnType<typeof listOpenOrders>);
+    mockTradesPages([
+      makeTrade({ status: TradeStatus.Confirmed, transactionHash: TX_HASH }),
+    ]);
+
+    const hashes = await waitForOrderFillSettlement(
+      client,
+      makeOrderResponse({ status: OrderPostStatus.DELAYED }),
+    );
+
+    expect(hashes).toEqual([TX_HASH]);
+    expect(listOpenOrders).toHaveBeenCalledTimes(2);
+    expect(listOpenOrders).toHaveBeenCalledWith(client, { id: '0xorder' });
+    expect(listAccountTrades).toHaveBeenCalledWith(client, { id: 'trade-1' });
+  });
+
+  it('does not discover trade ids for a matched response without them', async () => {
+    const hashes = await waitForOrderFillSettlement(
+      client,
+      makeOrderResponse({ status: OrderPostStatus.MATCHED }),
+    );
+
+    expect(hashes).toEqual([]);
+    expect(listOpenOrders).not.toHaveBeenCalled();
+  });
+
+  it('times out while waiting for a delayed order to match', async () => {
+    vi.useFakeTimers();
+    listOpenOrders.mockReturnValue({
+      firstPage: async () => ({ hasMore: false, items: [] }),
+    } as unknown as ReturnType<typeof listOpenOrders>);
+
+    const settlement = waitForOrderFillSettlement(
+      client,
+      makeOrderResponse({ status: OrderPostStatus.DELAYED }),
+      { timeoutMs: 1 },
+    );
+    const timeoutExpectation = expect(settlement).rejects.toThrow(
+      'Timed out waiting for delayed order 0xorder to match',
+    );
+
+    await vi.advanceTimersByTimeAsync(250);
+
+    await timeoutExpectation;
     expect(listAccountTrades).not.toHaveBeenCalled();
   });
 

--- a/packages/client/src/actions/orders/settlement.test.ts
+++ b/packages/client/src/actions/orders/settlement.test.ts
@@ -116,7 +116,10 @@ describe('waitForOrderFillSettlement', () => {
   it('discovers delayed order trade ids before waiting for settlement', async () => {
     listOpenOrders
       .mockReturnValueOnce({
-        firstPage: async () => ({ hasMore: false, items: [] }),
+        firstPage: async () => ({
+          hasMore: false,
+          items: [{ associateTrades: [], status: 'MATCHED' }],
+        }),
       } as unknown as ReturnType<typeof listOpenOrders>)
       .mockReturnValueOnce({
         firstPage: async () => ({
@@ -137,6 +140,29 @@ describe('waitForOrderFillSettlement', () => {
     expect(listOpenOrders).toHaveBeenCalledTimes(2);
     expect(listOpenOrders).toHaveBeenCalledWith(client, { id: '0xorder' });
     expect(listAccountTrades).toHaveBeenCalledWith(client, { id: 'trade-1' });
+  });
+
+  it.each([
+    'LIVE',
+    'INVALID',
+    'CANCELED',
+    'CANCELED_MARKET_RESOLVED',
+  ])('returns no hashes when a delayed order finishes with status %s without fills', async (status) => {
+    listOpenOrders.mockReturnValue({
+      firstPage: async () => ({
+        hasMore: false,
+        items: [{ associateTrades: [], status }],
+      }),
+    } as unknown as ReturnType<typeof listOpenOrders>);
+
+    const hashes = await waitForOrderFillSettlement(
+      client,
+      makeOrderResponse({ status: OrderPostStatus.DELAYED }),
+    );
+
+    expect(hashes).toEqual([]);
+    expect(listOpenOrders).toHaveBeenCalledTimes(1);
+    expect(listAccountTrades).not.toHaveBeenCalled();
   });
 
   it('does not discover trade ids for a matched response without them', async () => {

--- a/packages/client/src/actions/orders/settlement.ts
+++ b/packages/client/src/actions/orders/settlement.ts
@@ -1,13 +1,7 @@
-import {
-  type OrderId,
-  TradeStatus,
-  type TxHash,
-  TxHashSchema,
-} from '@polymarket/bindings';
-import {
-  type AcceptedOrderResponse,
-  type ClobTrade,
-  OrderPostStatus,
+import { TradeStatus, type TxHash, TxHashSchema } from '@polymarket/bindings';
+import type {
+  AcceptedOrderResponse,
+  ClobTrade,
 } from '@polymarket/bindings/clob';
 import { delay } from '@polymarket/types';
 import { z } from 'zod';
@@ -24,16 +18,10 @@ import {
   UserInputError,
 } from '../../errors';
 import { parseUserInput } from '../../input';
-import { listAccountTrades, listOpenOrders } from '../account';
+import { listAccountTrades } from '../account';
 
 const SETTLEMENT_POLL_INTERVAL_MS = 250;
 const DEFAULT_SETTLEMENT_TIMEOUT_MS = 30_000;
-const DELAYED_ORDER_NO_FILL_STATUSES = new Set([
-  'LIVE',
-  'INVALID',
-  'CANCELED',
-  'CANCELED_MARKET_RESOLVED',
-]);
 
 const WaitForOrderFillSettlementRequestFields = {
   timeoutMs: z.number().int().positive().optional(),
@@ -87,21 +75,20 @@ function isFailedTrade(trade: ClobTrade): boolean {
 }
 
 /**
- * Waits until every fill associated with an order reaches a terminal settlement
- * outcome and returns the settlement transaction hashes.
+ * Waits until every fill listed in an order response reaches a terminal
+ * settlement outcome and returns the settlement transaction hashes.
  *
  * @remarks
- * Settlement normally covers the fills listed in this order response,
- * identified by the response's `tradeIds`. When the response is `delayed`, the
- * order has been accepted but matching has not happened yet, so the SDK first
- * waits for the order's associated trade IDs to become available. It does not
- * wait for later fills of any remaining quantity resting on the book;
- * subscribe to the `user` channel to follow those.
+ * Settlement covers the fills listed in this order response, identified by the
+ * response's `tradeIds`. These are the fills that happened immediately when
+ * the order was accepted. It does not wait for later fills of any remaining
+ * quantity resting on the book; subscribe to the `user` channel to follow
+ * those.
  *
- * Orders that finish matching without fills resolve to any transaction hashes
- * carried by the order response, or an empty array. In the rare case where
- * some fills fail execution, the settled fills' hashes are still returned; the
- * failed fills simply contribute no hash.
+ * Orders without fill identifiers resolve immediately to any transaction
+ * hashes carried by the order response, or an empty array. In the rare case
+ * where some fills fail execution, the settled fills' hashes are still
+ * returned; the failed fills simply contribute no hash.
  *
  * @example
  * ```ts
@@ -129,22 +116,14 @@ export async function waitForOrderFillSettlement(
     WaitForOrderFillSettlementRequestSchema,
   );
 
-  const deadline = Date.now() + timeoutMs;
-  let tradeIds = [...new Set(order.tradeIds)];
+  const tradeIds = [...new Set(order.tradeIds)];
 
   if (tradeIds.length === 0) {
-    if (order.status !== OrderPostStatus.DELAYED) {
-      return [...order.transactionsHashes];
-    }
-
-    tradeIds = await waitForDelayedOrderTradeIds(
-      client,
-      order.orderId,
-      deadline,
-    );
+    return [...order.transactionsHashes];
   }
 
   const settled = new Map<string, ClobTrade>();
+  const deadline = Date.now() + timeoutMs;
 
   while (settled.size < tradeIds.length) {
     const pending = tradeIds.filter((id) => !settled.has(id));
@@ -176,7 +155,7 @@ export async function waitForOrderFillSettlement(
 
   const trades = [...settled.values()];
 
-  if (trades.length > 0 && trades.every(isFailedTrade)) {
+  if (trades.every(isFailedTrade)) {
     throw new TransactionFailedError(
       `Every fill of order ${order.orderId} failed execution: ${tradeIds.join(', ')}`,
     );
@@ -189,32 +168,4 @@ export async function waitForOrderFillSettlement(
         .map((trade) => trade.transactionHash),
     ),
   ].map((hash) => TxHashSchema.parse(hash));
-}
-
-async function waitForDelayedOrderTradeIds(
-  client: BaseSecureClient,
-  orderId: OrderId,
-  deadline: number,
-): Promise<string[]> {
-  while (true) {
-    const page = await listOpenOrders(client, { id: orderId }).firstPage();
-    const order = page.items[0];
-    const tradeIds = [...new Set(order?.associateTrades ?? [])];
-
-    if (tradeIds.length > 0) {
-      return tradeIds;
-    }
-
-    if (order && DELAYED_ORDER_NO_FILL_STATUSES.has(order.status)) {
-      return [];
-    }
-
-    if (Date.now() >= deadline) {
-      throw new TimeoutError(
-        `Timed out waiting for delayed order ${orderId} to match`,
-      );
-    }
-
-    await delay(SETTLEMENT_POLL_INTERVAL_MS);
-  }
 }

--- a/packages/client/src/actions/orders/settlement.ts
+++ b/packages/client/src/actions/orders/settlement.ts
@@ -28,6 +28,12 @@ import { listAccountTrades, listOpenOrders } from '../account';
 
 const SETTLEMENT_POLL_INTERVAL_MS = 250;
 const DEFAULT_SETTLEMENT_TIMEOUT_MS = 30_000;
+const DELAYED_ORDER_NO_FILL_STATUSES = new Set([
+  'LIVE',
+  'INVALID',
+  'CANCELED',
+  'CANCELED_MARKET_RESOLVED',
+]);
 
 const WaitForOrderFillSettlementRequestFields = {
   timeoutMs: z.number().int().positive().optional(),
@@ -92,10 +98,10 @@ function isFailedTrade(trade: ClobTrade): boolean {
  * wait for later fills of any remaining quantity resting on the book;
  * subscribe to the `user` channel to follow those.
  *
- * Non-delayed orders without fill identifiers resolve immediately to any
- * transaction hashes carried by the order response, or an empty array. In the
- * rare case where some fills fail execution, the settled fills' hashes are
- * still returned; the failed fills simply contribute no hash.
+ * Orders that finish matching without fills resolve to any transaction hashes
+ * carried by the order response, or an empty array. In the rare case where
+ * some fills fail execution, the settled fills' hashes are still returned; the
+ * failed fills simply contribute no hash.
  *
  * @example
  * ```ts
@@ -170,7 +176,7 @@ export async function waitForOrderFillSettlement(
 
   const trades = [...settled.values()];
 
-  if (trades.every(isFailedTrade)) {
+  if (trades.length > 0 && trades.every(isFailedTrade)) {
     throw new TransactionFailedError(
       `Every fill of order ${order.orderId} failed execution: ${tradeIds.join(', ')}`,
     );
@@ -192,10 +198,15 @@ async function waitForDelayedOrderTradeIds(
 ): Promise<string[]> {
   while (true) {
     const page = await listOpenOrders(client, { id: orderId }).firstPage();
-    const tradeIds = [...new Set(page.items[0]?.associateTrades ?? [])];
+    const order = page.items[0];
+    const tradeIds = [...new Set(order?.associateTrades ?? [])];
 
     if (tradeIds.length > 0) {
       return tradeIds;
+    }
+
+    if (order && DELAYED_ORDER_NO_FILL_STATUSES.has(order.status)) {
+      return [];
     }
 
     if (Date.now() >= deadline) {

--- a/packages/client/src/actions/orders/settlement.ts
+++ b/packages/client/src/actions/orders/settlement.ts
@@ -1,7 +1,13 @@
-import { TradeStatus, type TxHash, TxHashSchema } from '@polymarket/bindings';
-import type {
-  AcceptedOrderResponse,
-  ClobTrade,
+import {
+  type OrderId,
+  TradeStatus,
+  type TxHash,
+  TxHashSchema,
+} from '@polymarket/bindings';
+import {
+  type AcceptedOrderResponse,
+  type ClobTrade,
+  OrderPostStatus,
 } from '@polymarket/bindings/clob';
 import { delay } from '@polymarket/types';
 import { z } from 'zod';
@@ -18,7 +24,7 @@ import {
   UserInputError,
 } from '../../errors';
 import { parseUserInput } from '../../input';
-import { listAccountTrades } from '../account';
+import { listAccountTrades, listOpenOrders } from '../account';
 
 const SETTLEMENT_POLL_INTERVAL_MS = 250;
 const DEFAULT_SETTLEMENT_TIMEOUT_MS = 30_000;
@@ -75,20 +81,21 @@ function isFailedTrade(trade: ClobTrade): boolean {
 }
 
 /**
- * Waits until every fill listed in an order response reaches a terminal
- * settlement outcome and returns the settlement transaction hashes.
+ * Waits until every fill associated with an order reaches a terminal settlement
+ * outcome and returns the settlement transaction hashes.
  *
  * @remarks
- * Settlement covers the fills listed in this order response, identified by the
- * response's `tradeIds`. These are the fills that happened immediately when
- * the order was accepted. It does not wait for later fills of any remaining
- * quantity resting on the book; subscribe to the `user` channel to follow
- * those.
+ * Settlement normally covers the fills listed in this order response,
+ * identified by the response's `tradeIds`. When the response is `delayed`, the
+ * order has been accepted but matching has not happened yet, so the SDK first
+ * waits for the order's associated trade IDs to become available. It does not
+ * wait for later fills of any remaining quantity resting on the book;
+ * subscribe to the `user` channel to follow those.
  *
- * Orders without fill identifiers resolve immediately to any transaction
- * hashes carried by the order response, or an empty array. In the rare case
- * where some fills fail execution, the settled fills' hashes are still
- * returned; the failed fills simply contribute no hash.
+ * Non-delayed orders without fill identifiers resolve immediately to any
+ * transaction hashes carried by the order response, or an empty array. In the
+ * rare case where some fills fail execution, the settled fills' hashes are
+ * still returned; the failed fills simply contribute no hash.
  *
  * @example
  * ```ts
@@ -104,8 +111,7 @@ function isFailedTrade(trade: ClobTrade): boolean {
  * ```
  *
  * @throws {@link WaitForOrderFillSettlementError}
- * Thrown on failure: a timeout while fills are still settling, or every fill
- * failing execution. The order placement itself is unaffected.
+ * Thrown on failure.
  */
 export async function waitForOrderFillSettlement(
   client: BaseSecureClient,
@@ -117,14 +123,22 @@ export async function waitForOrderFillSettlement(
     WaitForOrderFillSettlementRequestSchema,
   );
 
-  const tradeIds = [...new Set(order.tradeIds)];
+  const deadline = Date.now() + timeoutMs;
+  let tradeIds = [...new Set(order.tradeIds)];
 
   if (tradeIds.length === 0) {
-    return [...order.transactionsHashes];
+    if (order.status !== OrderPostStatus.DELAYED) {
+      return [...order.transactionsHashes];
+    }
+
+    tradeIds = await waitForDelayedOrderTradeIds(
+      client,
+      order.orderId,
+      deadline,
+    );
   }
 
   const settled = new Map<string, ClobTrade>();
-  const deadline = Date.now() + timeoutMs;
 
   while (settled.size < tradeIds.length) {
     const pending = tradeIds.filter((id) => !settled.has(id));
@@ -169,4 +183,27 @@ export async function waitForOrderFillSettlement(
         .map((trade) => trade.transactionHash),
     ),
   ].map((hash) => TxHashSchema.parse(hash));
+}
+
+async function waitForDelayedOrderTradeIds(
+  client: BaseSecureClient,
+  orderId: OrderId,
+  deadline: number,
+): Promise<string[]> {
+  while (true) {
+    const page = await listOpenOrders(client, { id: orderId }).firstPage();
+    const tradeIds = [...new Set(page.items[0]?.associateTrades ?? [])];
+
+    if (tradeIds.length > 0) {
+      return tradeIds;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new TimeoutError(
+        `Timed out waiting for delayed order ${orderId} to match`,
+      );
+    }
+
+    await delay(SETTLEMENT_POLL_INTERVAL_MS);
+  }
 }

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -190,10 +190,9 @@ export type SecureTradingActions = {
    * settlement outcome and returns the settlement transaction hashes.
    *
    * @remarks
-   * Settlement normally covers the fills listed in this order response. When
-   * the response is `delayed`, the SDK first waits for the order's associated
-   * fills to become available, or for matching to finish without fills. It does
-   * not wait for later fills of any remaining quantity resting on the book;
+   * Settlement covers the fills listed in this order response. These are the
+   * fills that happened immediately when the order was accepted. It does not
+   * wait for later fills of any remaining quantity resting on the book;
    * subscribe to the `user` channel to follow those.
    *
    * @throws {@link WaitForOrderFillSettlementError}

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -190,14 +190,14 @@ export type SecureTradingActions = {
    * settlement outcome and returns the settlement transaction hashes.
    *
    * @remarks
-   * Settlement covers the fills listed in this order response. These are the
-   * fills that happened immediately when the order was accepted. It does not
-   * wait for later fills of any remaining quantity resting on the book;
-   * subscribe to the `user` channel to follow those.
+   * Settlement normally covers the fills listed in this order response. When
+   * the response is `delayed`, the SDK first waits for the order's associated
+   * fills to become available. It does not wait for later fills of any
+   * remaining quantity resting on the book; subscribe to the `user` channel to
+   * follow those.
    *
    * @throws {@link WaitForOrderFillSettlementError}
-   * Thrown on failure: a timeout while fills are still settling, or every
-   * fill failing execution. The order placement itself is unaffected.
+   * Thrown on failure.
    *
    * @example
    * ```ts

--- a/packages/client/src/decorators/trading.ts
+++ b/packages/client/src/decorators/trading.ts
@@ -192,9 +192,9 @@ export type SecureTradingActions = {
    * @remarks
    * Settlement normally covers the fills listed in this order response. When
    * the response is `delayed`, the SDK first waits for the order's associated
-   * fills to become available. It does not wait for later fills of any
-   * remaining quantity resting on the book; subscribe to the `user` channel to
-   * follow those.
+   * fills to become available, or for matching to finish without fills. It does
+   * not wait for later fills of any remaining quantity resting on the book;
+   * subscribe to the `user` channel to follow those.
    *
    * @throws {@link WaitForOrderFillSettlementError}
    * Thrown on failure.

--- a/packages/client/tests/integration/markets.ts
+++ b/packages/client/tests/integration/markets.ts
@@ -31,6 +31,7 @@ function hasRequiredOrderFields(candidate: Market) {
     candidate.state.acceptingOrders !== false &&
     candidate.trading.minimumOrderSize !== null &&
     candidate.trading.minimumOrderSize !== undefined &&
+    (candidate.trading.secondsDelay ?? 0) === 0 &&
     candidate.outcomes.yes.tokenId !== null
   );
 }


### PR DESCRIPTION
## Summary

- type accepted response `orderId` as the branded `OrderId`
- exclude markets with a positive matching delay from the integration market selector
- keep `waitForOrderFillSettlement` scoped to the trade IDs present in the accepted response

## Why

The failure in [Actions run 30833290676](https://github.com/Polymarket/ts-sdk/actions/runs/30833290676/job/91752737101) selected a market with a matching delay. Its accepted market-order response was therefore `delayed`, with zero fill amounts and no trade IDs or transaction hashes yet.

Rather than making the settlement helper discover an order's later execution outcome, the integration tests now avoid delayed markets before placing an order. Delayed execution remains visible to SDK consumers through the accepted response status.

## Validation

- `pnpm exec vitest run packages/client/src/actions/orders/settlement.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

Linear: [DEV-536](https://linear.app/polymarket/issue/DEV-536/handle-delayed-order-settlement-discovery-and-brand-order-response-ids)