### PR TITLE
fix(client): prevent perps order update race

### DIFF
--- a/.changeset/perps-order-update-race.md
+++ b/.changeset/perps-order-update-race.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Prevent Perps `placeOrder` from missing private order updates that arrive before the command acknowledgement.

--- a/.changeset/perps-order-update-race.md
+++ b/.changeset/perps-order-update-race.md
@@ -2,4 +2,4 @@
 "@polymarket/client": patch
 ---
 
-Prevent Perps `placeOrder` from missing private order updates that arrive before the command acknowledgement.
+Prevent Perps `placeOrder` from missing private order updates that arrive before the command acknowledgement. High-level placement now generates a client order ID when callers omit it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@
 ## Platform Invariants
 
 - A market's minimum tick size may become finer, such as `0.01` to `0.001`, but it cannot become coarser, such as `0.001` to `0.01`. SDK caching and recovery logic may rely on this monotonic behavior and should not add defensive handling for tick-size coarsening.
+- When a Perps order is submitted with a client order ID, every corresponding private order update echoes that same client order ID. SDK order-placement workflows may rely on this invariant for pre-acknowledgement correlation.
 
 ## TypeScript config
 

--- a/packages/client/src/websockets/perps/actions/trading.test.ts
+++ b/packages/client/src/websockets/perps/actions/trading.test.ts
@@ -3,7 +3,7 @@ import { PerpsTimeInForce } from '@polymarket/bindings/perps';
 import { describe, expect, it } from 'vitest';
 import { createPerpsOpTypedDataPayload } from '../signing';
 import {
-  type PerpsTradingTransport,
+  type PerpsCommandExecutor,
   postPerpsOrders,
   toPerpsCommandBodyOp,
   updatePerpsMargin,
@@ -17,8 +17,8 @@ const UPDATE_MARGIN_DATA_HASH =
 describe('Perps trading actions', () => {
   describe('createPerpsOpTypedDataPayload', () => {
     it('signs entry orders with backend-compatible createOrders bytes', async () => {
-      const transport: PerpsTradingTransport = {
-        async sendSignedWsCommand(request) {
+      const client: PerpsCommandExecutor = {
+        async executeCommand(request, responseSchema) {
           const payload = createPerpsOpTypedDataPayload({
             chainId: 31_337,
             op: request.op,
@@ -45,12 +45,12 @@ describe('Perps trading actions', () => {
             type: 'createOrders',
           });
 
-          return request.responseSchema.parse([{ oid: 123, status: 'ok' }]);
+          return responseSchema.parse([{ oid: 123, status: 'ok' }]);
         },
       };
 
       await expect(
-        postPerpsOrders(transport, {
+        postPerpsOrders(client, {
           orders: [
             {
               instrumentId: 1,
@@ -66,8 +66,8 @@ describe('Perps trading actions', () => {
     });
 
     it('serializes reduce-only entry orders', async () => {
-      const transport: PerpsTradingTransport = {
-        async sendSignedWsCommand(request) {
+      const client: PerpsCommandExecutor = {
+        async executeCommand(request, responseSchema) {
           expect(toPerpsCommandBodyOp(request.op)).toEqual({
             args: [
               {
@@ -83,12 +83,12 @@ describe('Perps trading actions', () => {
             type: 'createOrders',
           });
 
-          return request.responseSchema.parse([{ oid: 123, status: 'ok' }]);
+          return responseSchema.parse([{ oid: 123, status: 'ok' }]);
         },
       };
 
       await expect(
-        postPerpsOrders(transport, {
+        postPerpsOrders(client, {
           orders: [
             {
               instrumentId: 1,
@@ -104,8 +104,8 @@ describe('Perps trading actions', () => {
     });
 
     it('signs isolated margin adjustments with backend-compatible bytes', async () => {
-      const transport: PerpsTradingTransport = {
-        async sendSignedWsCommand(request) {
+      const client: PerpsCommandExecutor = {
+        async executeCommand(request, responseSchema) {
           const payload = createPerpsOpTypedDataPayload({
             chainId: 31_337,
             op: request.op,
@@ -126,12 +126,12 @@ describe('Perps trading actions', () => {
             type: 'updateMargin',
           });
 
-          return request.responseSchema.parse({ status: 'ok' });
+          return responseSchema.parse({ status: 'ok' });
         },
       };
 
       await expect(
-        updatePerpsMargin(transport, {
+        updatePerpsMargin(client, {
           amount: '-1234567890.123456789012345678',
           instrumentId: 7,
         }),

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -752,11 +752,13 @@ export async function placePerpsPositionTpSl(
     );
   }
 
-  const acknowledgements = await placePerpsOrderGroup(client, {
-    expiresAt: params.expiresAt,
-    group: PerpsTpSlScope.Position,
-    orders,
-  });
+  const acknowledgements = await client.executeCommand(
+    {
+      op: ['createOrders', orders, PerpsTpSlScope.Position],
+      expiresAt: params.expiresAt,
+    },
+    z.array(PerpsPostOrderAckSchema),
+  );
 
   for (const acknowledgement of acknowledgements) {
     if (acknowledgement.status === 'err') {
@@ -1157,23 +1159,6 @@ function toRawPerpsTpSlOrder(request: {
       request.kind,
     ],
   ];
-}
-
-async function placePerpsOrderGroup(
-  client: PerpsCommandExecutor,
-  request: {
-    orders: RawPerpsOrderInput[];
-    group: PerpsTpSlScope;
-    expiresAt?: number;
-  },
-): Promise<PerpsPostOrderAck[]> {
-  return await client.executeCommand(
-    {
-      op: ['createOrders', request.orders, request.group],
-      expiresAt: request.expiresAt,
-    },
-    z.array(PerpsPostOrderAckSchema),
-  );
 }
 
 /**

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -214,10 +214,7 @@ export type PerpsEventCommandExecutor = PerpsCommandExecutor & {
   executeCommandWithEvent<TResponse, TEvent extends PerpsSessionEvent>(
     request: PerpsCommandRequest,
     responseSchema: z.ZodType<TResponse>,
-    predicate: (
-      event: PerpsSessionEvent,
-      response: TResponse | undefined,
-    ) => event is TEvent,
+    predicate: (event: PerpsSessionEvent) => event is TEvent,
   ): Promise<readonly [TResponse, TEvent]>;
 };
 
@@ -1065,19 +1062,8 @@ function randomClientOrderId(): PerpsClientOrderId {
 }
 
 function isOrderUpdateFor(clientOrderId: PerpsClientOrderId) {
-  return (
-    event: PerpsSessionEvent,
-    acknowledgements: PerpsPostOrderAck[] | undefined,
-  ): event is PerpsOrderUpdateEvent => {
-    if (event.type !== 'order') return false;
-
-    const entryAcknowledgement = acknowledgements?.[0];
-    return (
-      event.payload.clientOrderId === clientOrderId ||
-      (entryAcknowledgement?.status === 'ok' &&
-        event.payload.id === entryAcknowledgement.orderId)
-    );
-  };
+  return (event: PerpsSessionEvent): event is PerpsOrderUpdateEvent =>
+    event.type === 'order' && event.payload.clientOrderId === clientOrderId;
 }
 
 function placedOrderFrom(

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -7,13 +7,17 @@ import {
   PerpsCancelAllOrdersResponseSchema,
   type PerpsCancelOrderResult,
   PerpsCancelOrderResultSchema,
+  type PerpsClientOrderId,
   PerpsClientOrderIdSchema,
   PerpsCommandAckSchema,
   type PerpsDecimalInput,
   PerpsDecimalInputSchema,
   type PerpsInstrumentId,
   PerpsInstrumentIdSchema,
+  type PerpsOrder,
+  type PerpsOrderId,
   PerpsOrderIdSchema,
+  type PerpsPortfolio,
   type PerpsPostOrderAck,
   PerpsPostOrderAckSchema,
   PerpsTimeInForce,
@@ -22,7 +26,11 @@ import {
   type PerpsUpdateLeverageResult,
   PerpsUpdateLeverageResultSchema,
 } from '@polymarket/bindings/perps';
-import { expectPresent, invariant, unwrap } from '@polymarket/types';
+import type {
+  PerpsOrderUpdateEvent,
+  PerpsSessionEvent,
+} from '@polymarket/bindings/subscriptions';
+import { expectPresent, invariant } from '@polymarket/types';
 import { z } from 'zod';
 import {
   makeErrorGuard,
@@ -32,8 +40,6 @@ import {
   UserInputError,
 } from '../../../errors';
 import { parseUserInput } from '../../../input';
-import { validateWith } from '../../../response';
-import type { ServiceClient } from '../../../ServiceClient';
 import type { PerpsSignedOp } from '../signing';
 
 const PerpsOrderBaseInputSchema = z.object({
@@ -187,30 +193,46 @@ const PerpsTpSlPairSchema = z.union([
   }),
 ]) satisfies z.ZodType<PerpsTpSlPairRequest>;
 
-/**
- * @experimental This API may change in a breaking way in any release, including patch releases.
- */
-export type PerpsSignedWsCommandRequest<T> = {
+/** @internal */
+export type PerpsCommandRequest = {
   op: PerpsSignedOp;
-  responseSchema: z.ZodType<T>;
-  timeoutMessage: string;
   expiresAt?: number;
 };
 
-/**
- * @experimental This API may change in a breaking way in any release, including patch releases.
- */
-export type PerpsTradingTransport = {
-  sendSignedWsCommand<T>(request: PerpsSignedWsCommandRequest<T>): Promise<T>;
+/** @internal */
+export type PerpsCommandExecutor = {
+  /** @internal */
+  executeCommand<T>(
+    request: PerpsCommandRequest,
+    responseSchema: z.ZodType<T>,
+  ): Promise<T>;
 };
 
-/**
- * @experimental This API may change in a breaking way in any release, including patch releases.
- */
-export type SignPerpsRestCommand = (
-  op: PerpsSignedOp,
-  expiresAt?: number,
-) => Record<string, unknown>;
+/** @internal */
+export type PerpsEventCommandExecutor = PerpsCommandExecutor & {
+  /** @internal */
+  executeCommandWithEvent<TResponse, TEvent extends PerpsSessionEvent>(
+    request: PerpsCommandRequest,
+    responseSchema: z.ZodType<TResponse>,
+    predicate: (
+      event: PerpsSessionEvent,
+      response: TResponse | undefined,
+    ) => event is TEvent,
+  ): Promise<readonly [TResponse, TEvent]>;
+};
+
+/** @internal */
+export type PerpsRestCommandRequest<T> = PerpsCommandRequest & {
+  method: 'delete';
+  path: string;
+  responseSchema: z.ZodType<T>;
+};
+
+/** @internal */
+export type PerpsRestCommandExecutor = {
+  /** @internal */
+  executeRestCommand<T>(request: PerpsRestCommandRequest<T>): Promise<T>;
+};
 
 /**
  * Request parameters for posting one or more Perps orders.
@@ -233,16 +255,17 @@ const PostPerpsOrdersRequestSchema = z.object({
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
 export async function postPerpsOrders(
-  transport: PerpsTradingTransport,
+  client: PerpsCommandExecutor,
   request: PostPerpsOrdersRequest,
 ): Promise<PerpsPostOrderAck[]> {
   const params = parseUserInput(request, PostPerpsOrdersRequestSchema);
-  return await transport.sendSignedWsCommand({
-    op: ['createOrders', params.orders.map(toRawPerpsOrder)],
-    responseSchema: z.array(PerpsPostOrderAckSchema),
-    timeoutMessage: 'Perps post order acknowledgement timed out.',
-    expiresAt: params.expiresAt,
-  });
+  return await client.executeCommand(
+    {
+      op: ['createOrders', params.orders.map(toRawPerpsOrder)],
+      expiresAt: params.expiresAt,
+    },
+    z.array(PerpsPostOrderAckSchema),
+  );
 }
 
 const PlacePerpsOrderWithTpSlRequestSchema = z.intersection(
@@ -250,6 +273,7 @@ const PlacePerpsOrderWithTpSlRequestSchema = z.intersection(
   z.intersection(
     PerpsTpSlPairSchema,
     z.object({
+      clientOrderId: PerpsClientOrderIdSchema.default(randomClientOrderId),
       expiresAt: z.number().int().positive().optional(),
     }),
   ),
@@ -476,22 +500,112 @@ export type PlacePerpsOrderRequestWithOptions =
   | PlacePerpsOrderRequest
   | PlacePerpsOrderWithTpSlRequest;
 
+const PlacePerpsOrderRequestSchema = z.intersection(
+  PerpsOrderRequestSchema,
+  z.object({
+    clientOrderId: PerpsClientOrderIdSchema.default(randomClientOrderId),
+    expiresAt: z.number().int().positive().optional(),
+    takeProfit: z.never().optional(),
+    stopLoss: z.never().optional(),
+  }),
+) satisfies z.ZodType<PlacePerpsOrderRequest>;
+
+const SuccessfulPerpsPostOrderAcksSchema = z
+  .array(PerpsPostOrderAckSchema)
+  .min(1)
+  .refine(
+    (acknowledgements) =>
+      acknowledgements.every(
+        (acknowledgement) => acknowledgement.status === 'ok',
+      ),
+    'Expected successful Perps order acknowledgements.',
+  );
+
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
-export function hasPerpsTpSl(
+export type PerpsPlacedTpSlOrder = {
+  orderId: PerpsOrderId;
+};
+
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export type PerpsPlacedTpSlOrders = {
+  takeProfit?: PerpsPlacedTpSlOrder;
+  stopLoss?: PerpsPlacedTpSlOrder;
+};
+
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export type PlacePerpsOrderResult = {
+  order: PerpsOrder;
+};
+
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export type PlacePerpsOrderWithTpSlResult = PlacePerpsOrderResult & {
+  tpSl: PerpsPlacedTpSlOrders;
+};
+
+function hasPerpsTpSl(
   request: PlacePerpsOrderRequestWithOptions,
 ): request is PlacePerpsOrderWithTpSlRequest {
   return request.takeProfit !== undefined || request.stopLoss !== undefined;
 }
 
 /**
+ * Places one Perps order and resolves with the first matching orders update.
+ *
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
-export async function placePerpsOrderWithTpSl(
-  transport: PerpsTradingTransport,
+export async function placePerpsOrder(
+  client: PerpsEventCommandExecutor,
   request: PlacePerpsOrderWithTpSlRequest,
-): Promise<PerpsPostOrderAck[]> {
+): Promise<PlacePerpsOrderWithTpSlResult>;
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export async function placePerpsOrder(
+  client: PerpsEventCommandExecutor,
+  request: PlacePerpsOrderRequest,
+): Promise<PlacePerpsOrderResult>;
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export async function placePerpsOrder(
+  client: PerpsEventCommandExecutor,
+  request: PlacePerpsOrderRequestWithOptions,
+): Promise<PlacePerpsOrderResult | PlacePerpsOrderWithTpSlResult>;
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export async function placePerpsOrder(
+  client: PerpsEventCommandExecutor,
+  request: PlacePerpsOrderRequestWithOptions,
+): Promise<PlacePerpsOrderResult | PlacePerpsOrderWithTpSlResult> {
+  if (hasPerpsTpSl(request)) {
+    return await placePerpsOrderWithTpSl(client, request);
+  }
+
+  const params = parseUserInput(request, PlacePerpsOrderRequestSchema);
+  const [, update] = await client.executeCommandWithEvent(
+    {
+      op: ['createOrders', [toRawPerpsOrder(params)]],
+      expiresAt: params.expiresAt,
+    },
+    SuccessfulPerpsPostOrderAcksSchema,
+    isOrderUpdateFor(params.clientOrderId),
+  );
+  return { order: update.payload };
+}
+
+async function placePerpsOrderWithTpSl(
+  client: PerpsEventCommandExecutor,
+  request: PlacePerpsOrderWithTpSlRequest,
+): Promise<PlacePerpsOrderWithTpSlResult> {
   const params = parseUserInput(request, PlacePerpsOrderWithTpSlRequestSchema);
   const orders: RawPerpsOrderInput[] = [toRawPerpsOrder(params)];
   const exitBuy = params.side === OrderSide.SELL;
@@ -519,11 +633,35 @@ export async function placePerpsOrderWithTpSl(
     );
   }
 
-  return await placePerpsOrderGroup(transport, {
-    expiresAt: params.expiresAt,
-    group: PerpsTpSlScope.Order,
-    orders,
-  });
+  const [acknowledgements, update] = await client.executeCommandWithEvent(
+    {
+      op: ['createOrders', orders, PerpsTpSlScope.Order],
+      expiresAt: params.expiresAt,
+    },
+    SuccessfulPerpsPostOrderAcksSchema,
+    isOrderUpdateFor(params.clientOrderId),
+  );
+
+  let triggerIndex = 1;
+  const tpSl: PerpsPlacedTpSlOrders = {};
+  if (params.takeProfit !== undefined) {
+    tpSl.takeProfit = placedOrderFrom(
+      expectPresent(
+        acknowledgements[triggerIndex++],
+        'Expected Perps take-profit acknowledgement.',
+      ),
+    );
+  }
+  if (params.stopLoss !== undefined) {
+    tpSl.stopLoss = placedOrderFrom(
+      expectPresent(
+        acknowledgements[triggerIndex],
+        'Expected Perps stop-loss acknowledgement.',
+      ),
+    );
+  }
+
+  return { order: update.payload, tpSl };
 }
 
 /**
@@ -570,32 +708,35 @@ const PlacePerpsPositionTpSlRequestSchema = z.intersection(
   }),
 ) satisfies z.ZodType<PlacePerpsPositionTpSlRequest>;
 
-const PlacePerpsPositionTpSlCommandRequestSchema = z.intersection(
-  PlacePerpsPositionTpSlRequestSchema,
-  z.object({ buy: z.boolean() }),
-);
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export type PlacePerpsPositionTpSlResult = {
+  tpSl: PerpsPlacedTpSlOrders;
+};
 
-type PlacePerpsPositionTpSlCommandRequest = PlacePerpsPositionTpSlRequest & {
-  buy: boolean;
+type PerpsPortfolioReader = {
+  fetchPortfolio(): Promise<PerpsPortfolio>;
 };
 
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
 export async function placePerpsPositionTpSl(
-  transport: PerpsTradingTransport,
-  request: PlacePerpsPositionTpSlCommandRequest,
-): Promise<PerpsPostOrderAck[]> {
-  const params = parseUserInput(
-    request,
-    PlacePerpsPositionTpSlCommandRequestSchema,
+  client: PerpsCommandExecutor & PerpsPortfolioReader,
+  request: PlacePerpsPositionTpSlRequest,
+): Promise<PlacePerpsPositionTpSlResult> {
+  const params = parseUserInput(request, PlacePerpsPositionTpSlRequestSchema);
+  const buy = positionTpSlExitBuy(
+    await client.fetchPortfolio(),
+    params.instrumentId,
   );
   const orders: RawPerpsOrderInput[] = [];
 
   if (params.takeProfit !== undefined) {
     orders.push(
       toRawPerpsTpSlOrder({
-        buy: params.buy,
+        buy,
         instrumentId: params.instrumentId,
         kind: PerpsTpSlKind.TakeProfit,
         quantity: '0',
@@ -606,7 +747,7 @@ export async function placePerpsPositionTpSl(
   if (params.stopLoss !== undefined) {
     orders.push(
       toRawPerpsTpSlOrder({
-        buy: params.buy,
+        buy,
         instrumentId: params.instrumentId,
         kind: PerpsTpSlKind.StopLoss,
         quantity: '0',
@@ -615,11 +756,38 @@ export async function placePerpsPositionTpSl(
     );
   }
 
-  return await placePerpsOrderGroup(transport, {
+  const acknowledgements = await placePerpsOrderGroup(client, {
     expiresAt: params.expiresAt,
     group: PerpsTpSlScope.Position,
     orders,
   });
+
+  for (const acknowledgement of acknowledgements) {
+    if (acknowledgement.status === 'err') {
+      throw new RequestRejectedError(acknowledgement.error, { status: 200 });
+    }
+  }
+
+  let triggerIndex = 0;
+  const tpSl: PerpsPlacedTpSlOrders = {};
+  if (params.takeProfit !== undefined) {
+    tpSl.takeProfit = placedOrderFrom(
+      expectPresent(
+        acknowledgements[triggerIndex++],
+        'Expected Perps take-profit acknowledgement.',
+      ),
+    );
+  }
+  if (params.stopLoss !== undefined) {
+    tpSl.stopLoss = placedOrderFrom(
+      expectPresent(
+        acknowledgements[triggerIndex],
+        'Expected Perps stop-loss acknowledgement.',
+      ),
+    );
+  }
+
+  return { tpSl };
 }
 
 const CancelPerpsOrderRequestSchema = z.union([
@@ -658,17 +826,17 @@ export type CancelPerpsOrderRequest =
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
 export async function cancelPerpsOrder(
-  transport: PerpsTradingTransport,
+  client: PerpsCommandExecutor,
   request: CancelPerpsOrderRequest,
 ): Promise<PerpsCancelOrderResult> {
   const params = parseUserInput(request, CancelPerpsOrderRequestSchema);
   const [result] =
     params.orderId !== undefined
-      ? await cancelPerpsOrders(transport, {
+      ? await cancelPerpsOrders(client, {
           orderIds: [params.orderId],
           expiresAt: params.expiresAt,
         })
-      : await cancelPerpsOrders(transport, {
+      : await cancelPerpsOrders(client, {
           clientOrderIds: [params.clientOrderId],
           expiresAt: params.expiresAt,
         });
@@ -711,24 +879,26 @@ export type CancelPerpsOrdersRequest =
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
 export async function cancelPerpsOrders(
-  transport: PerpsTradingTransport,
+  client: PerpsCommandExecutor,
   request: CancelPerpsOrdersRequest,
 ): Promise<PerpsCancelOrderResult[]> {
   const params = parseUserInput(request, CancelPerpsOrdersRequestSchema);
   if (params.orderIds !== undefined) {
-    return await transport.sendSignedWsCommand({
-      op: ['cancelOrders', params.orderIds],
-      responseSchema: z.array(PerpsCancelOrderResultSchema),
-      timeoutMessage: 'Perps cancel order response timed out.',
-      expiresAt: params.expiresAt,
-    });
+    return await client.executeCommand(
+      {
+        op: ['cancelOrders', params.orderIds],
+        expiresAt: params.expiresAt,
+      },
+      z.array(PerpsCancelOrderResultSchema),
+    );
   }
-  return await transport.sendSignedWsCommand({
-    op: ['cancelOrdersCOID', params.clientOrderIds],
-    responseSchema: z.array(PerpsCancelOrderResultSchema),
-    timeoutMessage: 'Perps cancel order response timed out.',
-    expiresAt: params.expiresAt,
-  });
+  return await client.executeCommand(
+    {
+      op: ['cancelOrdersCOID', params.clientOrderIds],
+      expiresAt: params.expiresAt,
+    },
+    z.array(PerpsCancelOrderResultSchema),
+  );
 }
 
 const CancelAllPerpsOrdersRequestSchema = z
@@ -752,8 +922,7 @@ export type CancelAllPerpsOrdersRequest = {
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
 export async function cancelAllOrders(
-  client: ServiceClient,
-  signCommand: SignPerpsRestCommand,
+  client: PerpsRestCommandExecutor,
   request?: CancelAllPerpsOrdersRequest,
 ): Promise<void> {
   const params = parseUserInput(request, CancelAllPerpsOrdersRequestSchema);
@@ -761,18 +930,13 @@ export async function cancelAllOrders(
     'cancelAll',
     params.instrumentId === undefined ? [] : [params.instrumentId],
   ] as const satisfies PerpsSignedOp;
-  const command = signCommand(op, params.expiresAt);
-
-  await unwrap(
-    client
-      .del('/v1/trade/orders/all', {
-        json: {
-          ...command,
-          op: toPerpsCommandBodyOp(op),
-        },
-      })
-      .andThen(validateWith(PerpsCancelAllOrdersResponseSchema)),
-  );
+  await client.executeRestCommand({
+    method: 'delete',
+    path: '/v1/trade/orders/all',
+    op,
+    responseSchema: PerpsCancelAllOrdersResponseSchema,
+    expiresAt: params.expiresAt,
+  });
 }
 
 const UpdatePerpsLeverageRequestSchema = z.object({
@@ -820,18 +984,19 @@ export const UpdatePerpsLeverageError = makeErrorGuard(
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
 export async function updatePerpsLeverage(
-  transport: PerpsTradingTransport,
+  client: PerpsCommandExecutor,
   request: UpdatePerpsLeverageRequest,
 ): Promise<PerpsUpdateLeverageResult> {
   const params = parseUserInput(request, UpdatePerpsLeverageRequestSchema);
-  return await transport.sendSignedWsCommand({
-    op: [
-      'updateLeverage',
-      [params.instrumentId, params.leverage, params.crossMargin],
-    ],
-    responseSchema: PerpsUpdateLeverageResultSchema,
-    timeoutMessage: 'Perps update leverage response timed out.',
-  });
+  return await client.executeCommand(
+    {
+      op: [
+        'updateLeverage',
+        [params.instrumentId, params.leverage, params.crossMargin],
+      ],
+    },
+    PerpsUpdateLeverageResultSchema,
+  );
 }
 
 const UpdatePerpsMarginRequestSchema = z.object({
@@ -878,19 +1043,76 @@ export const UpdatePerpsMarginError = makeErrorGuard(
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
 export async function updatePerpsMargin(
-  transport: PerpsTradingTransport,
+  client: PerpsCommandExecutor,
   request: UpdatePerpsMarginRequest,
 ): Promise<void> {
   const params = parseUserInput(request, UpdatePerpsMarginRequestSchema);
   const amount = toDecimalString(params.amount);
-  const ack = await transport.sendSignedWsCommand({
-    op: ['updateMargin', [params.instrumentId, amount]],
-    responseSchema: PerpsCommandAckSchema,
-    timeoutMessage: 'Perps update margin acknowledgement timed out.',
-  });
+  const ack = await client.executeCommand(
+    { op: ['updateMargin', [params.instrumentId, amount]] },
+    PerpsCommandAckSchema,
+  );
   if (ack.status === 'err') {
     throw new RequestRejectedError(ack.error, { status: 200 });
   }
+}
+
+function randomClientOrderId(): PerpsClientOrderId {
+  const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16));
+  return PerpsClientOrderIdSchema.parse(
+    Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(''),
+  );
+}
+
+function isOrderUpdateFor(clientOrderId: PerpsClientOrderId) {
+  return (
+    event: PerpsSessionEvent,
+    acknowledgements: PerpsPostOrderAck[] | undefined,
+  ): event is PerpsOrderUpdateEvent => {
+    if (event.type !== 'order') return false;
+
+    const entryAcknowledgement = acknowledgements?.[0];
+    return (
+      event.payload.clientOrderId === clientOrderId ||
+      (entryAcknowledgement?.status === 'ok' &&
+        event.payload.id === entryAcknowledgement.orderId)
+    );
+  };
+}
+
+function placedOrderFrom(
+  acknowledgement: PerpsPostOrderAck,
+): PerpsPlacedTpSlOrder {
+  if (acknowledgement.status === 'err') {
+    throw new RequestRejectedError(acknowledgement.error, { status: 200 });
+  }
+
+  return { orderId: acknowledgement.orderId };
+}
+
+function positionTpSlExitBuy(
+  portfolio: PerpsPortfolio,
+  instrumentId: PerpsInstrumentId,
+): boolean {
+  const position = portfolio.positions.find(
+    (item) => item.instrumentId === instrumentId,
+  );
+  const sign = position === undefined ? 0 : decimalSign(position.size);
+
+  if (sign === 0) {
+    throw new UserInputError(
+      `No open Perps position for instrument ${instrumentId}.`,
+    );
+  }
+
+  return sign < 0;
+}
+
+function decimalSign(value: string): -1 | 0 | 1 {
+  const trimmed = value.trim();
+  const digits = trimmed.replace(/^[+-]/, '').replace('.', '');
+  if (/^0*$/.test(digits)) return 0;
+  return trimmed.startsWith('-') ? -1 : 1;
 }
 
 type RawPerpsOrderInput = readonly [
@@ -954,19 +1176,20 @@ function toRawPerpsTpSlOrder(request: {
 }
 
 async function placePerpsOrderGroup(
-  transport: PerpsTradingTransport,
+  client: PerpsCommandExecutor,
   request: {
     orders: RawPerpsOrderInput[];
     group: PerpsTpSlScope;
     expiresAt?: number;
   },
 ): Promise<PerpsPostOrderAck[]> {
-  return await transport.sendSignedWsCommand({
-    op: ['createOrders', request.orders, request.group],
-    responseSchema: z.array(PerpsPostOrderAckSchema),
-    timeoutMessage: 'Perps place TP/SL order acknowledgement timed out.',
-    expiresAt: request.expiresAt,
-  });
+  return await client.executeCommand(
+    {
+      op: ['createOrders', request.orders, request.group],
+      expiresAt: request.expiresAt,
+    },
+    z.array(PerpsPostOrderAckSchema),
+  );
 }
 
 /**

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -295,7 +295,7 @@ export type PlacePerpsOrderRequest =
       postOnly?: boolean;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;
@@ -316,7 +316,7 @@ export type PlacePerpsOrderRequest =
       postOnly?: never;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;
@@ -337,7 +337,7 @@ export type PlacePerpsOrderRequest =
       postOnly?: never;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;
@@ -364,7 +364,7 @@ export type PlacePerpsOrderWithTpSlRequest =
       postOnly?: boolean;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;
@@ -388,7 +388,7 @@ export type PlacePerpsOrderWithTpSlRequest =
       postOnly?: boolean;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;
@@ -411,7 +411,7 @@ export type PlacePerpsOrderWithTpSlRequest =
       postOnly?: never;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;
@@ -434,7 +434,7 @@ export type PlacePerpsOrderWithTpSlRequest =
       postOnly?: never;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;
@@ -457,7 +457,7 @@ export type PlacePerpsOrderWithTpSlRequest =
       postOnly?: never;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;
@@ -480,7 +480,7 @@ export type PlacePerpsOrderWithTpSlRequest =
       postOnly?: never;
       /** Whether the order may only reduce or close an existing position. */
       reduceOnly?: boolean;
-      /** Optional caller-supplied idempotency identifier. */
+      /** Optional caller-supplied idempotency identifier. Generated when omitted. */
       clientOrderId?: string;
       /** Optional command expiration timestamp in milliseconds. */
       expiresAt?: number;

--- a/packages/client/src/websockets/perps/actions/trading.ts
+++ b/packages/client/src/websockets/perps/actions/trading.ts
@@ -219,16 +219,15 @@ export type PerpsEventCommandExecutor = PerpsCommandExecutor & {
 };
 
 /** @internal */
-export type PerpsRestCommandRequest<T> = PerpsCommandRequest & {
-  method: 'delete';
+export type PerpsDeleteCommandRequest<T> = PerpsCommandRequest & {
   path: string;
   responseSchema: z.ZodType<T>;
 };
 
 /** @internal */
-export type PerpsRestCommandExecutor = {
+export type PerpsDeleteCommandExecutor = {
   /** @internal */
-  executeRestCommand<T>(request: PerpsRestCommandRequest<T>): Promise<T>;
+  executeDeleteCommand<T>(request: PerpsDeleteCommandRequest<T>): Promise<T>;
 };
 
 /**
@@ -919,7 +918,7 @@ export type CancelAllPerpsOrdersRequest = {
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
 export async function cancelAllOrders(
-  client: PerpsRestCommandExecutor,
+  client: PerpsDeleteCommandExecutor,
   request?: CancelAllPerpsOrdersRequest,
 ): Promise<void> {
   const params = parseUserInput(request, CancelAllPerpsOrdersRequestSchema);
@@ -927,8 +926,7 @@ export async function cancelAllOrders(
     'cancelAll',
     params.instrumentId === undefined ? [] : [params.instrumentId],
   ] as const satisfies PerpsSignedOp;
-  await client.executeRestCommand({
-    method: 'delete',
+  await client.executeDeleteCommand({
     path: '/v1/trade/orders/all',
     op,
     responseSchema: PerpsCancelAllOrdersResponseSchema,

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -358,37 +358,6 @@ describe('PerpsSession', () => {
       await session.close();
     });
 
-    it('falls back to the acknowledged order id when the update omits the client order id', async () => {
-      mockOrderPlacementSession({
-        includeClientOrderIdInUpdate: false,
-        status: 'open',
-      });
-      const session = createSession();
-      await session.connect();
-
-      try {
-        await expect(
-          session.placeOrder({
-            clientOrderId: '0123456789abcdef0123456789abcdef',
-            instrumentId: 1,
-            postOnly: false,
-            price: '100.00',
-            quantity: '1.5',
-            side: OrderSide.BUY,
-            timeInForce: PerpsTimeInForce.GTC,
-          }),
-        ).resolves.toMatchObject({
-          order: {
-            id: 123,
-            restingQuantity: '1.5',
-            status: 'open',
-          },
-        });
-      } finally {
-        await session.close();
-      }
-    });
-
     it('uses a matching private order update received before the acknowledgement', async () => {
       const frames = mockOrderPlacementSession({
         status: 'open',
@@ -1749,7 +1718,6 @@ function mockCommandSession(
 }
 
 function mockOrderPlacementSession(request: {
-  includeClientOrderIdInUpdate?: boolean;
   status: string;
   updateBeforeAck?: boolean;
 }): unknown[] {
@@ -1762,12 +1730,10 @@ function mockOrderPlacementSession(request: {
         frames.push(frame);
 
         if (frame.op?.type === 'createOrders') {
-          const update = orderUpdate(request.status, {
-            clientOrderId:
-              request.includeClientOrderIdInUpdate === false
-                ? undefined
-                : clientOrderIdFromFrame(frame),
-          });
+          const update = orderUpdate(
+            request.status,
+            clientOrderIdFromFrame(frame),
+          );
           if (request.updateBeforeAck) {
             client.send(JSON.stringify(update));
           }
@@ -1798,13 +1764,18 @@ function mockOrderPlacementSession(request: {
 
 function clientOrderIdFromFrame(frame: {
   op?: { args?: unknown; type?: string };
-}): string | undefined {
+}): string {
   const [order] = Array.isArray(frame.op?.args) ? frame.op.args : [];
-  if (typeof order !== 'object' || order === null || !('c' in order)) {
-    return undefined;
+  if (
+    typeof order !== 'object' ||
+    order === null ||
+    !('c' in order) ||
+    typeof order.c !== 'string'
+  ) {
+    throw new Error('Expected Perps command client order ID.');
   }
 
-  return typeof order.c === 'string' ? order.c : undefined;
+  return order.c;
 }
 
 function responseForFrame(frame: {
@@ -1938,12 +1909,12 @@ function fillsUpdate(request: { sequence: number; tradeIds: number[] }) {
   };
 }
 
-function orderUpdate(status: string, request: { clientOrderId?: string } = {}) {
+function orderUpdate(status: string, clientOrderId: string) {
   return {
     ch: 'orders',
     data: {
       buy: true,
-      coid: request.clientOrderId ?? '0123456789abcdef0123456789abcdef',
+      coid: clientOrderId,
       cts: 1_700_000_000_000,
       fill: status === 'filled' ? '1.5' : '0',
       iid: 1,

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -358,6 +358,73 @@ describe('PerpsSession', () => {
       await session.close();
     });
 
+    it('falls back to the acknowledged order id when the update omits the client order id', async () => {
+      mockOrderPlacementSession({
+        includeClientOrderIdInUpdate: false,
+        status: 'open',
+      });
+      const session = createSession();
+      await session.connect();
+
+      try {
+        await expect(
+          session.placeOrder({
+            clientOrderId: '0123456789abcdef0123456789abcdef',
+            instrumentId: 1,
+            postOnly: false,
+            price: '100.00',
+            quantity: '1.5',
+            side: OrderSide.BUY,
+            timeInForce: PerpsTimeInForce.GTC,
+          }),
+        ).resolves.toMatchObject({
+          order: {
+            id: 123,
+            restingQuantity: '1.5',
+            status: 'open',
+          },
+        });
+      } finally {
+        await session.close();
+      }
+    });
+
+    it('uses a matching private order update received before the acknowledgement', async () => {
+      const frames = mockOrderPlacementSession({
+        status: 'open',
+        updateBeforeAck: true,
+      });
+      const session = createSession();
+      await session.connect();
+
+      try {
+        await expect(
+          session.placeOrder({
+            instrumentId: 1,
+            postOnly: false,
+            price: '100.00',
+            quantity: '1.5',
+            side: OrderSide.BUY,
+            timeInForce: PerpsTimeInForce.GTC,
+          }),
+        ).resolves.toMatchObject({
+          order: {
+            clientOrderId: expect.stringMatching(/^[0-9a-f]{32}$/),
+            id: 123,
+            restingQuantity: '1.5',
+            status: 'open',
+          },
+        });
+        expect(frames[2]).toMatchObject({
+          op: {
+            args: [{ c: expect.stringMatching(/^[0-9a-f]{32}$/) }],
+          },
+        });
+      } finally {
+        await session.close();
+      }
+    });
+
     it('returns terminal placement updates after the ack', async () => {
       mockOrderPlacementSession({
         status: 'post_only_rejected',
@@ -553,7 +620,10 @@ describe('PerpsSession', () => {
     });
 
     it('places an order with take-profit and stop-loss triggers', async () => {
-      const frames = mockOrderPlacementSession({ status: 'open' });
+      const frames = mockOrderPlacementSession({
+        status: 'open',
+        updateBeforeAck: true,
+      });
       const session = createSession();
       await session.connect();
 
@@ -590,6 +660,7 @@ describe('PerpsSession', () => {
           args: [
             {
               buy: true,
+              c: expect.stringMatching(/^[0-9a-f]{32}$/),
               iid: 1,
               p: '100.00',
               po: false,
@@ -1677,7 +1748,11 @@ function mockCommandSession(
   return frames;
 }
 
-function mockOrderPlacementSession(request: { status: string }): unknown[] {
+function mockOrderPlacementSession(request: {
+  includeClientOrderIdInUpdate?: boolean;
+  status: string;
+  updateBeforeAck?: boolean;
+}): unknown[] {
   const frames: unknown[] = [];
 
   server.use(
@@ -1687,14 +1762,24 @@ function mockOrderPlacementSession(request: { status: string }): unknown[] {
         frames.push(frame);
 
         if (frame.op?.type === 'createOrders') {
-          const update = orderUpdate(request.status);
+          const update = orderUpdate(request.status, {
+            clientOrderId:
+              request.includeClientOrderIdInUpdate === false
+                ? undefined
+                : clientOrderIdFromFrame(frame),
+          });
+          if (request.updateBeforeAck) {
+            client.send(JSON.stringify(update));
+          }
           client.send(
             JSON.stringify({
               id: frame.id,
               data: responseForFrame(frame),
             }),
           );
-          setTimeout(() => client.send(JSON.stringify(update)), 0);
+          if (!request.updateBeforeAck) {
+            setTimeout(() => client.send(JSON.stringify(update)), 0);
+          }
           return;
         }
 
@@ -1709,6 +1794,17 @@ function mockOrderPlacementSession(request: { status: string }): unknown[] {
   );
 
   return frames;
+}
+
+function clientOrderIdFromFrame(frame: {
+  op?: { args?: unknown; type?: string };
+}): string | undefined {
+  const [order] = Array.isArray(frame.op?.args) ? frame.op.args : [];
+  if (typeof order !== 'object' || order === null || !('c' in order)) {
+    return undefined;
+  }
+
+  return typeof order.c === 'string' ? order.c : undefined;
 }
 
 function responseForFrame(frame: {
@@ -1842,12 +1938,12 @@ function fillsUpdate(request: { sequence: number; tradeIds: number[] }) {
   };
 }
 
-function orderUpdate(status: string) {
+function orderUpdate(status: string, request: { clientOrderId?: string } = {}) {
   return {
     ch: 'orders',
     data: {
       buy: true,
-      coid: '0123456789abcdef0123456789abcdef',
+      coid: request.clientOrderId ?? '0123456789abcdef0123456789abcdef',
       cts: 1_700_000_000_000,
       fill: status === 'filled' ? '1.5' : '0',
       iid: 1,

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -19,7 +19,12 @@ import {
   vi,
 } from 'vitest';
 import { production } from '../../environments';
-import { RequestRejectedError, UserInputError } from '../../errors';
+import {
+  RequestRejectedError,
+  TimeoutError,
+  TransportError,
+  UserInputError,
+} from '../../errors';
 import {
   captureConnection,
   expectDropsUnknownFrame,
@@ -389,6 +394,64 @@ describe('PerpsSession', () => {
             args: [{ c: expect.stringMatching(/^[0-9a-f]{32}$/) }],
           },
         });
+      } finally {
+        await session.close();
+      }
+    });
+
+    it('times out waiting for an order update after the acknowledgement', async () => {
+      const session = createSession();
+      await session.connect();
+      vi.useFakeTimers();
+
+      try {
+        const placement = session.placeOrder({
+          instrumentId: 1,
+          postOnly: false,
+          price: '100.00',
+          quantity: '1.5',
+          side: OrderSide.BUY,
+          timeInForce: PerpsTimeInForce.GTC,
+        });
+        const rejection =
+          expect(placement).rejects.toBeInstanceOf(TimeoutError);
+
+        await vi.advanceTimersByTimeAsync(2000);
+
+        await rejection;
+      } finally {
+        await session.close();
+      }
+    });
+
+    it('uses the command timeout while waiting for the acknowledgement', async () => {
+      server.resetHandlers();
+      mockCommandSession((frame) =>
+        frame.op?.type === 'createOrders'
+          ? NO_RESPONSE
+          : responseForFrame(frame),
+      );
+      const session = createSession();
+      await session.connect();
+      vi.useFakeTimers();
+
+      try {
+        const placement = session.placeOrder({
+          instrumentId: 1,
+          postOnly: false,
+          price: '100.00',
+          quantity: '1.5',
+          side: OrderSide.BUY,
+          timeInForce: PerpsTimeInForce.GTC,
+        });
+        const rejection = expect(placement).rejects.toMatchObject({
+          message: 'Perps command response timed out.',
+          name: TransportError.name,
+        });
+
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        await rejection;
       } finally {
         await session.close();
       }
@@ -1691,6 +1754,8 @@ function createSession(): PerpsSession {
   });
 }
 
+const NO_RESPONSE = Symbol('NO_RESPONSE');
+
 function mockCommandSession(
   responder: (frame: {
     op?: { args?: unknown; type?: string };
@@ -1704,10 +1769,12 @@ function mockCommandSession(
       client.addEventListener('message', (event) => {
         const frame = JSON.parse(String(event.data));
         frames.push(frame);
+        const response = responder(frame);
+        if (response === NO_RESPONSE) return;
         client.send(
           JSON.stringify({
             id: frame.id,
-            data: responder(frame),
+            data: response,
           }),
         );
       });

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -844,26 +844,16 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async executeCommandWithEvent<TResponse, TEvent extends PerpsSessionEvent>(
     request: PerpsCommandRequest,
     responseSchema: z.ZodType<TResponse>,
-    predicate: (
-      event: PerpsSessionEvent,
-      response: TResponse | undefined,
-    ) => event is TEvent,
+    predicate: (event: PerpsSessionEvent) => event is TEvent,
   ): Promise<readonly [TResponse, TEvent]> {
-    let response: TResponse | undefined;
-    const waiter = this.#createEventWaiter(
-      (event) => predicate(event, response),
-      COMMAND_TIMEOUT_MS,
-    );
+    const waiter = this.#createEventWaiter(predicate, COMMAND_TIMEOUT_MS);
 
     try {
-      const [commandResponse, event] = await Promise.all([
-        this.executeCommand(request, responseSchema).then((value) => {
-          response = value;
-          return value;
-        }),
+      const [response, event] = await Promise.all([
+        this.executeCommand(request, responseSchema),
         waiter.promise,
       ]);
-      return [commandResponse, event as TEvent];
+      return [response, event as TEvent];
     } finally {
       this.#removeEventWaiter(waiter);
     }

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -12,7 +12,6 @@ import {
   type PerpsEquityPoint,
   type PerpsNotificationEntry,
   type PerpsOrder,
-  type PerpsOrderId,
   type PerpsPnlPoint,
   type PerpsPortfolio,
   type PerpsPostOrderAck,
@@ -21,16 +20,10 @@ import {
 } from '@polymarket/bindings/perps';
 import {
   PerpsNotificationsResyncFrameSchema,
-  type PerpsOrderUpdateEvent,
   type PerpsSessionEvent,
   PerpsSessionUpdateEventSchema,
 } from '@polymarket/bindings/subscriptions';
-import {
-  expectNonEmptyArray,
-  expectPresent,
-  invariant,
-  setNonBlockingTimeout,
-} from '@polymarket/types';
+import { invariant, setNonBlockingTimeout, unwrap } from '@polymarket/types';
 import { type Pushable, pushable } from 'it-pushable';
 import { z } from 'zod';
 import {
@@ -40,9 +33,10 @@ import {
   TimeoutError,
   TransportError,
   type UnexpectedResponseError,
-  UserInputError,
+  type UserInputError,
 } from '../../errors';
 import type { Paginated } from '../../pagination';
+import { validateWith } from '../../response';
 import { ServiceClient } from '../../ServiceClient';
 import { PerpsWebSocketHeartbeat } from '../heartbeat';
 import { ReconnectScheduler, WebSocketConnection } from '../lifecycle';
@@ -81,15 +75,17 @@ import {
   cancelAllOrders,
   cancelPerpsOrder,
   cancelPerpsOrders,
-  hasPerpsTpSl,
-  type PerpsSignedWsCommandRequest,
-  type PerpsTradingTransport,
+  type PerpsCommandRequest,
+  type PerpsRestCommandRequest,
   type PlacePerpsOrderRequest,
   type PlacePerpsOrderRequestWithOptions,
+  type PlacePerpsOrderResult,
   type PlacePerpsOrderWithTpSlRequest,
+  type PlacePerpsOrderWithTpSlResult,
   type PlacePerpsPositionTpSlRequest,
+  type PlacePerpsPositionTpSlResult,
   type PostPerpsOrdersRequest,
-  placePerpsOrderWithTpSl,
+  placePerpsOrder,
   placePerpsPositionTpSl,
   postPerpsOrders,
   toPerpsCommandBodyOp,
@@ -101,9 +97,7 @@ import {
 import { type PerpsSignableValue, signPerpsOp } from './signing';
 
 const AUTH_TIMEOUT_MS = 30_000;
-const ACK_TIMEOUT_MS = 30_000;
-// Purposefully generous: backend order updates are expected in the ~100ms range.
-const ORDER_PLACEMENT_UPDATE_TIMEOUT_MS = 2000;
+const COMMAND_TIMEOUT_MS = 30_000;
 const PERPS_SESSION_CHANNELS = [
   'balances',
   'portfolio',
@@ -146,6 +140,7 @@ type PendingResponse = {
 };
 
 type EventWaiter = {
+  promise: Promise<PerpsSessionEvent>;
   predicate(event: PerpsSessionEvent): boolean;
   reject(error: Error): void;
   resolve(event: PerpsSessionEvent): void;
@@ -176,14 +171,19 @@ export type {
   CancelPerpsOrderRequest,
   CancelPerpsOrdersRequest,
   PerpsOrderRequest,
+  PerpsPlacedTpSlOrder,
+  PerpsPlacedTpSlOrders,
   PerpsPlaceFokOrderRequest,
   PerpsPlaceGtcOrderRequest,
   PerpsPlaceIocOrderRequest,
   PerpsPositionTpSlTrigger,
   PerpsTpSlTrigger,
   PlacePerpsOrderRequest,
+  PlacePerpsOrderResult,
   PlacePerpsOrderWithTpSlRequest,
+  PlacePerpsOrderWithTpSlResult,
   PlacePerpsPositionTpSlRequest,
+  PlacePerpsPositionTpSlResult,
   PostPerpsOrdersRequest,
   UpdatePerpsLeverageRequest,
   UpdatePerpsMarginRequest,
@@ -227,45 +227,10 @@ export type PerpsSessionTradingError =
   | RateLimitError
   | RequestRejectedError
   | SigningError
+  | TimeoutError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
-
-/**
- * @experimental This API may change in a breaking way in any release, including patch releases.
- */
-export type PerpsPlacedTpSlOrder = {
-  orderId: PerpsOrderId;
-};
-
-/**
- * @experimental This API may change in a breaking way in any release, including patch releases.
- */
-export type PerpsPlacedTpSlOrders = {
-  takeProfit?: PerpsPlacedTpSlOrder;
-  stopLoss?: PerpsPlacedTpSlOrder;
-};
-
-/**
- * @experimental This API may change in a breaking way in any release, including patch releases.
- */
-export type PlacePerpsOrderResult = {
-  order: PerpsOrder;
-};
-
-/**
- * @experimental This API may change in a breaking way in any release, including patch releases.
- */
-export type PlacePerpsOrderWithTpSlResult = PlacePerpsOrderResult & {
-  tpSl: PerpsPlacedTpSlOrders;
-};
-
-/**
- * @experimental This API may change in a breaking way in any release, including patch releases.
- */
-export type PlacePerpsPositionTpSlResult = {
-  tpSl: PerpsPlacedTpSlOrders;
-};
 
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.
@@ -642,25 +607,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async placeOrder(
     request: PlacePerpsOrderRequestWithOptions,
   ): Promise<PlacePerpsOrderResult | PlacePerpsOrderWithTpSlResult> {
-    if (hasPerpsTpSl(request)) {
-      return await this.#placeOrderWithTpSl(request);
-    }
-
-    const [acknowledgement] = await postPerpsOrders(this.#tradingTransport(), {
-      orders: [request],
-      expiresAt: request.expiresAt,
-    }).then(expectNonEmptyArray);
-
-    if (acknowledgement.status === 'err') {
-      throw new RequestRejectedError(acknowledgement.error, { status: 200 });
-    }
-
-    const update = await this.#waitForEvent(
-      (event): event is PerpsOrderUpdateEvent =>
-        event.type === 'order' && event.payload.id === acknowledgement.orderId,
-      ORDER_PLACEMENT_UPDATE_TIMEOUT_MS,
-    );
-    return { order: update.payload };
+    return await placePerpsOrder(this, request);
   }
 
   /**
@@ -677,51 +624,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async postOrders(
     request: PostPerpsOrdersRequest,
   ): Promise<PerpsPostOrderAck[]> {
-    return await postPerpsOrders(this.#tradingTransport(), request);
-  }
-
-  async #placeOrderWithTpSl(
-    request: PlacePerpsOrderWithTpSlRequest,
-  ): Promise<PlacePerpsOrderWithTpSlResult> {
-    const acknowledgements = await placePerpsOrderWithTpSl(
-      this.#tradingTransport(),
-      request,
-    ).then(expectNonEmptyArray);
-
-    for (const acknowledgement of acknowledgements) {
-      if (acknowledgement.status === 'err') {
-        throw new RequestRejectedError(acknowledgement.error, { status: 200 });
-      }
-    }
-
-    const [entryAcknowledgement] = acknowledgements;
-    const entryPlacement = placedOrderFrom(entryAcknowledgement);
-    const update = await this.#waitForEvent(
-      (event): event is PerpsOrderUpdateEvent =>
-        event.type === 'order' && event.payload.id === entryPlacement.orderId,
-      ORDER_PLACEMENT_UPDATE_TIMEOUT_MS,
-    );
-
-    let triggerIndex = 1;
-    const tpSl: PerpsPlacedTpSlOrders = {};
-    if (request.takeProfit !== undefined) {
-      tpSl.takeProfit = placedOrderFrom(
-        expectPresent(
-          acknowledgements[triggerIndex++],
-          'Expected Perps take-profit acknowledgement.',
-        ),
-      );
-    }
-    if (request.stopLoss !== undefined) {
-      tpSl.stopLoss = placedOrderFrom(
-        expectPresent(
-          acknowledgements[triggerIndex],
-          'Expected Perps stop-loss acknowledgement.',
-        ),
-      );
-    }
-
-    return { order: update.payload, tpSl };
+    return await postPerpsOrders(this, request);
   }
 
   /**
@@ -750,56 +653,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async placePositionTpSl(
     request: PlacePerpsPositionTpSlRequest,
   ): Promise<PlacePerpsPositionTpSlResult> {
-    const acknowledgements = await placePerpsPositionTpSl(
-      this.#tradingTransport(),
-      {
-        ...request,
-        buy: await this.#positionTpSlExitBuy(request.instrumentId),
-      },
-    ).then(expectNonEmptyArray);
-
-    for (const acknowledgement of acknowledgements) {
-      if (acknowledgement.status === 'err') {
-        throw new RequestRejectedError(acknowledgement.error, { status: 200 });
-      }
-    }
-
-    let triggerIndex = 0;
-    const tpSl: PerpsPlacedTpSlOrders = {};
-    if (request.takeProfit !== undefined) {
-      tpSl.takeProfit = placedOrderFrom(
-        expectPresent(
-          acknowledgements[triggerIndex++],
-          'Expected Perps take-profit acknowledgement.',
-        ),
-      );
-    }
-    if (request.stopLoss !== undefined) {
-      tpSl.stopLoss = placedOrderFrom(
-        expectPresent(
-          acknowledgements[triggerIndex],
-          'Expected Perps stop-loss acknowledgement.',
-        ),
-      );
-    }
-
-    return { tpSl };
-  }
-
-  async #positionTpSlExitBuy(instrumentId: number): Promise<boolean> {
-    const portfolio = await this.fetchPortfolio();
-    const position = portfolio.positions.find(
-      (item) => item.instrumentId === instrumentId,
-    );
-    const sign = position === undefined ? 0 : decimalSign(position.size);
-
-    if (sign === 0) {
-      throw new UserInputError(
-        `No open Perps position for instrument ${instrumentId}.`,
-      );
-    }
-
-    return sign < 0;
+    return await placePerpsPositionTpSl(this, request);
   }
 
   /**
@@ -816,7 +670,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async cancelOrder(
     request: CancelPerpsOrderRequest,
   ): Promise<PerpsCancelOrderResult> {
-    return await cancelPerpsOrder(this.#tradingTransport(), request);
+    return await cancelPerpsOrder(this, request);
   }
 
   /**
@@ -833,7 +687,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async cancelOrders(
     request: CancelPerpsOrdersRequest,
   ): Promise<PerpsCancelOrderResult[]> {
-    return await cancelPerpsOrders(this.#tradingTransport(), request);
+    return await cancelPerpsOrders(this, request);
   }
 
   /**
@@ -850,11 +704,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
    * @experimental This API may change in a breaking way in any release, including patch releases.
    */
   async cancelAllOrders(request?: CancelAllPerpsOrdersRequest): Promise<void> {
-    await cancelAllOrders(
-      this.#api,
-      (op, expiresAt) => this.#createSignedCommand(op, expiresAt),
-      request,
-    );
+    await cancelAllOrders(this, request);
   }
 
   /**
@@ -877,7 +727,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
   async updateLeverage(
     request: UpdatePerpsLeverageRequest,
   ): Promise<PerpsUpdateLeverageResult> {
-    return await updatePerpsLeverage(this.#tradingTransport(), request);
+    return await updatePerpsLeverage(this, request);
   }
 
   /**
@@ -900,7 +750,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
    * @experimental This API may change in a breaking way in any release, including patch releases.
    */
   async updateMargin(request: UpdatePerpsMarginRequest): Promise<void> {
-    await updatePerpsMargin(this.#tradingTransport(), request);
+    await updatePerpsMargin(this, request);
   }
 
   async #connect(emitResync: boolean): Promise<void> {
@@ -952,7 +802,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
         chs: PERPS_SESSION_CHANNELS,
       },
       PerpsSessionAckSchema,
-      ACK_TIMEOUT_MS,
+      COMMAND_TIMEOUT_MS,
       'Perps session subscription timed out.',
     );
   }
@@ -964,14 +814,13 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     };
   }
 
-  #tradingTransport(): PerpsTradingTransport {
-    return {
-      sendSignedWsCommand: (request) => this.#sendSignedWsCommand(request),
-    };
-  }
-
-  async #sendSignedWsCommand<T>(
-    request: PerpsSignedWsCommandRequest<T>,
+  /**
+   * @internal
+   * @experimental This API may change in a breaking way in any release, including patch releases.
+   */
+  async executeCommand<T>(
+    request: PerpsCommandRequest,
+    responseSchema: z.ZodType<T>,
   ): Promise<T> {
     const bodyOp = toPerpsCommandBodyOp(request.op);
     const command = this.#createSignedCommand(request.op, request.expiresAt);
@@ -982,9 +831,59 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
         op: bodyOp,
         req: 'post',
       },
-      request.responseSchema,
-      ACK_TIMEOUT_MS,
-      request.timeoutMessage,
+      responseSchema,
+      COMMAND_TIMEOUT_MS,
+      'Perps command response timed out.',
+    );
+  }
+
+  /**
+   * @internal
+   * @experimental This API may change in a breaking way in any release, including patch releases.
+   */
+  async executeCommandWithEvent<TResponse, TEvent extends PerpsSessionEvent>(
+    request: PerpsCommandRequest,
+    responseSchema: z.ZodType<TResponse>,
+    predicate: (
+      event: PerpsSessionEvent,
+      response: TResponse | undefined,
+    ) => event is TEvent,
+  ): Promise<readonly [TResponse, TEvent]> {
+    let response: TResponse | undefined;
+    const waiter = this.#createEventWaiter(
+      (event) => predicate(event, response),
+      COMMAND_TIMEOUT_MS,
+    );
+
+    try {
+      const [commandResponse, event] = await Promise.all([
+        this.executeCommand(request, responseSchema).then((value) => {
+          response = value;
+          return value;
+        }),
+        waiter.promise,
+      ]);
+      return [commandResponse, event as TEvent];
+    } finally {
+      this.#removeEventWaiter(waiter);
+    }
+  }
+
+  /**
+   * @internal
+   * @experimental This API may change in a breaking way in any release, including patch releases.
+   */
+  async executeRestCommand<T>(request: PerpsRestCommandRequest<T>): Promise<T> {
+    const command = this.#createSignedCommand(request.op, request.expiresAt);
+    return await unwrap(
+      this.#api
+        .del(request.path, {
+          json: {
+            ...command,
+            op: toPerpsCommandBodyOp(request.op),
+          },
+        })
+        .andThen(validateWith(request.responseSchema)),
     );
   }
 
@@ -1142,33 +1041,30 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     this.#queue.push(event);
   }
 
-  #waitForEvent<TEvent extends PerpsSessionEvent>(
-    predicate: (event: PerpsSessionEvent) => event is TEvent,
-    timeoutMs: number,
-  ): Promise<TEvent> {
-    return this.#createEventWaiter(predicate, timeoutMs).then(
-      (event) => event as TEvent,
-    );
-  }
-
   #createEventWaiter(
     predicate: (event: PerpsSessionEvent) => boolean,
     timeoutMs: number,
-  ): Promise<PerpsSessionEvent> {
-    let waiter!: EventWaiter;
-    const promise = new Promise<PerpsSessionEvent>((resolve, reject) => {
-      waiter = {
-        predicate,
-        reject,
-        resolve,
-        timeout: setNonBlockingTimeout(() => {
-          this.#removeEventWaiter(waiter);
-          reject(new TimeoutError('Perps event wait timed out.'));
-        }, timeoutMs),
-      };
-    });
+  ): EventWaiter {
+    let resolve!: (event: PerpsSessionEvent) => void;
+    let reject!: (error: Error) => void;
+    const promise = new Promise<PerpsSessionEvent>(
+      (resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+      },
+    );
+    const waiter: EventWaiter = {
+      promise,
+      predicate,
+      reject,
+      resolve,
+      timeout: setNonBlockingTimeout(() => {
+        this.#removeEventWaiter(waiter);
+        reject(new TimeoutError('Perps event wait timed out.'));
+      }, timeoutMs),
+    };
     this.#eventWaiters.add(waiter);
-    return promise;
+    return waiter;
   }
 
   #resolveEventWaiters(event: PerpsSessionEvent): void {
@@ -1209,11 +1105,19 @@ function createPendingResponse<T>(
 function isRejectedPerpsAck(
   value: unknown,
 ): value is Extract<PerpsCommandAck, { status: 'err' }> {
+  if (Array.isArray(value)) return false;
   return errorAckFrom(value) !== undefined;
 }
 
 function errorAckFrom(value: unknown): { error: string } | undefined {
-  if (Array.isArray(value) || typeof value !== 'object' || value === null) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const error = errorAckFrom(item);
+      if (error !== undefined) return error;
+    }
+    return undefined;
+  }
+  if (typeof value !== 'object' || value === null) {
     return undefined;
   }
 
@@ -1223,25 +1127,6 @@ function errorAckFrom(value: unknown): { error: string } | undefined {
   return {
     error: typeof ack.error === 'string' ? ack.error : 'Perps command failed.',
   };
-}
-
-function placedOrderFrom(
-  acknowledgement: PerpsPostOrderAck,
-): PerpsPlacedTpSlOrder {
-  if (acknowledgement.status === 'err') {
-    throw new RequestRejectedError(acknowledgement.error, { status: 200 });
-  }
-
-  return {
-    orderId: acknowledgement.orderId,
-  };
-}
-
-function decimalSign(value: string): -1 | 0 | 1 {
-  const trimmed = value.trim();
-  const digits = trimmed.replace(/^[+-]/, '').replace('.', '');
-  if (/^0*$/.test(digits)) return 0;
-  return trimmed.startsWith('-') ? -1 : 1;
 }
 
 function randomUint32(): number {

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -1200,6 +1200,7 @@ function createPendingResponse<T>(
 function isRejectedPerpsAck(
   value: unknown,
 ): value is Extract<PerpsCommandAck, { status: 'err' }> {
+  // Array schemas own per-item error policy; only schema failures recurse into them.
   if (Array.isArray(value)) return false;
   return errorAckFrom(value) !== undefined;
 }

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -98,6 +98,8 @@ import { type PerpsSignableValue, signPerpsOp } from './signing';
 
 const AUTH_TIMEOUT_MS = 30_000;
 const COMMAND_TIMEOUT_MS = 30_000;
+// Purposefully generous: backend order updates are expected in the ~100ms range.
+const ORDER_PLACEMENT_UPDATE_TIMEOUT_MS = 2000;
 const PERPS_SESSION_CHANNELS = [
   'balances',
   'portfolio',
@@ -144,7 +146,7 @@ type EventWaiter = {
   predicate(event: PerpsSessionEvent): boolean;
   reject(error: Error): void;
   resolve(event: PerpsSessionEvent): void;
-  timeout: ReturnType<typeof setNonBlockingTimeout>;
+  timeout?: ReturnType<typeof setNonBlockingTimeout>;
 };
 
 export type {
@@ -846,14 +848,24 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
     responseSchema: z.ZodType<TResponse>,
     predicate: (event: PerpsSessionEvent) => event is TEvent,
   ): Promise<readonly [TResponse, TEvent]> {
-    const waiter = this.#createEventWaiter(predicate, COMMAND_TIMEOUT_MS);
+    const waiter = this.#createEventWaiter(predicate);
+    const command = this.executeCommand(request, responseSchema);
+    // The waiter is already active; its deadline begins after acknowledgement.
+    void command.then(
+      () =>
+        this.#startEventWaiterTimeout(
+          waiter,
+          ORDER_PLACEMENT_UPDATE_TIMEOUT_MS,
+        ),
+      () => undefined,
+    );
 
     try {
-      const [response, event] = await Promise.all([
-        this.executeCommand(request, responseSchema),
+      const [commandResponse, event] = await Promise.all([
+        command,
         waiter.promise,
       ]);
-      return [response, event as TEvent];
+      return [commandResponse, event as TEvent];
     } finally {
       this.#removeEventWaiter(waiter);
     }
@@ -1033,7 +1045,6 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   #createEventWaiter(
     predicate: (event: PerpsSessionEvent) => boolean,
-    timeoutMs: number,
   ): EventWaiter {
     let resolve!: (event: PerpsSessionEvent) => void;
     let reject!: (error: Error) => void;
@@ -1048,13 +1059,17 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
       predicate,
       reject,
       resolve,
-      timeout: setNonBlockingTimeout(() => {
-        this.#removeEventWaiter(waiter);
-        reject(new TimeoutError('Perps event wait timed out.'));
-      }, timeoutMs),
     };
     this.#eventWaiters.add(waiter);
     return waiter;
+  }
+
+  #startEventWaiterTimeout(waiter: EventWaiter, timeoutMs: number): void {
+    if (!this.#eventWaiters.has(waiter)) return;
+    waiter.timeout = setNonBlockingTimeout(() => {
+      this.#removeEventWaiter(waiter);
+      waiter.reject(new TimeoutError('Perps event wait timed out.'));
+    }, timeoutMs);
   }
 
   #resolveEventWaiters(event: PerpsSessionEvent): void {
@@ -1068,7 +1083,7 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
 
   #removeEventWaiter(waiter: EventWaiter): void {
     if (!this.#eventWaiters.delete(waiter)) return;
-    clearTimeout(waiter.timeout);
+    if (waiter.timeout !== undefined) clearTimeout(waiter.timeout);
   }
 
   #rejectEventWaiters(error: Error): void {

--- a/packages/client/src/websockets/perps/session.ts
+++ b/packages/client/src/websockets/perps/session.ts
@@ -76,7 +76,7 @@ import {
   cancelPerpsOrder,
   cancelPerpsOrders,
   type PerpsCommandRequest,
-  type PerpsRestCommandRequest,
+  type PerpsDeleteCommandRequest,
   type PlacePerpsOrderRequest,
   type PlacePerpsOrderRequestWithOptions,
   type PlacePerpsOrderResult,
@@ -875,7 +875,9 @@ export class PerpsSession implements AsyncIterable<PerpsSessionEvent> {
    * @internal
    * @experimental This API may change in a breaking way in any release, including patch releases.
    */
-  async executeRestCommand<T>(request: PerpsRestCommandRequest<T>): Promise<T> {
+  async executeDeleteCommand<T>(
+    request: PerpsDeleteCommandRequest<T>,
+  ): Promise<T> {
     const command = this.#createSignedCommand(request.op, request.expiresAt);
     return await unwrap(
       this.#api


### PR DESCRIPTION
## Summary

- register the private order-update waiter before sending placement commands, using a generated or caller-provided client order ID for correlation
- move Perps trading workflows into action functions bound directly to the session and remove `PerpsTradingTransport`
- preserve low-level `postOrders` behavior and add normal, TP/SL, and rejection coverage

## Verification

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:client --run`

Not run: live metered Perps placement.

Linear: https://linear.app/polymarket/issue/DEV-398/fix-perps-placeorder-order-update-race

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes order-placement timing and correlation in experimental Perps trading; behavior is well-tested but affects a critical trading path.
> 
> **Overview**
> Fixes a race where **`placeOrder`** could miss private order updates that arrive before the WebSocket command acknowledgement.
> 
> **`placeOrder`** now auto-generates a **client order ID** when omitted and correlates the first matching private order update by that ID (not server `orderId` after ack). **`PerpsSession`** registers the event waiter **before** sending the command via **`executeCommandWithEvent`**; the post-ack update window starts only after a successful ack. **`TimeoutError`** is part of the documented trading error surface.
> 
> Perps trading workflows move into **`trading` actions** bound to the session (**`executeCommand`**, **`executeDeleteCommand`**). **`PerpsTradingTransport`** / **`sendSignedWsCommand`** are removed. Low-level **`postOrders`** is unchanged. **`placePositionTpSl`** infers exit side from **`fetchPortfolio`** inside the action. **`AGENTS.md`** documents the client-order-ID echo invariant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7927fba63b976aecaff216fdee6c09db281ad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->