### PR TITLE
feat(client): allow tickSize/negRisk in order prepare params to skip fetches

### DIFF
--- a/.changeset/prepare-order-tick-size-neg-risk.md
+++ b/.changeset/prepare-order-tick-size-neg-risk.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": minor
+---
+
+Allow supplying `tickSize` and `negRisk` in limit- and market-order prepare params to skip the per-order `tick-size` / `neg-risk` fetches. Latency-sensitive integrators that already stream a market's tick size and neg-risk can pass them to remove round-trips from the click-to-sign path. When omitted, the SDK fetches them as before, and the two fallback fetches now run in parallel instead of sequentially.

--- a/packages/client/src/actions/orders/limit.ts
+++ b/packages/client/src/actions/orders/limit.ts
@@ -5,6 +5,7 @@ import {
   OrderType,
   PositiveDecimalNumberSchema,
   type TickSizeValue,
+  TickSizeValueSchema,
   TokenIdSchema,
 } from '@polymarket/bindings';
 import type { EvmAddress } from '@polymarket/types';
@@ -36,6 +37,8 @@ export const PrepareLimitOrderParamsSchema = z
     builderCode: BuilderCodeSchema.optional(),
     postOnly: z.boolean().default(false),
     expiration: z.number().int().nonnegative().optional(),
