### PR TITLE
feat(client): cache order market metadata

### DIFF
--- a/.changeset/dev-93-order-metadata-cache.md
+++ b/.changeset/dev-93-order-metadata-cache.md
@@ -3,4 +3,4 @@
 "@polymarket/client": minor
 ---
 
-Cache market configuration used to prepare repeated limit and protected market orders. If cached tick metadata rejects a limit or protected price, the SDK fetches current metadata and validates once more before returning the input error. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response, while `maxSpend` preparations continue fetching current platform and builder fee inputs. Order-book tick sizes are normalized to supported numeric values.
+Cache market configuration and platform fees used to prepare repeated orders. If cached tick metadata rejects a limit or protected price, the SDK fetches current metadata and validates once more before returning the input error. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response, while attributed `maxSpend` preparations continue fetching current builder fees. Order-book tick sizes are normalized to supported numeric values.

--- a/.changeset/dev-93-order-metadata-cache.md
+++ b/.changeset/dev-93-order-metadata-cache.md
@@ -3,4 +3,4 @@
 "@polymarket/client": minor
 ---
 
-Cache market configuration and platform fees used to prepare repeated orders. If cached tick metadata rejects a limit or protected price, the SDK fetches current metadata and validates once more before returning the input error. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response, while attributed `maxSpend` preparations continue fetching current builder fees. Order-book tick sizes are normalized to supported numeric values.
+Cache market configuration, platform fees, and builder fee rates used to prepare repeated orders. If cached tick metadata rejects a limit or protected price, the SDK fetches current metadata and validates once more before returning the input error. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response. Order-book tick sizes are normalized to supported numeric values.

--- a/.changeset/dev-93-order-metadata-cache.md
+++ b/.changeset/dev-93-order-metadata-cache.md
@@ -3,4 +3,4 @@
 "@polymarket/client": minor
 ---
 
-Cache market configuration, platform fees, and builder fee rates used to prepare repeated orders. If cached tick metadata rejects a limit or protected price, the SDK fetches current metadata and validates once more before returning the input error. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response. Order-book tick sizes are normalized to supported numeric values.
+Cache market configuration, platform fees, and builder fee rates used to prepare repeated orders. If cached tick metadata rejects a limit or protected price, the SDK fetches current metadata and validates once more before returning the input error. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response. Order-book tick sizes are normalized to supported numeric values. `maxSpend` is now documented as an estimated all-in spend target based on recently resolved fees rather than a strict cap.

--- a/.changeset/dev-93-order-metadata-cache.md
+++ b/.changeset/dev-93-order-metadata-cache.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": minor
+"@polymarket/client": minor
+---
+
+Cache market configuration used to prepare repeated limit and protected market orders. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response, while `maxSpend` preparations continue fetching current platform and builder fee inputs. Order-book tick sizes are normalized to supported numeric values.

--- a/.changeset/dev-93-order-metadata-cache.md
+++ b/.changeset/dev-93-order-metadata-cache.md
@@ -3,4 +3,4 @@
 "@polymarket/client": minor
 ---
 
-Cache market configuration used to prepare repeated limit and protected market orders. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response, while `maxSpend` preparations continue fetching current platform and builder fee inputs. Order-book tick sizes are normalized to supported numeric values.
+Cache market configuration used to prepare repeated limit and protected market orders. If cached tick metadata rejects a limit or protected price, the SDK fetches current metadata and validates once more before returning the input error. Unprotected market orders now derive price, tick size, and exchange selection from one live order-book response, while `maxSpend` preparations continue fetching current platform and builder fee inputs. Order-book tick sizes are normalized to supported numeric values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,18 @@
 - For any public SDK function export, including actions and client methods, document the public thrown-error surface explicitly. Export a flattened `...Error` union of the concrete public error types the function can throw through its public contract, dedupe the union, and do not include internal assertion-style errors such as `InvariantError` in that union.
 - Public SDK functions with a documented `...Error` union should include an `@throws` line in TSDoc that references that union. The accompanying sentence can be brief and generic; it does not need to enumerate every specific failure path.
 
+## Data Flow and Responsibility
+
+- Preserve one-way workflow data flow: resolve data, validate it, derive values, then build the result. Do not route operational data through a shared abstraction merely because multiple call sites need it.
+- Keep policy in the layer that owns it. Bindings normalize wire data, caches fetch and store reusable data, actions own workflow decisions and recovery, and public action boundaries attach user-facing parameter names and errors.
+- A helper should return the data or result named by its responsibility. Empty arrays, sentinel `undefined` values, refresh callbacks, or helpers returning unrelated values are signs that an abstraction is carrying multiple concerns.
+- Prefer explicit branches and small local duplication when workflows use different sources, freshness requirements, or error semantics. Do not force distinct workflows through a generic abstraction only to remove duplication.
+- Use one coherent source of truth for related values. Do not combine live and cached fields when one response provides the values required for a single operation.
+- Treat freshness as part of correctness. Cache a value only when bounded staleness cannot violate the public contract; keep inputs to hard guarantees current unless immutability or safe invalidation is proven.
+- Keep lower-level validation field-neutral. The action that owns a public parameter should attach its name and user-facing error context.
+- Implement recovery at the workflow that observes the failure. Fetch fresh data and run the normal local path again instead of teaching storage or transport layers about caller-specific validation and retry behavior.
+- Judge an abstraction primarily by whether it makes its callers easier to read top-to-bottom. If callers need to prepare descriptors, callbacks, or placeholder values for the abstraction, prefer a simpler local composition.
+
 ## Testing
 
 - Default client tests to integration-style coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,9 @@
 
 - Default client tests to integration-style coverage.
 - Do not mock API responses unless explicitly requested or unless mocking is necessary to isolate a boundary under test.
+- Never build local fake-client helpers by casting partial objects to `BaseClient` or `BaseSecureClient` and stubbing transport responses. Those fixtures can silently diverge from upstream behavior.
+- Prove cross-boundary behavior such as request counts, caching, retries, and pagination in `packages/client/tests/integration` with real clients and live APIs. Observing the real network with a `fetch` spy is fine; replacing responses is not.
+- When stateful policy requires controlled time or failures, extract it behind a consumer-defined, domain-typed dependency seam and unit test that logic without clients, transports, responses, or wire-format fixtures.
 - For tests involving async iterators, especially integration tests, prefer idiomatic consumer usage such as `for await (...)` so the test reads like final SDK DX. Manual iterator calls like `iterator.next()` are acceptable in unit tests or narrow cases where they make the behavior materially easier to isolate or understand.
 - Add tests when they protect user-facing behavior, public API contracts, integration boundaries, or regressions that are likely to recur.
 - Do not add tests reflexively for every small implementation change. For narrow schema or mechanical changes, prefer existing broader coverage plus `typecheck` or build verification when that gives enough confidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,10 @@
 - Do not leak `ky` details outside of `ServiceClient`. Keep `ky` instances, types, and option shapes internal, and expose Polymarket-specific abstractions instead.
 - Wallet-library integrations must stay isolated to their entry points and optional peer dependencies. If `viem` is an optional peer tied to the `viem` entry point, non-`viem` code paths must not import `viem`. Apply the same rule to future entry points for other wallet libraries such as Ethers, Privy, Safe SDK, or Turnkey.
 
+## Platform Invariants
+
+- A market's minimum tick size may become finer, such as `0.01` to `0.001`, but it cannot become coarser, such as `0.001` to `0.01`. SDK caching and recovery logic may rely on this monotonic behavior and should not add defensive handling for tick-size coarsening.
+
 ## TypeScript config
 
 - Root `tsconfig.json` and package-level `tsconfig.json` files are for editor tooling and source navigation only.

--- a/packages/bindings/src/clob/market-data.test.ts
+++ b/packages/bindings/src/clob/market-data.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { OrderSide, TokenIdSchema } from '../shared';
-import { MidpointsSchema, PricesSchema, SpreadsSchema } from './market-data';
+import {
+  MarketInfoSchema,
+  MidpointsSchema,
+  PricesSchema,
+  SpreadsSchema,
+} from './market-data';
 
 const TOKEN_ID =
   '8501497159083948713316135768103773293754490207922884688769443031624417212426';
@@ -53,5 +58,29 @@ describe('SpreadsSchema', () => {
     });
 
     expect(spreads[tokenId]).toBe('0.02');
+  });
+});
+
+describe('MarketInfoSchema', () => {
+  it('normalizes order metadata and defaults omitted flags', () => {
+    expect(
+      MarketInfoSchema.parse({
+        fd: { r: 0.02, e: 1 },
+        mts: 0.01,
+        t: [{ t: TOKEN_ID, o: 'Yes' }],
+      }),
+    ).toEqual({
+      feeInfo: { rate: 0.02, exponent: 1 },
+      negRisk: false,
+      tickSize: 0.01,
+      tokens: [{ tokenId: TOKEN_ID, outcome: 'Yes' }],
+    });
+  });
+
+  it('rejects missing and unsupported tick sizes', () => {
+    const tokens = [{ t: TOKEN_ID, o: 'Yes' }];
+
+    expect(() => MarketInfoSchema.parse({ t: tokens })).toThrow();
+    expect(() => MarketInfoSchema.parse({ mts: 0.02, t: tokens })).toThrow();
   });
 });

--- a/packages/bindings/src/clob/market-data.ts
+++ b/packages/bindings/src/clob/market-data.ts
@@ -3,6 +3,7 @@ import {
   CtfConditionIdSchema,
   DecimalStringSchema,
   OrderSideSchema,
+  TickSizeValueSchema,
   TokenIdSchema,
 } from '../shared';
 
@@ -129,10 +130,14 @@ export const MarketTokenSchema = z
 export const MarketInfoSchema = z
   .object({
     fd: MarketFeeInfoSchema.nullish(),
+    mts: TickSizeValueSchema,
+    nr: z.boolean().optional(),
     t: z.array(MarketTokenSchema),
   })
