### PR TITLE
docs(repo): add review method guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,20 @@
 - Example: if `packages/bindings` changes and you are validating `packages/client`, run `pnpm --filter @polymarket/bindings build` before `pnpm test:client`.
 - If multiple packages changed or the dependency chain is unclear, prefer root-level verification such as `pnpm build` and `pnpm test`.
 
+## Review Method
+
+- Review from the developer workflow inward. Start by understanding what the consumer is trying to accomplish and inspect realistic usage examples.
+- Build a complete mental model before judging the implementation. Clarify terminology, lifecycle, ownership, and failure behavior.
+- Review the public contract first: naming, symmetry, defaults, state representation, validation, errors, and call-site ergonomics.
+- Separate SDK behavior, integrator behavior, documentation examples, and backend behavior. Attach findings to the layer that owns them.
+- Compare questionable code with established repository patterns before requesting a change.
+- Evaluate findings by practical impact. Downgrade or discard concerns when the risk is bounded and the proposed complexity is not justified.
+- Prefer tests that prove meaningful boundaries. Favor one live integration workflow over multiple mocks when a safe test environment exists.
+- Use mocks for conditions that cannot reasonably be produced through integration testing.
+- Distinguish demonstrated bugs, contract problems, missing regression coverage, and optional hardening.
+- Revisit initial findings as understanding improves rather than defending the first interpretation.
+- Keep review comments short, human, line-specific, and actionable.
+
 ## Product and API guardrails
 
 - This repo is the home for Polymarket's TypeScript SDKs. The first shipping target is `@polymarket/client`.


### PR DESCRIPTION
## Summary

- add a workflow-first review method to `AGENTS.md`
- clarify ownership, practical-impact, and testing-boundary expectations
- require concise actionable comments and reassessment as context improves

## Verification

- `pnpm lint`
- `pnpm typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor/reviewer guidance with no runtime or API impact.
> 
> **Overview**
> Adds a **Review Method** section to `AGENTS.md` between **Required workflow** and **Product and API guardrails**, giving agents and reviewers a shared workflow for PR review.
> 
> The guidance pushes **workflow-first** review (consumer intent and realistic examples before internals), **public contract** focus, clear **layer ownership** (SDK vs integrator vs docs vs backend), and **practical impact** when triaging findings. It also sets expectations for **testing boundaries** (integration over mocks when safe), **finding categories** (bugs vs contract vs coverage vs hardening), **revising** early conclusions as context improves, and **short, actionable** comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d83f331253f23903d4ad5eb6da6c5d4ccb475c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->