### PR TITLE
fix(ci): prevent release and canary publish race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
   changesets:
     name: Changesets
     runs-on: ubuntu-latest
+    outputs:
+      has_changesets: ${{ steps.release.outputs.hasChangesets }}
+      published: ${{ steps.release.outputs.published }}
     needs:
       - verify
       - test
@@ -47,6 +50,7 @@ jobs:
         uses: ./.github/actions/setup
 
       - name: Create Or Update Release PR
+        id: release
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: pnpm version:bump
@@ -61,11 +65,8 @@ jobs:
     name: Publish Canary
     runs-on: ubuntu-latest
     needs:
-      - verify
-      - test
-      # Temporarily do not block canary publishing while we solve the integration test runner issue.
-      # - integration-tests
-    if: "${{ !contains(github.event.head_commit.message, 'chore: bumps package versions') }}"
+      - changesets
+    if: "${{ needs.changesets.outputs.has_changesets == 'true' && needs.changesets.outputs.published != 'true' }}"
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## Summary

- expose the Changesets action publish and changeset-state outputs
- make canary publication wait for the Changesets decision
- publish a canary only when unreleased changesets exist and no stable release was published

## Why

The release PR merge commit bypassed the commit-message check. With the changesets already consumed, snapshot versioning left the stable version unchanged and the canary job published it under the `canary` tag before the stable publisher completed.

## Validation

- `actionlint .github/workflows/release.yml`
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation ordering and publish conditions; misconfigured outputs could skip needed canaries or still allow duplicate publishes, but scope is limited to CI workflow logic.
> 
> **Overview**
> Fixes a **release vs canary race** on `main` by wiring the Changesets action’s **`hasChangesets`** and **`published`** outputs through the `changesets` job and gating canary on that decision instead of a commit-message skip.
> 
> The **Publish Canary** job now **depends only on `changesets`** (not parallel `verify`/`test`) and runs **only when** there are unreleased changesets and Changesets **did not** just publish a stable release—so a release-PR merge no longer publishes a snapshot under the `canary` tag with an unchanged stable version while the real release is still in flight.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec20cd45a6c52ef5344e0a841473e18fb9254a65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->