+    tickSize: TickSizeValueSchema.optional(),
+    negRisk: z.boolean().optional(),
   })
   .superRefine((params, context) => {
     if (params.expiration !== undefined) {
@@ -57,7 +60,9 @@ export type PrepareLimitOrderDraftParams = z.output<
 >;
 
 type ResolveLimitOrderContextParams = {
+  negRisk?: boolean;
   price: number;
+  tickSize?: TickSizeValue;
   tokenId: string;
 };
 
@@ -66,7 +71,9 @@ export async function prepareLimitOrderDraft(
   params: PrepareLimitOrderDraftParams,
 ): Promise<OrderDraft> {
   const context = await resolveLimitOrderContext(client, {
+    negRisk: params.negRisk,
     price: params.price,
+    tickSize: params.tickSize,
     tokenId: params.tokenId,
   });
   const amounts = computeLimitOrderAmounts({
@@ -105,12 +112,10 @@ async function resolveLimitOrderContext(
   params: ResolveLimitOrderContextParams,
 ): Promise<LimitOrderContext> {
   const account = client.account;
-  const tickSize = await fetchTickSize(client, {
-    tokenId: params.tokenId,
-  });
-  const negRisk = await fetchNegRisk(client, {
-    tokenId: params.tokenId,
-  });
+  const [tickSize, negRisk] = await Promise.all([
+    params.tickSize ?? fetchTickSize(client, { tokenId: params.tokenId }),
+    params.negRisk ?? fetchNegRisk(client, { tokenId: params.tokenId }),
+  ]);
 
   return {
     exchangeAddress: resolveExchangeAddress(client, negRisk),

--- a/packages/client/src/actions/orders/market.ts
+++ b/packages/client/src/actions/orders/market.ts
@@ -5,6 +5,7 @@ import {
   OrderType,
   PositiveDecimalNumberSchema,
   type TickSizeValue,
+  TickSizeValueSchema,
   TokenIdSchema,
 } from '@polymarket/bindings';
 import type { EvmAddress } from '@polymarket/types';
@@ -32,6 +33,8 @@ const BasePrepareMarketOrderParamsSchema = z.object({
   orderType: z
     .union([z.literal(OrderType.FAK), z.literal(OrderType.FOK)])
     .default(OrderType.FAK),
+  tickSize: TickSizeValueSchema.optional(),
+  negRisk: z.boolean().optional(),
 });
 
 export const PrepareMarketOrderParamsSchema = z.discriminatedUnion('side', [
@@ -104,14 +107,12 @@ async function resolveMarketOrderContext(
   params: PrepareMarketOrderDraftParams,
 ): Promise<MarketOrderContext> {
   const account = client.account;
-  const tickSize = await fetchTickSize(client, {
-    tokenId: params.tokenId,
-  });
+  const [tickSize, negRisk] = await Promise.all([
+    params.tickSize ?? fetchTickSize(client, { tokenId: params.tokenId }),
+    params.negRisk ?? fetchNegRisk(client, { tokenId: params.tokenId }),
+  ]);
   const amount = params.side === OrderSide.BUY ? params.amount : params.shares;
   const price = await resolveMarketOrderPrice(client, params, amount, tickSize);
-  const negRisk = await fetchNegRisk(client, {
-    tokenId: params.tokenId,
-  });
   const resolvedAmount = await resolveMarketOrderAmount(client, {
     amount,
     builderCode: params.builderCode,

--- a/packages/client/src/actions/orders/prepare-context.test.ts
+++ b/packages/client/src/actions/orders/prepare-context.test.ts
@@ -1,0 +1,139 @@
+import { OrderSide, OrderType, toTokenId } from '@polymarket/bindings';
+import type { EvmAddress } from '@polymarket/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { BaseSecureClient } from '../../clients';
+
+const fetchTickSize = vi.fn(async () => 0.01 as const);
+const fetchNegRisk = vi.fn(async () => false);
+
+vi.mock('../clob', () => ({
+  fetchTickSize,
+  fetchNegRisk,
+  fetchBuilderFeeRates: vi.fn(),
+  fetchMarketInfo: vi.fn(),
+  resolveConditionByToken: vi.fn(),
+}));
+
+// Imported after the mock so the modules pick up the mocked `../clob`.
+const { prepareLimitOrderDraft } = await import('./limit');
+const { prepareMarketOrderDraft } = await import('./market');
+
+const STANDARD_EXCHANGE =
+  '0x0000000000000000000000000000000000000010' as EvmAddress;
+const NEG_RISK_EXCHANGE =
+  '0x0000000000000000000000000000000000000020' as EvmAddress;
+const SIGNER = '0x0000000000000000000000000000000000000001' as EvmAddress;
+const WALLET = '0x0000000000000000000000000000000000000002' as EvmAddress;
+const TOKEN_ID = toTokenId('123');
+
+function createClient(): BaseSecureClient {
+  return {
+    account: { signer: SIGNER, wallet: WALLET },
+    environment: {
+      chainId: 137,
+      contracts: {
+        standardExchange: STANDARD_EXCHANGE,
+        negRiskExchange: NEG_RISK_EXCHANGE,
+      },
+    },
+  } as unknown as BaseSecureClient;
+}
+
+describe('prepare order context fetch skipping', () => {
+  afterEach(() => {
+    fetchTickSize.mockClear();
+    fetchNegRisk.mockClear();
+  });
+
+  describe('prepareLimitOrderDraft', () => {
+    it('skips both fetches when tickSize and negRisk are supplied', async () => {
+      const draft = await prepareLimitOrderDraft(createClient(), {
+        negRisk: false,
+        postOnly: false,
+        price: 0.52,
+        side: OrderSide.BUY,
+        size: 10,
+        tickSize: 0.01,
+        tokenId: TOKEN_ID,
+      });
+
+      expect(fetchTickSize).not.toHaveBeenCalled();
+      expect(fetchNegRisk).not.toHaveBeenCalled();
+      expect(draft.exchangeAddress).toBe(STANDARD_EXCHANGE);
+    });
+
+    it('honours a supplied negRisk=true by selecting the neg-risk exchange', async () => {
+      const draft = await prepareLimitOrderDraft(createClient(), {
+        negRisk: true,
+        postOnly: false,
+        price: 0.52,
+        side: OrderSide.BUY,
+        size: 10,
+        tickSize: 0.01,
+        tokenId: TOKEN_ID,
+      });
+
+      expect(fetchNegRisk).not.toHaveBeenCalled();
+      expect(draft.exchangeAddress).toBe(NEG_RISK_EXCHANGE);
+    });
+
+    it('fetches only the missing value when one override is supplied', async () => {
+      await prepareLimitOrderDraft(createClient(), {
+        postOnly: false,
+        price: 0.52,
+        side: OrderSide.BUY,
+        size: 10,
+        tickSize: 0.01,
+        tokenId: TOKEN_ID,
+      });
+
+      expect(fetchTickSize).not.toHaveBeenCalled();
+      expect(fetchNegRisk).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches both values when neither override is supplied', async () => {
+      await prepareLimitOrderDraft(createClient(), {
+        postOnly: false,
+        price: 0.52,
+        side: OrderSide.BUY,
+        size: 10,
+        tokenId: TOKEN_ID,
+      });
+
+      expect(fetchTickSize).toHaveBeenCalledTimes(1);
+      expect(fetchNegRisk).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('prepareMarketOrderDraft', () => {
+    it('skips both fetches when tickSize and negRisk are supplied', async () => {
+      const draft = await prepareMarketOrderDraft(createClient(), {
+        amount: 10,
+        maxPrice: 0.55,
+        negRisk: false,
+        orderType: OrderType.FAK,
+        side: OrderSide.BUY,
+        tickSize: 0.01,
+        tokenId: TOKEN_ID,
+      });
+
+      expect(fetchTickSize).not.toHaveBeenCalled();
+      expect(fetchNegRisk).not.toHaveBeenCalled();
+      expect(draft.exchangeAddress).toBe(STANDARD_EXCHANGE);
+    });
+
+    it('fetches only the missing value when one override is supplied', async () => {
+      await prepareMarketOrderDraft(createClient(), {
+        amount: 10,
+        maxPrice: 0.55,
+        negRisk: true,
+        orderType: OrderType.FAK,
+        side: OrderSide.BUY,
+        tokenId: TOKEN_ID,
+      });
+
+      expect(fetchTickSize).toHaveBeenCalledTimes(1);
+      expect(fetchNegRisk).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/client/src/actions/orders/types.ts
+++ b/packages/client/src/actions/orders/types.ts
@@ -2,6 +2,7 @@ import type {
   BuilderCode,
   OrderSide,
   OrderType,
+  TickSizeValue,
   TokenId,
 } from '@polymarket/bindings';
 import type { OrderResponse, SignatureType } from '@polymarket/bindings/clob';
@@ -29,6 +30,27 @@ type BasePrepareMarketOrderRequest = {
    * @defaultValue OrderType.FAK
    */
   orderType?: OrderType.FAK | OrderType.FOK;
+
+  /**
+   * Market minimum tick size, supplied to skip the per-order `tick-size`
+   * network fetch.
+   *
+   * Latency-sensitive integrators that already stream a market's tick size can
+   * pass it here to remove a round-trip from the click-to-sign path. When
+   * omitted, the SDK fetches it. Must be a valid tick size for the market; an
+   * incorrect value produces an invalid order.
+   */
+  tickSize?: TickSizeValue;
+
+  /**
+   * Whether the token belongs to a negative-risk market, supplied to skip the
+   * per-order `neg-risk` network fetch.
+   *
+   * The value selects the exchange contract the order is signed against, so an
+   * incorrect value produces an order that cannot fill. When omitted, the SDK
+   * fetches it.
+   */
+  negRisk?: boolean;
 };
 
 export type PrepareMarketBuyOrderRequest = BasePrepareMarketOrderRequest & {
@@ -137,6 +159,27 @@ export type PrepareLimitOrderRequest = {
    * When omitted, the SDK prepares a Good-Til-Cancelled (GTC) limit order.
    */
   expiration?: number;
+
+  /**
+   * Market minimum tick size, supplied to skip the per-order `tick-size`
+   * network fetch.
+   *
+   * Latency-sensitive integrators that already stream a market's tick size can
+   * pass it here to remove a round-trip from the click-to-sign path. When
+   * omitted, the SDK fetches it. Must be a valid tick size for the market; an
+   * incorrect value produces an invalid order.
+   */
+  tickSize?: TickSizeValue;
+
+  /**
+   * Whether the token belongs to a negative-risk market, supplied to skip the
+   * per-order `neg-risk` network fetch.
+   *
+   * The value selects the exchange contract the order is signed against, so an
+   * incorrect value produces an order that cannot fill. When omitted, the SDK
+   * fetches it.
+   */
+  negRisk?: boolean;
 };
 
 export type OrderDraft = {


### PR DESCRIPTION
Closes #256.

## What

Adds optional `tickSize` and `negRisk` fields to the limit- and market-order prepare params. When a caller supplies them, the SDK uses those values instead of the per-order `tick-size` / `neg-risk` network fetches. When omitted, behavior is unchanged (values are fetched), but the two fallback fetches now run in parallel via `Promise.all` instead of sequentially.

This removes 2 RTTs from the click-to-sign path for latency-sensitive integrators (e.g. a trading terminal) that already stream a market's live tick size and neg-risk.

## Changes

- `PrepareLimitOrderRequest` / `PrepareMarketOrderRequest` (public types): new optional `tickSize?: TickSizeValue` and `negRisk?: boolean`, with JSDoc noting an incorrect value produces an invalid/unfillable order.
- `PrepareLimitOrderParamsSchema` (was `strictObject`, previously rejected the extra keys) and `PrepareMarketOrderParamsSchema` now accept and validate the fields. `tickSize` is validated against `TickSizeValueSchema` — an invalid tick is rejected rather than silently used.
- `resolveLimitOrderContext` / `resolveMarketOrderContext`: use supplied values when present, otherwise fetch; fetches parallelized. Supplied `tickSize` is still run through `validatePriceOnTickGrid`, so price validation is unchanged.

## Verification

- New unit tests (`prepare-context.test.ts`) mock the clob fetch layer and drive `prepareLimitOrderDraft` / `prepareMarketOrderDraft`, asserting: both fetches skipped when both overrides supplied; only the missing value fetched when one is supplied; both fetched when neither is supplied; and a supplied `negRisk=true` selects the neg-risk exchange address.
- `pnpm typecheck`, `pnpm test:client` (284 passed), and `pnpm lint` all green.
- Changeset added (`@polymarket/client` minor).

Note: `false ?? fetch()` correctly short-circuits — `??` only falls through on `null`/`undefined`, so `negRisk: false` is honored without a fetch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong tickSize or negRisk can sign orders against the wrong exchange or with invalid pricing, though overrides are opt-in and documented; default fetch path remains.
> 
> **Overview**
> Adds optional **`tickSize`** and **`negRisk`** on limit- and market-order prepare params so callers that already have market metadata can skip the per-order CLOB **`tick-size`** / **`neg-risk`** round-trips on the click-to-sign path.
> 
> When overrides are omitted, behavior is unchanged except **`resolveLimitOrderContext`** and **`resolveMarketOrderContext`** now load the two values with **`Promise.all`** instead of back-to-back awaits. Schemas validate **`tickSize`** via **`TickSizeValueSchema`**; supplied values still drive tick-grid validation and exchange selection (**`negRisk`** picks the neg-risk contract). New **`prepare-context.test.ts`** covers full skip, partial fetch, and **`negRisk: false`** without a fetch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c28c11c9214772b5e70c48019bf7ba17bc128f29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->