### PR TITLE
feat(client): support isolated margin adjustments

### DIFF
--- a/.changeset/perps-isolated-margin.md
+++ b/.changeset/perps-isolated-margin.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/client': patch
+---
+
+Add Perps session support for adjusting isolated position margin.

--- a/packages/client/src/actions/perps.test-d.ts
+++ b/packages/client/src/actions/perps.test-d.ts
@@ -31,9 +31,10 @@ import type {
   RevokePerpsCredentialsRequest,
   FetchPerpsInstrumentsRequest as RootFetchPerpsInstrumentsRequest,
   UpdatePerpsLeverageRequest,
+  UpdatePerpsMarginRequest,
   WithdrawFromPerpsRequest,
 } from '../index';
-import { FetchPerpsTickerError } from '../index';
+import { FetchPerpsTickerError, UpdatePerpsMarginError } from '../index';
 import type { FetchPerpsInstrumentsRequest } from './perps';
 
 describe('FetchPerpsInstrumentsRequest', () => {
@@ -89,6 +90,7 @@ describe('public Perps exports', () => {
       CancelPerpsOrderRequest,
       CancelPerpsOrdersRequest,
       UpdatePerpsLeverageRequest,
+      UpdatePerpsMarginRequest,
     ];
 
     expectTypeOf<RootPerpsRequests>().toEqualTypeOf<RootPerpsRequests>();
@@ -103,5 +105,6 @@ describe('public Perps exports', () => {
 
     expectTypeOf<RootPerpsSessionErrors>().toEqualTypeOf<RootPerpsSessionErrors>();
     void FetchPerpsTickerError;
+    void UpdatePerpsMarginError;
   });
 });

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -122,8 +122,12 @@ export type {
   PlacePerpsPositionTpSlResult,
   PostPerpsOrdersRequest,
   UpdatePerpsLeverageRequest,
+  UpdatePerpsMarginRequest,
 } from '../websockets/perps/session';
-export { UpdatePerpsLeverageError } from '../websockets/perps/session';
+export {
+  UpdatePerpsLeverageError,
+  UpdatePerpsMarginError,
+} from '../websockets/perps/session';
 
 import { snakeCase, toSearchParams } from './params';
 

--- a/packages/client/src/decorators/perps.ts
+++ b/packages/client/src/decorators/perps.ts
@@ -94,6 +94,7 @@ export type {
   ResumePerpsSessionRequest,
   RevokePerpsCredentialsRequest,
   UpdatePerpsLeverageRequest,
+  UpdatePerpsMarginRequest,
   WithdrawFromPerpsRequest,
 } from '../actions';
 export {
@@ -109,6 +110,7 @@ export {
   OpenPerpsSessionError,
   RevokePerpsCredentialsError,
   UpdatePerpsLeverageError,
+  UpdatePerpsMarginError,
   WithdrawFromPerpsError,
 } from '../actions';
 

--- a/packages/client/src/websockets/perps/actions/trading.test.ts
+++ b/packages/client/src/websockets/perps/actions/trading.test.ts
@@ -6,10 +6,13 @@ import {
   type PerpsTradingTransport,
   postPerpsOrders,
   toPerpsCommandBodyOp,
+  updatePerpsMargin,
 } from './trading';
 
 const CREATE_ORDER_DATA_HASH =
   '0x817207b7b8b31044a8f27e43c16e24d9fd5e11d3f106feb962f104f3ef28d52a';
+const UPDATE_MARGIN_DATA_HASH =
+  '0xf61d7d83b4367ce136bf66cfee6a5d41303a8b2d8724f5458f9812c46f5e55b3';
 
 describe('Perps trading actions', () => {
   describe('createPerpsOpTypedDataPayload', () => {
@@ -98,6 +101,41 @@ describe('Perps trading actions', () => {
           ],
         }),
       ).resolves.toMatchObject([{ orderId: 123, status: 'ok' }]);
+    });
+
+    it('signs isolated margin adjustments with backend-compatible bytes', async () => {
+      const transport: PerpsTradingTransport = {
+        async sendSignedWsCommand(request) {
+          const payload = createPerpsOpTypedDataPayload({
+            chainId: 31_337,
+            op: request.op,
+            salt: 1,
+            timestamp: 1_739_491_200_000,
+          });
+
+          expect(payload.message).toMatchObject({
+            data: UPDATE_MARGIN_DATA_HASH,
+            salt: 1n,
+            ts: 1_739_491_200_000n,
+          });
+          expect(toPerpsCommandBodyOp(request.op)).toEqual({
+            args: {
+              amt: '-1234567890.123456789012345678',
+              iid: 7,
+            },
+            type: 'updateMargin',
+          });
+
+          return request.responseSchema.parse({ status: 'ok' });
+        },
+      };
+
+      await expect(
+        updatePerpsMargin(transport, {
+          amount: '-1234567890.123456789012345678',
+          instrumentId: 7,
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -852,7 +852,28 @@ export type UpdatePerpsMarginRequest = {
 };
 
 /**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export type UpdatePerpsMarginError =
+  | RequestRejectedError
+  | SigningError
+  | TransportError
+  | UserInputError;
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export const UpdatePerpsMarginError = makeErrorGuard(
+  RequestRejectedError,
+  SigningError,
+  TransportError,
+  UserInputError,
+);
+
+/**
  * Adjusts isolated margin for an instrument position.
+ *
+ * @throws {@link UpdatePerpsMarginError}
+ * Thrown on failure.
  *
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -8,6 +8,7 @@ import {
   type PerpsCancelOrderResult,
   PerpsCancelOrderResultSchema,
   PerpsClientOrderIdSchema,
+  PerpsCommandAckSchema,
   type PerpsDecimalInput,
   PerpsDecimalInputSchema,
   type PerpsInstrumentId,
@@ -833,6 +834,44 @@ export async function updatePerpsLeverage(
   });
 }
 
+const UpdatePerpsMarginRequestSchema = z.object({
+  instrumentId: PerpsInstrumentIdSchema,
+  amount: PerpsDecimalInputSchema,
+}) satisfies z.ZodType<UpdatePerpsMarginRequest>;
+
+/**
+ * Request parameters for adjusting isolated margin on a Perps position.
+ *
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export type UpdatePerpsMarginRequest = {
+  /** Perps instrument identifier whose isolated margin should be adjusted. */
+  instrumentId: number;
+  /** Margin adjustment. Positive values add margin; negative values remove it. */
+  amount: PerpsDecimalInput;
+};
+
+/**
+ * Adjusts isolated margin for an instrument position.
+ *
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export async function updatePerpsMargin(
+  transport: PerpsTradingTransport,
+  request: UpdatePerpsMarginRequest,
+): Promise<void> {
+  const params = parseUserInput(request, UpdatePerpsMarginRequestSchema);
+  const amount = toDecimalString(params.amount);
+  const ack = await transport.sendSignedWsCommand({
+    op: ['updateMargin', [params.instrumentId, amount]],
+    responseSchema: PerpsCommandAckSchema,
+    timeoutMessage: 'Perps update margin acknowledgement timed out.',
+  });
+  if (ack.status === 'err') {
+    throw new RequestRejectedError(ack.error, { status: 200 });
+  }
+}
+
 type RawPerpsOrderInput = readonly [
   PerpsInstrumentId,
   boolean,
@@ -945,6 +984,19 @@ export function toPerpsCommandBodyOp(op: PerpsSignedOp) {
           cross: crossMargin,
           iid: instrumentId,
           lev: leverage,
+        },
+      };
+    }
+    case 'updateMargin': {
+      const [instrumentId, amount] = args as readonly [
+        PerpsInstrumentId,
+        string,
+      ];
+      return {
+        type,
+        args: {
+          amt: amount,
+          iid: instrumentId,
         },
       };
     }

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -764,6 +764,78 @@ describe('PerpsSession', () => {
       }
     });
 
+    it('updates isolated margin over the session socket', async () => {
+      const session = createSession();
+      await session.connect();
+
+      await expect(
+        session.updateMargin({
+          amount: '-1234567890.123456789012345678',
+          instrumentId: 7,
+        }),
+      ).resolves.toBeUndefined();
+      expect(frames[2]).toMatchObject({
+        id: 3,
+        op: {
+          args: {
+            amt: '-1234567890.123456789012345678',
+            iid: 7,
+          },
+          type: 'updateMargin',
+        },
+        req: 'post',
+        salt: expect.any(Number),
+        sig: expect.stringMatching(/^0x[0-9a-f]{130}$/),
+        ts: expect.any(Number),
+      });
+
+      await session.close();
+    });
+
+    it('validates isolated margin updates before sending a command', async () => {
+      const session = createSession();
+      await session.connect();
+
+      try {
+        await expect(
+          session.updateMargin({ amount: '1', instrumentId: -1 }),
+        ).rejects.toBeInstanceOf(UserInputError);
+        await expect(
+          session.updateMargin({
+            // @ts-expect-error Runtime validation rejects non-decimal inputs.
+            amount: true,
+            instrumentId: 7,
+          }),
+        ).rejects.toBeInstanceOf(UserInputError);
+        expect(frames).toHaveLength(2);
+      } finally {
+        await session.close();
+      }
+    });
+
+    it('throws when an isolated margin update is rejected', async () => {
+      mockCommandSession((frame) => {
+        if (frame.op?.type === 'updateMargin') {
+          return { status: 'err', error: 'invalid margin adjustment' };
+        }
+
+        return responseForFrame(frame);
+      });
+      const session = createSession();
+      await session.connect();
+
+      try {
+        await expect(
+          session.updateMargin({ amount: '1', instrumentId: 7 }),
+        ).rejects.toMatchObject({
+          message: 'invalid margin adjustment',
+          name: RequestRejectedError.name,
+        });
+      } finally {
+        await session.close();
+      }
+    });
+
     it('cancels a single order by client order id', async () => {
       const session = createSession();
       await session.connect();
@@ -1663,6 +1735,8 @@ function responseForFrame(frame: {
     }
     case 'updateLeverage':
       return { status: 'ok', instrument_id: 1, leverage: 5, cross: false };
+    case 'updateMargin':
+      return { status: 'ok' };
     case 'cancelOrdersCOID':
       return [
         {

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -94,7 +94,9 @@ import {
   postPerpsOrders,
   toPerpsCommandBodyOp,
   type UpdatePerpsLeverageRequest,
+  type UpdatePerpsMarginRequest,
   updatePerpsLeverage,
+  updatePerpsMargin,
 } from './actions/trading';
 import { type PerpsSignableValue, signPerpsOp } from './signing';
 
@@ -184,6 +186,7 @@ export type {
   PlacePerpsPositionTpSlRequest,
   PostPerpsOrdersRequest,
   UpdatePerpsLeverageRequest,
+  UpdatePerpsMarginRequest,
 } from './actions/trading';
 export { UpdatePerpsLeverageError } from './actions/trading';
 
@@ -872,6 +875,29 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     request: UpdatePerpsLeverageRequest,
   ): Promise<PerpsUpdateLeverageResult> {
     return await updatePerpsLeverage(this.#tradingTransport(), request);
+  }
+
+  /**
+   * Adjusts isolated margin for an instrument position.
+   *
+   * @remarks
+   * A positive amount adds isolated margin. A negative amount removes it.
+   *
+   * @example
+   * ```ts
+   * await session.updateMargin({
+   *   instrumentId: 1,
+   *   amount: '100.25',
+   * });
+   * ```
+   *
+   * @throws {@link PerpsSessionTradingError}
+   * Thrown on failure.
+   *
+   * @experimental This API may change in a breaking way in any release, including patch releases.
+   */
+  async updateMargin(request: UpdatePerpsMarginRequest): Promise<void> {
+    await updatePerpsMargin(this.#tradingTransport(), request);
   }
 
   async #connect(emitResync: boolean): Promise<void> {

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -894,7 +894,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
    * });
    * ```
    *
-   * @throws {@link PerpsSessionTradingError}
+   * @throws {@link UpdatePerpsMarginError}
    * Thrown on failure.
    *
    * @experimental This API may change in a breaking way in any release, including patch releases.

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -188,7 +188,10 @@ export type {
   UpdatePerpsLeverageRequest,
   UpdatePerpsMarginRequest,
 } from './actions/trading';
-export { UpdatePerpsLeverageError } from './actions/trading';
+export {
+  UpdatePerpsLeverageError,
+  UpdatePerpsMarginError,
+} from './actions/trading';
 
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.


### PR DESCRIPTION
## Summary

- add `PerpsSession.updateMargin` for positive and negative isolated-margin adjustments
- preserve decimal precision when signing and serializing `updateMargin`
- validate public inputs and map rejected acknowledgements through existing Perps errors

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- 47 focused Perps tests
- `pnpm test:client` (282 tests)

Live mutation testing was not performed because production feature-flag enablement was not independently confirmed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a signed trading command that moves margin on live positions; behavior is aligned with existing leverage updates but incorrect amounts or backend rejections directly affect user funds.
> 
> **Overview**
> Adds **`PerpsSession.updateMargin`** so callers can add or remove **isolated margin** on a per-instrument position via the existing signed Perps WebSocket command path.
> 
> The new flow mirrors **`updateLeverage`**: inputs are validated (`instrumentId`, decimal **`amount`**), the amount is serialized with **`toDecimalString`** for signing and wire format, and the **`updateMargin`** op is mapped in **`toPerpsCommandBodyOp`** as `{ iid, amt }`. Rejected acks surface as **`RequestRejectedError`** through **`UpdatePerpsMarginError`**.
> 
> **`UpdatePerpsMarginRequest`** and **`UpdatePerpsMarginError`** are re-exported from the client package entry points; tests cover backend-compatible signing bytes, session framing, input validation, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 970ddbfe8a8cb7b50f4ee5a6b54caa9c7272ddd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->