-  .transform(({ fd, t }) => ({
+  .transform(({ fd, mts, nr, t }) => ({
     feeInfo: fd ?? { rate: 0, exponent: 0 },
+    negRisk: nr ?? false,
+    tickSize: mts,
     tokens: t,
   }));
 

--- a/packages/bindings/src/clob/order-book.test.ts
+++ b/packages/bindings/src/clob/order-book.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { OrderBookSchema } from './order-book';
+
+const orderBook = {
+  market: `0x${'ab'.repeat(32)}`,
+  asset_id: '111',
+  bids: [],
+  asks: [],
+  min_order_size: '5',
+  tick_size: '0.01',
+  neg_risk: false,
+  hash: 'a'.repeat(40),
+};
+
+describe('OrderBookSchema', () => {
+  it('normalizes tick size to a supported numeric value', () => {
+    expect(OrderBookSchema.parse(orderBook).tickSize).toBe(0.01);
+  });
+
+  it('rejects unsupported tick sizes', () => {
+    expect(() =>
+      OrderBookSchema.parse({ ...orderBook, tick_size: '0.02' }),
+    ).toThrow();
+  });
+});

--- a/packages/bindings/src/clob/order-book.ts
+++ b/packages/bindings/src/clob/order-book.ts
@@ -6,6 +6,8 @@ import {
   DecimalStringSchema,
   type EpochMilliseconds,
   EpochMillisecondsStringSchema,
+  type TickSizeValue,
+  TickSizeValueSchema,
   type TokenId,
   TokenIdSchema,
 } from '../shared';
@@ -31,7 +33,7 @@ export type OrderBook = {
   asks: OrderBookLevel[];
 
   minOrderSize: DecimalString;
-  tickSize: DecimalString;
+  tickSize: TickSizeValue;
   negRisk: boolean;
   lastTradePrice?: DecimalString | null;
   hash: OrderBookHash;
@@ -47,6 +49,9 @@ export const OrderBookHashSchema = z
   .regex(/^[a-f0-9]{40}$/)
   .transform((value) => value as OrderBookHash);
 
+const OrderBookTickSizeSchema =
+  DecimalStringSchema.transform(Number).pipe(TickSizeValueSchema);
+
 export const OrderBookSchema = z
   .object({
     market: CtfConditionIdSchema,
@@ -55,7 +60,7 @@ export const OrderBookSchema = z
     bids: z.array(OrderBookLevelSchema),
     asks: z.array(OrderBookLevelSchema),
     min_order_size: DecimalStringSchema,
-    tick_size: DecimalStringSchema,
+    tick_size: OrderBookTickSizeSchema,
     neg_risk: z.boolean(),
     last_trade_price: DecimalStringSchema.nullish(),
     hash: OrderBookHashSchema,

--- a/packages/client/src/actions/orders/cache.test.ts
+++ b/packages/client/src/actions/orders/cache.test.ts
@@ -1,4 +1,8 @@
-import { CtfConditionIdSchema, TokenIdSchema } from '@polymarket/bindings';
+import {
+  BuilderCodeSchema,
+  CtfConditionIdSchema,
+  TokenIdSchema,
+} from '@polymarket/bindings';
 import type { MarketInfo } from '@polymarket/bindings/clob';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { UnexpectedResponseError } from '../../errors';
@@ -8,7 +12,8 @@ const TOKEN_YES = TokenIdSchema.parse('111');
 const TOKEN_NO = TokenIdSchema.parse('222');
 const STRAY_TOKEN = TokenIdSchema.parse('999');
 const CONDITION_ID = CtfConditionIdSchema.parse(`0x${'ab'.repeat(32)}`);
-const MARKET_TTL_MS = 10 * 60 * 1000;
+const BUILDER_CODE = BuilderCodeSchema.parse(`0x${'cd'.repeat(32)}`);
+const METADATA_TTL_MS = 10 * 60 * 1000;
 
 const market: MarketInfo = {
   feeInfo: { exponent: 1, rate: 0.02 },
@@ -72,7 +77,7 @@ describe('OrderMetadataCache', () => {
     const { cache, deps } = createCache();
 
     await cache.resolveMarket(TOKEN_YES);
-    vi.advanceTimersByTime(MARKET_TTL_MS + 1);
+    vi.advanceTimersByTime(METADATA_TTL_MS + 1);
     deps.fetchMarket.mockResolvedValueOnce({ ...market, tickSize: 0.001 });
 
     expect(await cache.resolveMarket(TOKEN_YES)).toEqual({
@@ -118,10 +123,27 @@ describe('OrderMetadataCache', () => {
     expect(deps.resolveCondition).toHaveBeenCalledTimes(1);
     expect(deps.fetchMarket).toHaveBeenCalledTimes(3);
   });
+
+  it('caches builder taker fees until the metadata TTL expires', async () => {
+    vi.useFakeTimers();
+    const { cache, deps } = createCache();
+
+    expect(await cache.resolveBuilderTakerFeeRate(undefined)).toBe(0);
+    expect(await cache.resolveBuilderTakerFeeRate(BUILDER_CODE)).toBe(0.01);
+    expect(await cache.resolveBuilderTakerFeeRate(BUILDER_CODE)).toBe(0.01);
+    expect(deps.fetchBuilderTakerFeeRate).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(METADATA_TTL_MS + 1);
+    deps.fetchBuilderTakerFeeRate.mockResolvedValueOnce(0.02);
+
+    expect(await cache.resolveBuilderTakerFeeRate(BUILDER_CODE)).toBe(0.02);
+    expect(deps.fetchBuilderTakerFeeRate).toHaveBeenCalledTimes(2);
+  });
 });
 
 function createCache() {
   const deps = {
+    fetchBuilderTakerFeeRate: vi.fn(async () => 0.01),
     fetchMarket: vi.fn(async () => market),
     resolveCondition: vi.fn(async () => CONDITION_ID),
   };

--- a/packages/client/src/actions/orders/cache.test.ts
+++ b/packages/client/src/actions/orders/cache.test.ts
@@ -29,6 +29,7 @@ describe('OrderMetadataCache', () => {
     const { cache, deps } = createCache();
 
     expect(await cache.resolveMarket(TOKEN_YES)).toEqual({
+      feeInfo: market.feeInfo,
       negRisk: false,
       tickSize: 0.01,
     });
@@ -57,6 +58,7 @@ describe('OrderMetadataCache', () => {
 
     await expect(cache.resolveMarket(TOKEN_YES)).rejects.toThrow('boom');
     await expect(cache.resolveMarket(TOKEN_YES)).resolves.toEqual({
+      feeInfo: market.feeInfo,
       negRisk: false,
       tickSize: 0.01,
     });
@@ -74,6 +76,7 @@ describe('OrderMetadataCache', () => {
     deps.fetchMarket.mockResolvedValueOnce({ ...market, tickSize: 0.001 });
 
     expect(await cache.resolveMarket(TOKEN_YES)).toEqual({
+      feeInfo: market.feeInfo,
       negRisk: false,
       tickSize: 0.001,
     });
@@ -107,6 +110,7 @@ describe('OrderMetadataCache', () => {
     });
     await cache.fetchCurrentMarket(TOKEN_YES);
     expect(await cache.resolveMarket(TOKEN_YES)).toEqual({
+      feeInfo: market.feeInfo,
       negRisk: false,
       tickSize: 0.01,
     });

--- a/packages/client/src/actions/orders/cache.test.ts
+++ b/packages/client/src/actions/orders/cache.test.ts
@@ -1,0 +1,126 @@
+import { CtfConditionIdSchema, TokenIdSchema } from '@polymarket/bindings';
+import type { MarketInfo } from '@polymarket/bindings/clob';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { UnexpectedResponseError } from '../../errors';
+import { OrderMetadataCache } from './cache';
+
+const TOKEN_YES = TokenIdSchema.parse('111');
+const TOKEN_NO = TokenIdSchema.parse('222');
+const STRAY_TOKEN = TokenIdSchema.parse('999');
+const CONDITION_ID = CtfConditionIdSchema.parse(`0x${'ab'.repeat(32)}`);
+const MARKET_TTL_MS = 10 * 60 * 1000;
+
+const market: MarketInfo = {
+  feeInfo: { exponent: 1, rate: 0.02 },
+  negRisk: false,
+  tickSize: 0.01,
+  tokens: [
+    { outcome: 'Yes', tokenId: TOKEN_YES },
+    { outcome: 'No', tokenId: TOKEN_NO },
+  ],
+};
+
+describe('OrderMetadataCache', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('caches market metadata and warms sibling token mappings', async () => {
+    const { cache, deps } = createCache();
+
+    expect(await cache.resolveMarket(TOKEN_YES)).toEqual({
+      negRisk: false,
+      tickSize: 0.01,
+    });
+    await cache.resolveMarket(TOKEN_YES);
+    await cache.resolveMarket(TOKEN_NO);
+
+    expect(deps.resolveCondition).toHaveBeenCalledTimes(1);
+    expect(deps.fetchMarket).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent cold reads', async () => {
+    const { cache, deps } = createCache();
+
+    await Promise.all([
+      cache.resolveMarket(TOKEN_YES),
+      cache.resolveMarket(TOKEN_YES),
+    ]);
+
+    expect(deps.resolveCondition).toHaveBeenCalledTimes(1);
+    expect(deps.fetchMarket).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts rejected reads so the next call retries', async () => {
+    const { cache, deps } = createCache();
+    deps.fetchMarket.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(cache.resolveMarket(TOKEN_YES)).rejects.toThrow('boom');
+    await expect(cache.resolveMarket(TOKEN_YES)).resolves.toEqual({
+      negRisk: false,
+      tickSize: 0.01,
+    });
+
+    expect(deps.resolveCondition).toHaveBeenCalledTimes(1);
+    expect(deps.fetchMarket).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes expired market metadata without resolving the condition again', async () => {
+    vi.useFakeTimers();
+    const { cache, deps } = createCache();
+
+    await cache.resolveMarket(TOKEN_YES);
+    vi.advanceTimersByTime(MARKET_TTL_MS + 1);
+    deps.fetchMarket.mockResolvedValueOnce({ ...market, tickSize: 0.001 });
+
+    expect(await cache.resolveMarket(TOKEN_YES)).toEqual({
+      negRisk: false,
+      tickSize: 0.001,
+    });
+    expect(deps.resolveCondition).toHaveBeenCalledTimes(1);
+    expect(deps.fetchMarket).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects inconsistent token-to-market responses without caching the token mapping', async () => {
+    const { cache, deps } = createCache();
+
+    await expect(cache.resolveMarket(STRAY_TOKEN)).rejects.toBeInstanceOf(
+      UnexpectedResponseError,
+    );
+    await expect(cache.resolveMarket(STRAY_TOKEN)).rejects.toBeInstanceOf(
+      UnexpectedResponseError,
+    );
+
+    expect(deps.resolveCondition).toHaveBeenCalledTimes(2);
+    expect(deps.fetchMarket).toHaveBeenCalledTimes(2);
+  });
+
+  it('fetches current metadata on every sequential read and updates the cache', async () => {
+    const { cache, deps } = createCache();
+
+    await cache.resolveMarket(TOKEN_YES);
+    deps.fetchMarket.mockResolvedValueOnce({ ...market, tickSize: 0.001 });
+    expect(await cache.fetchCurrentMarket(TOKEN_YES)).toEqual({
+      feeInfo: market.feeInfo,
+      negRisk: false,
+      tickSize: 0.001,
+    });
+    await cache.fetchCurrentMarket(TOKEN_YES);
+    expect(await cache.resolveMarket(TOKEN_YES)).toEqual({
+      negRisk: false,
+      tickSize: 0.01,
+    });
+
+    expect(deps.resolveCondition).toHaveBeenCalledTimes(1);
+    expect(deps.fetchMarket).toHaveBeenCalledTimes(3);
+  });
+});
+
+function createCache() {
+  const deps = {
+    fetchMarket: vi.fn(async () => market),
+    resolveCondition: vi.fn(async () => CONDITION_ID),
+  };
+
+  return { cache: new OrderMetadataCache(deps), deps };
+}

--- a/packages/client/src/actions/orders/cache.ts
+++ b/packages/client/src/actions/orders/cache.ts
@@ -13,13 +13,9 @@ const IMMUTABLE_TTL_MS = Number.POSITIVE_INFINITY;
 
 /** @internal */
 export type OrderMarketMetadata = {
+  feeInfo: MarketFeeInfo;
   negRisk: boolean;
   tickSize: TickSizeValue;
-};
-
-/** @internal */
-export type CurrentOrderMarketMetadata = OrderMarketMetadata & {
-  feeInfo: MarketFeeInfo;
 };
 
 /** @internal */
@@ -28,7 +24,7 @@ export type OrderMetadataCacheDeps = {
   resolveCondition(tokenId: TokenId): Promise<CtfConditionId>;
 };
 
-type MarketRecord = CurrentOrderMarketMetadata & {
+type MarketRecord = OrderMarketMetadata & {
   tokenIds: ReadonlySet<TokenId>;
 };
 
@@ -50,12 +46,14 @@ export class OrderMetadataCache {
   async resolveMarket(tokenId: TokenId): Promise<OrderMarketMetadata> {
     const market = await this.#resolveMarket(tokenId);
 
-    return { negRisk: market.negRisk, tickSize: market.tickSize };
+    return {
+      feeInfo: market.feeInfo,
+      negRisk: market.negRisk,
+      tickSize: market.tickSize,
+    };
   }
 
-  async fetchCurrentMarket(
-    tokenId: TokenId,
-  ): Promise<CurrentOrderMarketMetadata> {
+  async fetchCurrentMarket(tokenId: TokenId): Promise<OrderMarketMetadata> {
     const conditionId = await readThrough(
       this.#conditions,
       tokenId,
@@ -181,7 +179,7 @@ export function resolveOrderMarketMetadata(
 export function fetchCurrentOrderMarketMetadata(
   client: BaseClient,
   tokenId: TokenId,
-): Promise<CurrentOrderMarketMetadata> {
+): Promise<OrderMarketMetadata> {
   return resolveCache(client).fetchCurrentMarket(tokenId);
 }
 

--- a/packages/client/src/actions/orders/cache.ts
+++ b/packages/client/src/actions/orders/cache.ts
@@ -1,4 +1,5 @@
 import type {
+  BuilderCode,
   CtfConditionId,
   TickSizeValue,
   TokenId,
@@ -6,9 +7,13 @@ import type {
 import type { MarketFeeInfo, MarketInfo } from '@polymarket/bindings/clob';
 import type { BaseClient } from '../../clients';
 import { UnexpectedResponseError } from '../../errors';
-import { fetchMarketInfo, resolveConditionByToken } from '../clob';
+import {
+  fetchBuilderFeeRates,
+  fetchMarketInfo,
+  resolveConditionByToken,
+} from '../clob';
 
-const MARKET_TTL_MS = 10 * 60 * 1000;
+const METADATA_TTL_MS = 10 * 60 * 1000;
 const IMMUTABLE_TTL_MS = Number.POSITIVE_INFINITY;
 
 /** @internal */
@@ -20,6 +25,7 @@ export type OrderMarketMetadata = {
 
 /** @internal */
 export type OrderMetadataCacheDeps = {
+  fetchBuilderTakerFeeRate(builderCode: BuilderCode): Promise<number>;
   fetchMarket(conditionId: CtfConditionId): Promise<MarketInfo>;
   resolveCondition(tokenId: TokenId): Promise<CtfConditionId>;
 };
@@ -36,6 +42,7 @@ type CacheEntry<TValue> = {
 /** @internal */
 export class OrderMetadataCache {
   readonly #deps: OrderMetadataCacheDeps;
+  readonly #builderTakerFeeRates = new Map<BuilderCode, CacheEntry<number>>();
   readonly #conditions = new Map<TokenId, CacheEntry<CtfConditionId>>();
   readonly #markets = new Map<CtfConditionId, CacheEntry<MarketRecord>>();
 
@@ -53,6 +60,21 @@ export class OrderMetadataCache {
     };
   }
 
+  async resolveBuilderTakerFeeRate(
+    builderCode: BuilderCode | undefined,
+  ): Promise<number> {
+    if (builderCode === undefined) {
+      return 0;
+    }
+
+    return readThrough(
+      this.#builderTakerFeeRates,
+      builderCode,
+      METADATA_TTL_MS,
+      () => this.#deps.fetchBuilderTakerFeeRate(builderCode),
+    );
+  }
+
   async fetchCurrentMarket(tokenId: TokenId): Promise<OrderMarketMetadata> {
     const conditionId = await readThrough(
       this.#conditions,
@@ -63,7 +85,7 @@ export class OrderMetadataCache {
     const market = await this.#fetchMarket(conditionId);
 
     this.#assertMarketContainsToken(tokenId, conditionId, market);
-    this.#markets.set(conditionId, resolvedEntry(market, MARKET_TTL_MS));
+    this.#markets.set(conditionId, resolvedEntry(market, METADATA_TTL_MS));
 
     return {
       feeInfo: market.feeInfo,
@@ -82,7 +104,7 @@ export class OrderMetadataCache {
     const market = await readThrough(
       this.#markets,
       conditionId,
-      MARKET_TTL_MS,
+      METADATA_TTL_MS,
       () => this.#fetchMarket(conditionId),
     );
 
@@ -183,6 +205,14 @@ export function fetchCurrentOrderMarketMetadata(
   return resolveCache(client).fetchCurrentMarket(tokenId);
 }
 
+/** @internal */
+export function resolveBuilderTakerFeeRate(
+  client: BaseClient,
+  builderCode: BuilderCode | undefined,
+): Promise<number> {
+  return resolveCache(client).resolveBuilderTakerFeeRate(builderCode);
+}
+
 function resolveCache(client: BaseClient): OrderMetadataCache {
   const existing = cachesByClient.get(client);
 
@@ -191,6 +221,8 @@ function resolveCache(client: BaseClient): OrderMetadataCache {
   }
 
   const created = new OrderMetadataCache({
+    fetchBuilderTakerFeeRate: async (builderCode) =>
+      (await fetchBuilderFeeRates(client, { builderCode })).taker,
     fetchMarket: (conditionId) => fetchMarketInfo(client, { conditionId }),
     resolveCondition: (tokenId) => resolveConditionByToken(client, { tokenId }),
   });

--- a/packages/client/src/actions/orders/cache.ts
+++ b/packages/client/src/actions/orders/cache.ts
@@ -1,0 +1,202 @@
+import type {
+  CtfConditionId,
+  TickSizeValue,
+  TokenId,
+} from '@polymarket/bindings';
+import type { MarketFeeInfo, MarketInfo } from '@polymarket/bindings/clob';
+import type { BaseClient } from '../../clients';
+import { UnexpectedResponseError } from '../../errors';
+import { fetchMarketInfo, resolveConditionByToken } from '../clob';
+
+const MARKET_TTL_MS = 10 * 60 * 1000;
+const IMMUTABLE_TTL_MS = Number.POSITIVE_INFINITY;
+
+/** @internal */
+export type OrderMarketMetadata = {
+  negRisk: boolean;
+  tickSize: TickSizeValue;
+};
+
+/** @internal */
+export type CurrentOrderMarketMetadata = OrderMarketMetadata & {
+  feeInfo: MarketFeeInfo;
+};
+
+/** @internal */
+export type OrderMetadataCacheDeps = {
+  fetchMarket(conditionId: CtfConditionId): Promise<MarketInfo>;
+  resolveCondition(tokenId: TokenId): Promise<CtfConditionId>;
+};
+
+type MarketRecord = CurrentOrderMarketMetadata & {
+  tokenIds: ReadonlySet<TokenId>;
+};
+
+type CacheEntry<TValue> = {
+  expiresAt?: number;
+  promise: Promise<TValue>;
+};
+
+/** @internal */
+export class OrderMetadataCache {
+  readonly #deps: OrderMetadataCacheDeps;
+  readonly #conditions = new Map<TokenId, CacheEntry<CtfConditionId>>();
+  readonly #markets = new Map<CtfConditionId, CacheEntry<MarketRecord>>();
+
+  constructor(deps: OrderMetadataCacheDeps) {
+    this.#deps = deps;
+  }
+
+  async resolveMarket(tokenId: TokenId): Promise<OrderMarketMetadata> {
+    const market = await this.#resolveMarket(tokenId);
+
+    return { negRisk: market.negRisk, tickSize: market.tickSize };
+  }
+
+  async fetchCurrentMarket(
+    tokenId: TokenId,
+  ): Promise<CurrentOrderMarketMetadata> {
+    const conditionId = await readThrough(
+      this.#conditions,
+      tokenId,
+      IMMUTABLE_TTL_MS,
+      () => this.#deps.resolveCondition(tokenId),
+    );
+    const market = await this.#fetchMarket(conditionId);
+
+    this.#validateMembership(tokenId, conditionId, market);
+    this.#markets.set(conditionId, resolvedEntry(market, MARKET_TTL_MS));
+
+    return {
+      feeInfo: market.feeInfo,
+      negRisk: market.negRisk,
+      tickSize: market.tickSize,
+    };
+  }
+
+  async #resolveMarket(tokenId: TokenId): Promise<MarketRecord> {
+    const conditionId = await readThrough(
+      this.#conditions,
+      tokenId,
+      IMMUTABLE_TTL_MS,
+      () => this.#deps.resolveCondition(tokenId),
+    );
+    const market = await readThrough(
+      this.#markets,
+      conditionId,
+      MARKET_TTL_MS,
+      () => this.#fetchMarket(conditionId),
+    );
+
+    this.#validateMembership(tokenId, conditionId, market);
+
+    return market;
+  }
+
+  #validateMembership(
+    tokenId: TokenId,
+    conditionId: CtfConditionId,
+    market: MarketRecord,
+  ): void {
+    if (market.tokenIds.has(tokenId)) {
+      return;
+    }
+
+    this.#conditions.delete(tokenId);
+    this.#markets.delete(conditionId);
+    throw new UnexpectedResponseError(
+      `Market ${conditionId} does not include token ${tokenId}.`,
+    );
+  }
+
+  async #fetchMarket(conditionId: CtfConditionId): Promise<MarketRecord> {
+    const market = await this.#deps.fetchMarket(conditionId);
+    const tokenIds = new Set(market.tokens.map(({ tokenId }) => tokenId));
+
+    for (const tokenId of tokenIds) {
+      this.#conditions.set(tokenId, resolvedEntry(conditionId));
+    }
+
+    return {
+      feeInfo: market.feeInfo,
+      negRisk: market.negRisk,
+      tickSize: market.tickSize,
+      tokenIds,
+    };
+  }
+}
+
+function readThrough<TKey, TValue>(
+  entries: Map<TKey, CacheEntry<TValue>>,
+  key: TKey,
+  ttlMs: number,
+  load: () => Promise<TValue>,
+): Promise<TValue> {
+  const cached = entries.get(key);
+
+  if (
+    cached !== undefined &&
+    (cached.expiresAt === undefined || cached.expiresAt > Date.now())
+  ) {
+    return cached.promise;
+  }
+
+  const entry: CacheEntry<TValue> = { promise: load() };
+  entry.promise.then(
+    () => {
+      entry.expiresAt = Date.now() + ttlMs;
+    },
+    () => {
+      if (entries.get(key) === entry) {
+        entries.delete(key);
+      }
+    },
+  );
+  entries.set(key, entry);
+
+  return entry.promise;
+}
+
+function resolvedEntry<TValue>(
+  value: TValue,
+  ttlMs = IMMUTABLE_TTL_MS,
+): CacheEntry<TValue> {
+  return {
+    expiresAt: Date.now() + ttlMs,
+    promise: Promise.resolve(value),
+  };
+}
+
+const cachesByClient = new WeakMap<BaseClient, OrderMetadataCache>();
+
+/** @internal */
+export function resolveOrderMarketMetadata(
+  client: BaseClient,
+  tokenId: TokenId,
+): Promise<OrderMarketMetadata> {
+  return resolveCache(client).resolveMarket(tokenId);
+}
+
+/** @internal */
+export function fetchCurrentOrderMarketMetadata(
+  client: BaseClient,
+  tokenId: TokenId,
+): Promise<CurrentOrderMarketMetadata> {
+  return resolveCache(client).fetchCurrentMarket(tokenId);
+}
+
+function resolveCache(client: BaseClient): OrderMetadataCache {
+  const existing = cachesByClient.get(client);
+
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const created = new OrderMetadataCache({
+    fetchMarket: (conditionId) => fetchMarketInfo(client, { conditionId }),
+    resolveCondition: (tokenId) => resolveConditionByToken(client, { tokenId }),
+  });
+  cachesByClient.set(client, created);
+
+  return created;
+}

--- a/packages/client/src/actions/orders/cache.ts
+++ b/packages/client/src/actions/orders/cache.ts
@@ -64,7 +64,7 @@ export class OrderMetadataCache {
     );
     const market = await this.#fetchMarket(conditionId);
 
-    this.#validateMembership(tokenId, conditionId, market);
+    this.#assertMarketContainsToken(tokenId, conditionId, market);
     this.#markets.set(conditionId, resolvedEntry(market, MARKET_TTL_MS));
 
     return {
@@ -88,12 +88,12 @@ export class OrderMetadataCache {
       () => this.#fetchMarket(conditionId),
     );
 
-    this.#validateMembership(tokenId, conditionId, market);
+    this.#assertMarketContainsToken(tokenId, conditionId, market);
 
     return market;
   }
 
-  #validateMembership(
+  #assertMarketContainsToken(
     tokenId: TokenId,
     conditionId: CtfConditionId,
     market: MarketRecord,

--- a/packages/client/src/actions/orders/context.test.ts
+++ b/packages/client/src/actions/orders/context.test.ts
@@ -54,9 +54,7 @@ describe('validatePriceOnTickGrid', () => {
       const { scale, step } = grid(tick);
 
       for (let k = step; k <= scale - step; k += step) {
-        expect(validatePriceOnTickGrid(k / scale, tick, 'Price')).toBe(
-          k / scale,
-        );
+        expect(validatePriceOnTickGrid(k / scale, tick)).toBe(k / scale);
       }
     }
   });
@@ -68,7 +66,7 @@ describe('validatePriceOnTickGrid', () => {
       for (let k = step; k <= scale - step; k += 1) {
         if (k % step !== 0) {
           expect(
-            () => validatePriceOnTickGrid(k / scale, tick, 'Price'),
+            () => validatePriceOnTickGrid(k / scale, tick),
             `price ${k / scale} on tick ${tick}`,
           ).toThrow('must be a multiple of tick size');
         }
@@ -93,7 +91,7 @@ describe('validatePriceOnTickGrid', () => {
     number,
     TickSizeValue,
   ][])('rejects %s for exceeding the %s tick precision', (price, tick) => {
-    expect(() => validatePriceOnTickGrid(price, tick, 'Price')).toThrow(
+    expect(() => validatePriceOnTickGrid(price, tick)).toThrow(
       'decimal places',
     );
   });
@@ -101,10 +99,10 @@ describe('validatePriceOnTickGrid', () => {
   it('rejects prices outside [tick, 1 - tick]', () => {
     for (const tick of ALL_TICKS) {
       for (const price of [0, 1, 1.5, -tick, tick / 2]) {
-        expect(() => validatePriceOnTickGrid(price, tick, 'Price')).toThrow(
+        expect(() => validatePriceOnTickGrid(price, tick)).toThrow(
           UserInputError,
         );
-        expect(() => validatePriceOnTickGrid(price, tick, 'Price')).toThrow(
+        expect(() => validatePriceOnTickGrid(price, tick)).toThrow(
           'must be between',
         );
       }

--- a/packages/client/src/actions/orders/context.ts
+++ b/packages/client/src/actions/orders/context.ts
@@ -37,33 +37,31 @@ export function resolveRoundingConfig(tickSize: TickSizeValue): RoundingConfig {
  * Grid membership is fully determined by the tick size: valid prices have at
  * most as many decimals as the tick and are integer multiples of it. This
  * mirrors the exchange's own validation, which divides the price by the
- * market's minimum tick and requires an integer result. `field` names the
- * caller's parameter and prefixes every error message.
+ * market's minimum tick and requires an integer result.
  *
  * @internal
  */
 export function validatePriceOnTickGrid(
   price: number,
   tickSize: TickSizeValue,
-  field: string,
 ): number {
   const tickDecimals = decimalPlaces(tickSize);
 
   if (price < tickSize || price > 1 - tickSize) {
     throw new UserInputError(
-      `${field} must be between ${tickSize} and ${1 - tickSize} for tick size ${tickSize}.`,
+      `must be between ${tickSize} and ${1 - tickSize} for tick size ${tickSize}.`,
     );
   }
 
   if (decimalPlaces(price) > tickDecimals) {
     throw new UserInputError(
-      `${field} must conform to tick size ${tickSize} with at most ${tickDecimals} decimal places.`,
+      `must conform to tick size ${tickSize} with at most ${tickDecimals} decimal places.`,
     );
   }
 
   if (!isMultipleOf(price, tickSize)) {
     throw new UserInputError(
-      `${field} ${price} must be a multiple of tick size ${tickSize}.`,
+      `${price} must be a multiple of tick size ${tickSize}.`,
     );
   }
 

--- a/packages/client/src/actions/orders/estimate.ts
+++ b/packages/client/src/actions/orders/estimate.ts
@@ -4,7 +4,7 @@ import {
   PositiveDecimalNumberSchema,
   type TickSizeValue,
 } from '@polymarket/bindings';
-import type { OrderBookLevel } from '@polymarket/bindings/clob';
+import type { OrderBook, OrderBookLevel } from '@polymarket/bindings/clob';
 import { invariant } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseClient } from '../../clients';
@@ -18,7 +18,7 @@ import {
   UserInputError,
 } from '../../errors';
 import { parseUserInput } from '../../input';
-import { fetchOrderBook, fetchTickSize } from '../clob';
+import { fetchOrderBook } from '../clob';
 
 const BaseEstimateMarketPriceRequestSchema = z.object({
   tokenId: z.string(),
@@ -130,16 +130,12 @@ export async function estimateMarketPrice(
   request: EstimateMarketPriceRequest,
 ): Promise<number> {
   const params = parseUserInput(request, EstimateMarketPriceRequestSchema);
-  const tickSize = await fetchTickSize(client, {
-    tokenId: params.tokenId,
-  });
   const amount = params.side === OrderSide.BUY ? params.amount : params.shares;
 
   return resolveEstimatedMarketPrice(client, {
     amount,
     orderType: params.orderType,
     side: params.side,
-    tickSize,
     tokenId: params.tokenId,
   });
 }
@@ -152,12 +148,28 @@ export async function resolveEstimatedMarketPrice(
     orderType: OrderType;
     side: OrderSide;
     tokenId: string;
-    tickSize: TickSizeValue;
   },
 ): Promise<number> {
   const orderBook = await fetchOrderBook(client, {
     tokenId: params.tokenId,
   });
+
+  return resolveMarketPriceFromOrderBook({
+    amount: params.amount,
+    orderBook,
+    orderType: params.orderType,
+    side: params.side,
+  });
+}
+
+/** @internal */
+export function resolveMarketPriceFromOrderBook(params: {
+  amount: number;
+  orderBook: OrderBook;
+  orderType: OrderType;
+  side: OrderSide;
+}): number {
+  const { orderBook } = params;
 
   const price =
     params.side === OrderSide.BUY
@@ -169,8 +181,8 @@ export async function resolveEstimatedMarketPrice(
         );
 
   invariant(
-    isValidPrice(price, params.tickSize),
-    `Resolved market price fell outside the valid range for tick size ${params.tickSize}.`,
+    isValidPrice(price, orderBook.tickSize),
+    `Resolved market price fell outside the valid range for tick size ${orderBook.tickSize}.`,
   );
 
   return price;

--- a/packages/client/src/actions/orders/limit.ts
+++ b/packages/client/src/actions/orders/limit.ts
@@ -12,7 +12,11 @@ import type { EvmAddress } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseSecureClient } from '../../clients';
 import { UserInputError } from '../../errors';
-import { resolveOrderMarketMetadata } from './cache';
+import {
+  fetchCurrentOrderMarketMetadata,
+  type OrderMarketMetadata,
+  resolveOrderMarketMetadata,
+} from './cache';
 import {
   resolveExchangeAddress,
   resolveRoundingConfig,
@@ -105,15 +109,36 @@ async function resolveLimitOrderContext(
   client: BaseSecureClient,
   params: ResolveLimitOrderContextParams,
 ): Promise<LimitOrderContext> {
-  const account = client.account;
   const metadata = await resolveOrderMarketMetadata(client, params.tokenId);
+
+  try {
+    return buildLimitOrderContext(client, params, metadata);
+  } catch (error) {
+    if (!(error instanceof UserInputError)) {
+      throw error;
+    }
+
+    const currentMetadata = await fetchCurrentOrderMarketMetadata(
+      client,
+      params.tokenId,
+    );
+
+    return buildLimitOrderContext(client, params, currentMetadata);
+  }
+}
+
+function buildLimitOrderContext(
+  client: BaseSecureClient,
+  params: ResolveLimitOrderContextParams,
+  metadata: OrderMarketMetadata,
+): LimitOrderContext {
   const price = validateExactPriceOnTickGrid(params.price, metadata.tickSize);
 
   return {
     exchangeAddress: resolveExchangeAddress(client, metadata.negRisk),
-    funderAddress: account.wallet,
+    funderAddress: client.account.wallet,
     price,
-    signerAddress: account.signer,
+    signerAddress: client.account.signer,
     tickSize: metadata.tickSize,
   };
 }

--- a/packages/client/src/actions/orders/limit.ts
+++ b/packages/client/src/actions/orders/limit.ts
@@ -5,12 +5,14 @@ import {
   OrderType,
   PositiveDecimalNumberSchema,
   type TickSizeValue,
+  type TokenId,
   TokenIdSchema,
 } from '@polymarket/bindings';
 import type { EvmAddress } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseSecureClient } from '../../clients';
-import { fetchNegRisk, fetchTickSize } from '../clob';
+import { UserInputError } from '../../errors';
+import { resolveOrderMarketMetadata } from './cache';
 import {
   resolveExchangeAddress,
   resolveRoundingConfig,
@@ -58,7 +60,7 @@ export type PrepareLimitOrderDraftParams = z.output<
 
 type ResolveLimitOrderContextParams = {
   price: number;
-  tokenId: string;
+  tokenId: TokenId;
 };
 
 export async function prepareLimitOrderDraft(
@@ -94,7 +96,6 @@ export async function prepareLimitOrderDraft(
 type LimitOrderContext = {
   exchangeAddress: EvmAddress;
   funderAddress: EvmAddress;
-  negRisk: boolean;
   price: number;
   signerAddress: EvmAddress;
   tickSize: TickSizeValue;
@@ -105,21 +106,31 @@ async function resolveLimitOrderContext(
   params: ResolveLimitOrderContextParams,
 ): Promise<LimitOrderContext> {
   const account = client.account;
-  const tickSize = await fetchTickSize(client, {
-    tokenId: params.tokenId,
-  });
-  const negRisk = await fetchNegRisk(client, {
-    tokenId: params.tokenId,
-  });
+  const metadata = await resolveOrderMarketMetadata(client, params.tokenId);
+  const price = validateExactPriceOnTickGrid(params.price, metadata.tickSize);
 
   return {
-    exchangeAddress: resolveExchangeAddress(client, negRisk),
+    exchangeAddress: resolveExchangeAddress(client, metadata.negRisk),
     funderAddress: account.wallet,
-    negRisk,
-    price: validatePriceOnTickGrid(params.price, tickSize, 'Price'),
+    price,
     signerAddress: account.signer,
-    tickSize,
+    tickSize: metadata.tickSize,
   };
+}
+
+function validateExactPriceOnTickGrid(
+  price: number,
+  tickSize: TickSizeValue,
+): number {
+  try {
+    return validatePriceOnTickGrid(price, tickSize);
+  } catch (error) {
+    if (!(error instanceof UserInputError)) {
+      throw error;
+    }
+
+    throw new UserInputError(`Price ${error.message}`, { cause: error });
+  }
 }
 
 function computeLimitOrderAmounts(params: {

--- a/packages/client/src/actions/orders/market.ts
+++ b/packages/client/src/actions/orders/market.ts
@@ -14,7 +14,6 @@ import type { BaseSecureClient } from '../../clients';
 import { UnexpectedResponseError, UserInputError } from '../../errors';
 import { fetchBuilderFeeRates, fetchOrderBook } from '../clob';
 import {
-  type CurrentOrderMarketMetadata,
   fetchCurrentOrderMarketMetadata,
   type OrderMarketMetadata,
   resolveOrderMarketMetadata,
@@ -107,7 +106,7 @@ async function resolveProtectedMarketOrderContext(
   const amount = params.side === OrderSide.BUY ? params.amount : params.shares;
 
   if (params.side === OrderSide.BUY && params.maxSpend !== undefined) {
-    const { builderTakerFeeRate, market } = await resolveCurrentFeeInputs(
+    const { builderTakerFeeRate, market } = await resolveFeeInputs(
       client,
       params.tokenId,
       params.builderCode,
@@ -179,9 +178,9 @@ async function resolveUnprotectedMarketOrderContext(
   const amount = params.side === OrderSide.BUY ? params.amount : params.shares;
   const feeInputs =
     params.side === OrderSide.BUY && params.maxSpend !== undefined
-      ? resolveCurrentFeeInputs(client, params.tokenId, params.builderCode)
+      ? resolveFeeInputs(client, params.tokenId, params.builderCode)
       : undefined;
-  const [orderBook, currentFeeInputs] = await Promise.all([
+  const [orderBook, resolvedFeeInputs] = await Promise.all([
     fetchOrderBook(client, { tokenId: params.tokenId }),
     feeInputs,
   ]);
@@ -207,7 +206,7 @@ async function resolveUnprotectedMarketOrderContext(
       params,
       amount,
       price,
-      currentFeeInputs,
+      resolvedFeeInputs,
     ),
     signerAddress: client.account.signer,
     tickSize: orderBook.tickSize,
@@ -218,7 +217,7 @@ function resolveUnprotectedMarketOrderAmount(
   params: PrepareMarketOrderDraftParams,
   amount: number,
   price: number,
-  feeInputs: CurrentFeeInputs | undefined,
+  feeInputs: FeeInputs | undefined,
 ): number {
   if (
     params.side !== OrderSide.BUY ||
@@ -339,18 +338,18 @@ export function computeMarketOrderAmounts(params: {
   };
 }
 
-type CurrentFeeInputs = {
+type FeeInputs = {
   builderTakerFeeRate: number;
-  market: CurrentOrderMarketMetadata;
+  market: OrderMarketMetadata;
 };
 
-async function resolveCurrentFeeInputs(
+async function resolveFeeInputs(
   client: BaseSecureClient,
   tokenId: TokenId,
   builderCode: BuilderCode | undefined,
-): Promise<CurrentFeeInputs> {
+): Promise<FeeInputs> {
   const [market, builderTakerFeeRate] = await Promise.all([
-    fetchCurrentOrderMarketMetadata(client, tokenId),
+    resolveOrderMarketMetadata(client, tokenId),
     fetchBuilderTakerFeeRate(client, builderCode),
   ]);
 

--- a/packages/client/src/actions/orders/market.ts
+++ b/packages/client/src/actions/orders/market.ts
@@ -16,6 +16,7 @@ import { fetchBuilderFeeRates, fetchOrderBook } from '../clob';
 import {
   type CurrentOrderMarketMetadata,
   fetchCurrentOrderMarketMetadata,
+  type OrderMarketMetadata,
   resolveOrderMarketMetadata,
 } from './cache';
 import {
@@ -131,6 +132,34 @@ async function resolveProtectedMarketOrderContext(
   }
 
   const metadata = await resolveOrderMarketMetadata(client, params.tokenId);
+
+  try {
+    return buildProtectedMarketOrderContext(client, params, amount, metadata);
+  } catch (error) {
+    if (!(error instanceof UserInputError)) {
+      throw error;
+    }
+
+    const currentMetadata = await fetchCurrentOrderMarketMetadata(
+      client,
+      params.tokenId,
+    );
+
+    return buildProtectedMarketOrderContext(
+      client,
+      params,
+      amount,
+      currentMetadata,
+    );
+  }
+}
+
+function buildProtectedMarketOrderContext(
+  client: BaseSecureClient,
+  params: PrepareMarketOrderDraftParams,
+  amount: number,
+  metadata: OrderMarketMetadata,
+): MarketOrderContext {
   const price = resolveProtectedMarketOrderPrice(params, metadata.tickSize);
 
   return {

--- a/packages/client/src/actions/orders/market.ts
+++ b/packages/client/src/actions/orders/market.ts
@@ -111,23 +111,35 @@ async function resolveProtectedMarketOrderContext(
       params.tokenId,
       params.builderCode,
     );
-    const price = resolveProtectedMarketOrderPrice(params, market.tickSize);
 
-    return {
-      exchangeAddress: resolveExchangeAddress(client, market.negRisk),
-      funderAddress: client.account.wallet,
-      price,
-      resolvedAmount: adjustBuyAmountForFees({
+    try {
+      return buildProtectedBuyMarketOrderContext(
+        client,
+        params,
         amount,
         builderTakerFeeRate,
-        maxSpend: params.maxSpend,
-        platformFeeExponent: market.feeInfo.exponent,
-        platformFeeRate: market.feeInfo.rate,
-        price,
-      }),
-      signerAddress: client.account.signer,
-      tickSize: market.tickSize,
-    };
+        params.maxSpend,
+        market,
+      );
+    } catch (error) {
+      if (!(error instanceof UserInputError)) {
+        throw error;
+      }
+
+      const currentMarket = await fetchCurrentOrderMarketMetadata(
+        client,
+        params.tokenId,
+      );
+
+      return buildProtectedBuyMarketOrderContext(
+        client,
+        params,
+        amount,
+        builderTakerFeeRate,
+        params.maxSpend,
+        currentMarket,
+      );
+    }
   }
 
   const metadata = await resolveOrderMarketMetadata(client, params.tokenId);
@@ -151,6 +163,33 @@ async function resolveProtectedMarketOrderContext(
       currentMetadata,
     );
   }
+}
+
+function buildProtectedBuyMarketOrderContext(
+  client: BaseSecureClient,
+  params: PrepareMarketOrderDraftParams,
+  amount: number,
+  builderTakerFeeRate: number,
+  maxSpend: number,
+  metadata: OrderMarketMetadata,
+): MarketOrderContext {
+  const price = resolveProtectedMarketOrderPrice(params, metadata.tickSize);
+
+  return {
+    exchangeAddress: resolveExchangeAddress(client, metadata.negRisk),
+    funderAddress: client.account.wallet,
+    price,
+    resolvedAmount: adjustBuyAmountForFees({
+      amount,
+      builderTakerFeeRate,
+      maxSpend,
+      platformFeeExponent: metadata.feeInfo.exponent,
+      platformFeeRate: metadata.feeInfo.rate,
+      price,
+    }),
+    signerAddress: client.account.signer,
+    tickSize: metadata.tickSize,
+  };
 }
 
 function buildProtectedMarketOrderContext(

--- a/packages/client/src/actions/orders/market.ts
+++ b/packages/client/src/actions/orders/market.ts
@@ -12,10 +12,11 @@ import { type EvmAddress, invariant } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseSecureClient } from '../../clients';
 import { UnexpectedResponseError, UserInputError } from '../../errors';
-import { fetchBuilderFeeRates, fetchOrderBook } from '../clob';
+import { fetchOrderBook } from '../clob';
 import {
   fetchCurrentOrderMarketMetadata,
   type OrderMarketMetadata,
+  resolveBuilderTakerFeeRate,
   resolveOrderMarketMetadata,
 } from './cache';
 import {
@@ -389,23 +390,10 @@ async function resolveFeeInputs(
 ): Promise<FeeInputs> {
   const [market, builderTakerFeeRate] = await Promise.all([
     resolveOrderMarketMetadata(client, tokenId),
-    fetchBuilderTakerFeeRate(client, builderCode),
+    resolveBuilderTakerFeeRate(client, builderCode),
   ]);
 
   return { builderTakerFeeRate, market };
-}
-
-async function fetchBuilderTakerFeeRate(
-  client: BaseSecureClient,
-  builderCode: BuilderCode | undefined,
-): Promise<number> {
-  if (builderCode === undefined) {
-    return 0;
-  }
-
-  const builderFees = await fetchBuilderFeeRates(client, { builderCode });
-
-  return builderFees.taker;
 }
 
 export function adjustBuyAmountForFees(params: {

--- a/packages/client/src/actions/orders/market.ts
+++ b/packages/client/src/actions/orders/market.ts
@@ -5,24 +5,25 @@ import {
   OrderType,
   PositiveDecimalNumberSchema,
   type TickSizeValue,
+  type TokenId,
   TokenIdSchema,
 } from '@polymarket/bindings';
-import type { EvmAddress } from '@polymarket/types';
+import { type EvmAddress, invariant } from '@polymarket/types';
 import { z } from 'zod';
 import type { BaseSecureClient } from '../../clients';
+import { UnexpectedResponseError, UserInputError } from '../../errors';
+import { fetchBuilderFeeRates, fetchOrderBook } from '../clob';
 import {
-  fetchBuilderFeeRates,
-  fetchMarketInfo,
-  fetchNegRisk,
-  fetchTickSize,
-  resolveConditionByToken,
-} from '../clob';
+  type CurrentOrderMarketMetadata,
+  fetchCurrentOrderMarketMetadata,
+  resolveOrderMarketMetadata,
+} from './cache';
 import {
   resolveExchangeAddress,
   resolveRoundingConfig,
   validatePriceOnTickGrid,
 } from './context';
-import { resolveEstimatedMarketPrice } from './estimate';
+import { resolveMarketPriceFromOrderBook } from './estimate';
 import { decimalPlaces, parseAmount, roundDown, roundUp } from './math';
 import type { OrderDraft, PrepareMarketOrderRequest } from './types';
 
@@ -80,19 +81,9 @@ export async function prepareMarketOrderDraft(
   };
 }
 
-type ResolveMarketOrderAmountParams = {
-  amount: number;
-  builderCode?: BuilderCode;
-  maxSpend?: number;
-  price: number;
-  side: OrderSide;
-  tokenId: string;
-};
-
 type MarketOrderContext = {
   exchangeAddress: EvmAddress;
   funderAddress: EvmAddress;
-  negRisk: boolean;
   price: number;
   resolvedAmount: number;
   signerAddress: EvmAddress;
@@ -103,56 +94,162 @@ async function resolveMarketOrderContext(
   client: BaseSecureClient,
   params: PrepareMarketOrderDraftParams,
 ): Promise<MarketOrderContext> {
-  const account = client.account;
-  const tickSize = await fetchTickSize(client, {
-    tokenId: params.tokenId,
-  });
+  return hasProtectedPrice(params)
+    ? resolveProtectedMarketOrderContext(client, params)
+    : resolveUnprotectedMarketOrderContext(client, params);
+}
+
+async function resolveProtectedMarketOrderContext(
+  client: BaseSecureClient,
+  params: PrepareMarketOrderDraftParams,
+): Promise<MarketOrderContext> {
   const amount = params.side === OrderSide.BUY ? params.amount : params.shares;
-  const price = await resolveMarketOrderPrice(client, params, amount, tickSize);
-  const negRisk = await fetchNegRisk(client, {
-    tokenId: params.tokenId,
-  });
-  const resolvedAmount = await resolveMarketOrderAmount(client, {
-    amount,
-    builderCode: params.builderCode,
-    maxSpend: params.side === OrderSide.BUY ? params.maxSpend : undefined,
-    price,
-    side: params.side,
-    tokenId: params.tokenId,
-  });
+
+  if (params.side === OrderSide.BUY && params.maxSpend !== undefined) {
+    const { builderTakerFeeRate, market } = await resolveCurrentFeeInputs(
+      client,
+      params.tokenId,
+      params.builderCode,
+    );
+    const price = resolveProtectedMarketOrderPrice(params, market.tickSize);
+
+    return {
+      exchangeAddress: resolveExchangeAddress(client, market.negRisk),
+      funderAddress: client.account.wallet,
+      price,
+      resolvedAmount: adjustBuyAmountForFees({
+        amount,
+        builderTakerFeeRate,
+        maxSpend: params.maxSpend,
+        platformFeeExponent: market.feeInfo.exponent,
+        platformFeeRate: market.feeInfo.rate,
+        price,
+      }),
+      signerAddress: client.account.signer,
+      tickSize: market.tickSize,
+    };
+  }
+
+  const metadata = await resolveOrderMarketMetadata(client, params.tokenId);
+  const price = resolveProtectedMarketOrderPrice(params, metadata.tickSize);
 
   return {
-    exchangeAddress: resolveExchangeAddress(client, negRisk),
-    funderAddress: account.wallet,
-    negRisk,
+    exchangeAddress: resolveExchangeAddress(client, metadata.negRisk),
+    funderAddress: client.account.wallet,
     price,
-    resolvedAmount,
-    signerAddress: account.signer,
-    tickSize,
+    resolvedAmount: amount,
+    signerAddress: client.account.signer,
+    tickSize: metadata.tickSize,
   };
 }
 
-async function resolveMarketOrderPrice(
+async function resolveUnprotectedMarketOrderContext(
   client: BaseSecureClient,
   params: PrepareMarketOrderDraftParams,
-  amount: number,
-  tickSize: TickSizeValue,
-): Promise<number> {
-  if (params.side === OrderSide.BUY && params.maxPrice !== undefined) {
-    return validatePriceOnTickGrid(params.maxPrice, tickSize, 'maxPrice');
+): Promise<MarketOrderContext> {
+  const amount = params.side === OrderSide.BUY ? params.amount : params.shares;
+  const feeInputs =
+    params.side === OrderSide.BUY && params.maxSpend !== undefined
+      ? resolveCurrentFeeInputs(client, params.tokenId, params.builderCode)
+      : undefined;
+  const [orderBook, currentFeeInputs] = await Promise.all([
+    fetchOrderBook(client, { tokenId: params.tokenId }),
+    feeInputs,
+  ]);
+
+  if (orderBook.tokenId !== params.tokenId) {
+    throw new UnexpectedResponseError(
+      `Order book returned token ${orderBook.tokenId} for requested token ${params.tokenId}.`,
+    );
   }
 
-  if (params.side === OrderSide.SELL && params.minPrice !== undefined) {
-    return validatePriceOnTickGrid(params.minPrice, tickSize, 'minPrice');
-  }
-
-  return resolveEstimatedMarketPrice(client, {
+  const price = resolveMarketPriceFromOrderBook({
     amount,
+    orderBook,
     orderType: params.orderType,
     side: params.side,
-    tickSize,
-    tokenId: params.tokenId,
   });
+
+  return {
+    exchangeAddress: resolveExchangeAddress(client, orderBook.negRisk),
+    funderAddress: client.account.wallet,
+    price,
+    resolvedAmount: resolveUnprotectedMarketOrderAmount(
+      params,
+      amount,
+      price,
+      currentFeeInputs,
+    ),
+    signerAddress: client.account.signer,
+    tickSize: orderBook.tickSize,
+  };
+}
+
+function resolveUnprotectedMarketOrderAmount(
+  params: PrepareMarketOrderDraftParams,
+  amount: number,
+  price: number,
+  feeInputs: CurrentFeeInputs | undefined,
+): number {
+  if (
+    params.side !== OrderSide.BUY ||
+    params.maxSpend === undefined ||
+    feeInputs === undefined
+  ) {
+    return amount;
+  }
+
+  return adjustBuyAmountForFees({
+    amount,
+    builderTakerFeeRate: feeInputs.builderTakerFeeRate,
+    maxSpend: params.maxSpend,
+    platformFeeExponent: feeInputs.market.feeInfo.exponent,
+    platformFeeRate: feeInputs.market.feeInfo.rate,
+    price,
+  });
+}
+
+function resolveProtectedMarketOrderPrice(
+  params: PrepareMarketOrderDraftParams,
+  tickSize: TickSizeValue,
+): number {
+  if (params.side === OrderSide.BUY) {
+    invariant(
+      params.maxPrice !== undefined,
+      'Protected BUY market order requires maxPrice.',
+    );
+    return validateProtectedPriceOnTickGrid(
+      'maxPrice',
+      params.maxPrice,
+      tickSize,
+    );
+  }
+
+  invariant(
+    params.minPrice !== undefined,
+    'Protected SELL market order requires minPrice.',
+  );
+  return validateProtectedPriceOnTickGrid(
+    'minPrice',
+    params.minPrice,
+    tickSize,
+  );
+}
+
+function validateProtectedPriceOnTickGrid(
+  field: 'maxPrice' | 'minPrice',
+  price: number,
+  tickSize: TickSizeValue,
+): number {
+  try {
+    return validatePriceOnTickGrid(price, tickSize);
+  } catch (error) {
+    if (!(error instanceof UserInputError)) {
+      throw error;
+    }
+
+    throw new UserInputError(`${field} ${error.message}`, { cause: error });
+  }
 }
 
 function hasProtectedPrice(params: PrepareMarketOrderDraftParams): boolean {
@@ -213,44 +310,22 @@ export function computeMarketOrderAmounts(params: {
   };
 }
 
-async function resolveMarketOrderAmount(
-  client: BaseSecureClient,
-  params: ResolveMarketOrderAmountParams,
-): Promise<number> {
-  if (params.side !== OrderSide.BUY || params.maxSpend === undefined) {
-    return params.amount;
-  }
-
-  const [feeInfo, builderTakerFeeRate] = await Promise.all([
-    fetchMarketFeeInfo(client, params.tokenId),
-    fetchBuilderTakerFeeRate(client, params.builderCode),
-  ]);
-
-  return adjustBuyAmountForFees({
-    amount: params.amount,
-    builderTakerFeeRate,
-    platformFeeExponent: feeInfo.exponent,
-    platformFeeRate: feeInfo.rate,
-    maxSpend: params.maxSpend,
-    price: params.price,
-  });
-}
-
-type MarketFeeInfo = {
-  rate: number;
-  exponent: number;
+type CurrentFeeInputs = {
+  builderTakerFeeRate: number;
+  market: CurrentOrderMarketMetadata;
 };
 
-async function fetchMarketFeeInfo(
+async function resolveCurrentFeeInputs(
   client: BaseSecureClient,
-  tokenId: string,
-): Promise<MarketFeeInfo> {
-  const conditionId = await resolveConditionByToken(client, { tokenId });
-  const marketInfo = await fetchMarketInfo(client, {
-    conditionId,
-  });
+  tokenId: TokenId,
+  builderCode: BuilderCode | undefined,
+): Promise<CurrentFeeInputs> {
+  const [market, builderTakerFeeRate] = await Promise.all([
+    fetchCurrentOrderMarketMetadata(client, tokenId),
+    fetchBuilderTakerFeeRate(client, builderCode),
+  ]);
 
-  return marketInfo.feeInfo;
+  return { builderTakerFeeRate, market };
 }
 
 async function fetchBuilderTakerFeeRate(

--- a/packages/client/src/actions/orders/trade.ts
+++ b/packages/client/src/actions/orders/trade.ts
@@ -18,8 +18,8 @@ import {
 import { completeWith } from '../../workflow';
 import { updateBalanceAllowance } from '../account';
 import { approveErc20, approveErc1155ForAll } from '../approvals';
-import { fetchNegRisk } from '../clob';
 import { resolveCurrentAllowance } from './allowance';
+import { resolveOrderMarketMetadata } from './cache';
 import { resolveExchangeAddress } from './context';
 import { type PostOrderError, postOrder } from './post';
 import {
@@ -243,8 +243,8 @@ async function ensureOrderApproval(
   client: BaseSecureClient,
   order: SignedOrder,
 ): Promise<boolean> {
-  const negRisk = await fetchNegRisk(client, { tokenId: order.tokenId });
-  const exchangeAddress = resolveExchangeAddress(client, negRisk);
+  const metadata = await resolveOrderMarketMetadata(client, order.tokenId);
+  const exchangeAddress = resolveExchangeAddress(client, metadata.negRisk);
   const requiredAllowance = BigInt(order.makerAmount);
   const currentAllowance = await resolveCurrentAllowance(client, {
     spenderAddress: exchangeAddress,

--- a/packages/client/src/actions/orders/types.ts
+++ b/packages/client/src/actions/orders/types.ts
@@ -39,19 +39,18 @@ export type PrepareMarketBuyOrderRequest = BasePrepareMarketOrderRequest & {
    * Desired USD notional to buy, before market and builder taker fees.
    *
    * By default, the SDK prepares the order for this full buy amount and applicable
-   * fees are paid on top. Set `maxSpend` when the total USD spent, including
-   * fees, must not exceed a cap.
+   * fees are paid on top. Set `maxSpend` to let the SDK resize the amount against
+   * an estimated all-in spend target.
    */
   amount: number | string;
 
   /**
-   * Optional all-in USD spend cap for BUY market orders, including market and
-   * builder taker fees.
+   * Optional estimated all-in USD spend target for BUY market orders, including
+   * market and builder taker fees.
    *
    * When provided, the SDK keeps `amount` unchanged if `maxSpend` covers the
-   * requested buy amount plus fees. If fees would make total spend exceed this
-   * cap, the SDK reduces the signed buy amount so total spend fits within
-   * `maxSpend`.
+   * requested buy amount plus estimated fees. Otherwise, the SDK reduces the
+   * signed buy amount using the order price and recently resolved fee rates.
    *
    * Set `maxSpend` equal to `amount` when the requested amount should include
    * fees. Leave it unset to pay fees on top of `amount`.

--- a/packages/client/tests/integration/clob.test.ts
+++ b/packages/client/tests/integration/clob.test.ts
@@ -19,7 +19,7 @@ describe('CLOB', () => {
       expect(result.tokenId).toBe(tokenId);
       expect(Array.isArray(result.bids)).toBe(true);
       expect(Array.isArray(result.asks)).toBe(true);
-      expect(result.tickSize).toEqual(expect.any(String));
+      expect(result.tickSize).toEqual(expect.any(Number));
       expect(result.minOrderSize).toEqual(expect.any(String));
       expect(result.negRisk).toEqual(expect.any(Boolean));
       expect(result.hash).toEqual(expect.any(String));

--- a/packages/client/tests/integration/orders.test.ts
+++ b/packages/client/tests/integration/orders.test.ts
@@ -371,7 +371,7 @@ describe('Orders', { timeout: 60_000 }, () => {
       }
     });
 
-    it('fetches current builder fees for every attributed maxSpend preparation', async ({
+    it('caches builder fees for repeated attributed maxSpend preparations', async ({
       builderCode,
       randomEoaSigner,
     }) => {
@@ -394,7 +394,7 @@ describe('Orders', { timeout: 60_000 }, () => {
         await client.createMarketOrder(request);
         await client.createMarketOrder(request);
 
-        expect(countRequests(fetchSpy, '/fees/builder-fees/')).toBe(2);
+        expect(countRequests(fetchSpy, '/fees/builder-fees/')).toBe(1);
       } finally {
         fetchSpy.mockRestore();
       }

--- a/packages/client/tests/integration/orders.test.ts
+++ b/packages/client/tests/integration/orders.test.ts
@@ -343,7 +343,7 @@ describe('Orders', { timeout: 60_000 }, () => {
       ).rejects.toThrow('maxPrice must be between');
     });
 
-    it('fetches current market fees for every maxSpend preparation', async ({
+    it('caches market fees for repeated maxSpend preparations', async ({
       randomEoaSigner,
     }) => {
       const tokenId = expectPresent(market.outcomes.yes.tokenId);
@@ -365,7 +365,7 @@ describe('Orders', { timeout: 60_000 }, () => {
         await client.createMarketOrder(request);
 
         expect(countRequests(fetchSpy, '/markets-by-token/')).toBe(1);
-        expect(countRequests(fetchSpy, '/clob-markets/')).toBe(2);
+        expect(countRequests(fetchSpy, '/clob-markets/')).toBe(1);
       } finally {
         fetchSpy.mockRestore();
       }

--- a/packages/client/tests/integration/orders.test.ts
+++ b/packages/client/tests/integration/orders.test.ts
@@ -6,13 +6,14 @@ import {
 } from '@polymarket/bindings';
 import { OrderPostStatus } from '@polymarket/bindings/clob';
 import {
+  createSecureClient,
   InsufficientLiquidityError,
   type Market,
   type SecureClient,
   UserInputError,
 } from '@polymarket/client';
 import { expectPresent } from '@polymarket/types';
-import { afterAll } from 'vitest';
+import { afterAll, type MockInstance, vi } from 'vitest';
 import {
   describe,
   expect,
@@ -213,6 +214,190 @@ describe('Orders', { timeout: 60_000 }, () => {
           tokenId: yesTokenId,
         }),
       ).rejects.toThrow(UserInputError);
+    });
+  });
+
+  describe('order metadata caching', () => {
+    it('reuses cached metadata for repeated limit and protected market orders', async ({
+      randomEoaSigner,
+    }) => {
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const client = await createSecureClient({
+        signer: randomEoaSigner,
+        wallet: await randomEoaSigner.getAddress(),
+      });
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      try {
+        await client.createLimitOrder({
+          price: expectPresent(market.trading.minimumTickSize),
+          side: OrderSide.BUY,
+          size: expectPresent(market.trading.minimumOrderSize),
+          tokenId,
+        });
+
+        expect(countRequests(fetchSpy, '/markets-by-token/')).toBe(1);
+        expect(countRequests(fetchSpy, '/clob-markets/')).toBe(1);
+
+        fetchSpy.mockClear();
+        await client.createLimitOrder({
+          price: expectPresent(market.trading.minimumTickSize),
+          side: OrderSide.BUY,
+          size: expectPresent(market.trading.minimumOrderSize),
+          tokenId,
+        });
+        await client.createMarketOrder({
+          amount: expectPresent(market.trading.minimumOrderSize),
+          maxPrice: expectPresent(market.trading.minimumTickSize),
+          side: OrderSide.BUY,
+          tokenId,
+        });
+
+        expect(requestedUrls(fetchSpy)).toEqual([]);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('uses only the live order book for unprotected market orders without maxSpend', async ({
+      randomEoaSigner,
+    }) => {
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const client = await createSecureClient({
+        signer: randomEoaSigner,
+        wallet: await randomEoaSigner.getAddress(),
+      });
+      const request = {
+        amount: expectPresent(market.trading.minimumOrderSize),
+        orderType: OrderType.FAK as const,
+        side: OrderSide.BUY as const,
+        tokenId,
+      };
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      try {
+        await client.createMarketOrder(request);
+        await client.createMarketOrder(request);
+
+        expect(requestedUrls(fetchSpy)).toHaveLength(2);
+        expect(countRequests(fetchSpy, '/book')).toBe(2);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('coalesces concurrent cold metadata reads', async ({
+      randomEoaSigner,
+    }) => {
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const client = await createSecureClient({
+        signer: randomEoaSigner,
+        wallet: await randomEoaSigner.getAddress(),
+      });
+      const request = {
+        price: expectPresent(market.trading.minimumTickSize),
+        side: OrderSide.BUY as const,
+        size: expectPresent(market.trading.minimumOrderSize),
+        tokenId,
+      };
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      try {
+        await Promise.all([
+          client.createLimitOrder(request),
+          client.createLimitOrder(request),
+        ]);
+
+        expect(countRequests(fetchSpy, '/markets-by-token/')).toBe(1);
+        expect(countRequests(fetchSpy, '/clob-markets/')).toBe(1);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('adds action input names to tick-grid validation errors', async ({
+      randomEoaSigner,
+    }) => {
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const invalidPrice = expectPresent(market.trading.minimumTickSize) / 2;
+      const client = await createSecureClient({
+        signer: randomEoaSigner,
+        wallet: await randomEoaSigner.getAddress(),
+      });
+
+      await expect(
+        client.createLimitOrder({
+          price: invalidPrice,
+          side: OrderSide.BUY,
+          size: expectPresent(market.trading.minimumOrderSize),
+          tokenId,
+        }),
+      ).rejects.toThrow('Price must be between');
+      await expect(
+        client.createMarketOrder({
+          amount: expectPresent(market.trading.minimumOrderSize),
+          maxPrice: invalidPrice,
+          side: OrderSide.BUY,
+          tokenId,
+        }),
+      ).rejects.toThrow('maxPrice must be between');
+    });
+
+    it('fetches current market fees for every maxSpend preparation', async ({
+      randomEoaSigner,
+    }) => {
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const client = await createSecureClient({
+        signer: randomEoaSigner,
+        wallet: await randomEoaSigner.getAddress(),
+      });
+      const request = {
+        amount: expectPresent(market.trading.minimumOrderSize),
+        maxPrice: expectPresent(market.trading.minimumTickSize),
+        maxSpend: expectPresent(market.trading.minimumOrderSize),
+        side: OrderSide.BUY as const,
+        tokenId,
+      };
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      try {
+        await client.createMarketOrder(request);
+        await client.createMarketOrder(request);
+
+        expect(countRequests(fetchSpy, '/markets-by-token/')).toBe(1);
+        expect(countRequests(fetchSpy, '/clob-markets/')).toBe(2);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('fetches current builder fees for every attributed maxSpend preparation', async ({
+      builderCode,
+      randomEoaSigner,
+    }) => {
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const client = await createSecureClient({
+        signer: randomEoaSigner,
+        wallet: await randomEoaSigner.getAddress(),
+      });
+      const request = {
+        amount: expectPresent(market.trading.minimumOrderSize),
+        builderCode,
+        maxPrice: expectPresent(market.trading.minimumTickSize),
+        maxSpend: expectPresent(market.trading.minimumOrderSize),
+        side: OrderSide.BUY as const,
+        tokenId,
+      };
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      try {
+        await client.createMarketOrder(request);
+        await client.createMarketOrder(request);
+
+        expect(countRequests(fetchSpy, '/fees/builder-fees/')).toBe(2);
+      } finally {
+        fetchSpy.mockRestore();
+      }
     });
   });
 
@@ -525,4 +710,17 @@ async function cancelMarketOrderWithRetry(
     tokenId: order.tokenId,
     market: conditionId,
   });
+}
+
+function requestedUrls(fetchSpy: MockInstance<typeof fetch>): string[] {
+  return fetchSpy.mock.calls.map(([input]) =>
+    input instanceof Request ? input.url : String(input),
+  );
+}
+
+function countRequests(
+  fetchSpy: MockInstance<typeof fetch>,
+  path: string,
+): number {
+  return requestedUrls(fetchSpy).filter((url) => url.includes(path)).length;
 }


### PR DESCRIPTION
Resolves DEV-93. Replaces #262 with a smaller cache boundary and action-owned recovery.

- Caches reusable order metadata per client: token-to-condition mappings for the client lifetime, and market configuration, platform fees, and builder taker fees for 10 minutes. Promise-valued entries coalesce concurrent reads, evict failures, and warm sibling token mappings from one market response.
- Limit and protected market orders reuse cached metadata. If cached tick validation rejects a price, the action fetches current market metadata once and rebuilds before returning the input error.
- Unprotected market orders use one live order-book response for depth, price, tick size, and exchange selection. Public fetch actions remain uncached.
- Builder fee metadata is requested only for BUY orders using `maxSpend` and a `builderCode`. Allowance recovery reuses cached neg-risk metadata.
- Bindings normalize consolidated market metadata and order-book tick sizes to supported SDK values.

`maxSpend` is documented as an estimated all-in spend target. An internal platform-fee buffer to improve execution reliability remains scoped to DEV-522.

Verified with `pnpm lint`, `pnpm typecheck`, `pnpm test` (289 tests), and focused live integration tests covering request counts, warm reuse, concurrent coalescing, fee caching, live-book sourcing, and input-error composition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches order preparation, fee sizing, and tick validation paths where stale cache or book/metadata mismatch could change signed amounts or errors; mitigated by TTL, one-shot refresh on validation failure, and integration tests on request counts.
> 
> **Overview**
> Adds a per-client **order metadata cache** (10-minute TTL for market config, fees, and builder taker rates; permanent token→condition mapping) so repeated limit orders, protected market orders, and `maxSpend` flows avoid redundant API calls. Concurrent cold reads coalesce; failed loads evict entries.
> 
> **Limit and protected market orders** pull tick size, neg-risk, and fees from the cache. If tick-grid validation fails on cached data, the action fetches fresh metadata once and retries validation before surfacing a `UserInputError` with field names (`Price`, `maxPrice`, `minPrice`) attached at the action layer.
> 
> **Unprotected market orders** no longer fan out separate tick/neg-risk/estimate calls: one live **order book** supplies depth, price, tick size, and exchange selection. **Bindings** extend `MarketInfo` with `tickSize`/`negRisk` and normalize order-book `tick_size` to supported numeric `TickSizeValue` (breaking type change from string).
> 
> **Docs:** `maxSpend` is clarified as an estimated all-in spend target from recently resolved fees, not a hard cap. **AGENTS.md** adds platform invariants (tick sizes only get finer), data-flow guidance, and stricter integration-testing rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d204b2976632ffbac38590598b68ea0dbba4ff65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->