### PR TITLE
feat(bindings): add id to perps funding payment records

### DIFF
--- a/.changeset/dev-451-funding-payment-id.md
+++ b/.changeset/dev-451-funding-payment-id.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/bindings": patch
+---
+
+Add a required `id` on Perps account funding payment records, matching the unique funding-record id the platform now returns on funding history and the realtime funding stream. The id is exposed as the branded `PerpsFundingPaymentId` type.

--- a/packages/bindings/src/perps/account.ts
+++ b/packages/bindings/src/perps/account.ts
@@ -8,6 +8,7 @@ import {
   PerpsAssetSchema,
   PerpsDataResponseSchema,
   PerpsEntityIdSchema,
+  PerpsFundingPaymentIdSchema,
   PerpsInstrumentIdSchema,
 } from './common';
 
@@ -168,6 +169,7 @@ export const FetchPerpsPortfolioResponseSchema = PerpsPortfolioSchema;
  */
 export const PerpsAccountFundingPaymentSchema = z
   .object({
+    id: PerpsFundingPaymentIdSchema,
     instrument_id: PerpsInstrumentIdSchema,
     size: DecimalStringSchema,
     funding_rate: DecimalStringSchema,
@@ -176,6 +178,7 @@ export const PerpsAccountFundingPaymentSchema = z
     timestamp: EpochMillisecondsSchema,
   })
   .transform((funding) => ({
+    id: funding.id,
     instrumentId: funding.instrument_id,
     size: funding.size,
     fundingRate: funding.funding_rate,
@@ -203,6 +206,7 @@ export const ListPerpsFundingPaymentsResponseSchema = PerpsDataResponseSchema(
  */
 export const PerpsAccountFundingPaymentEntrySchema = z
   .object({
+    id: PerpsFundingPaymentIdSchema,
     iid: PerpsInstrumentIdSchema,
     sz: DecimalStringSchema,
     fr: DecimalStringSchema,
@@ -211,6 +215,7 @@ export const PerpsAccountFundingPaymentEntrySchema = z
     ts: EpochMillisecondsSchema,
   })
   .transform((funding) => ({
+    id: funding.id,
     instrumentId: funding.iid,
     size: funding.sz,
     fundingRate: funding.fr,

--- a/packages/bindings/src/perps/common.ts
+++ b/packages/bindings/src/perps/common.ts
@@ -36,6 +36,10 @@ export type PerpsTradeId = Tagged<number, 'PerpsTradeId'>;
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.
  */
+export type PerpsFundingPaymentId = Tagged<number, 'PerpsFundingPaymentId'>;
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
 export type PerpsWithdrawalId = Tagged<number, 'PerpsWithdrawalId'>;
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.
@@ -95,6 +99,15 @@ export const PerpsTradeIdSchema = z
   .int()
   .nonnegative()
   .transform(taggedInteger<PerpsTradeId>);
+
+/**
+ * @experimental This API may change in a breaking way in any release, including patch releases.
+ */
+export const PerpsFundingPaymentIdSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .transform(taggedInteger<PerpsFundingPaymentId>);
 
 /**
  * @experimental This API may change in a breaking way in any release, including patch releases.

--- a/packages/client/src/websockets/perps/session.test.ts
+++ b/packages/client/src/websockets/perps/session.test.ts
@@ -191,6 +191,31 @@ describe('PerpsSession', () => {
 
       await session.close();
     });
+
+    it('emits a funding event with the funding payment id', async () => {
+      const connection = captureConnection(server, perps);
+      const session = createSession();
+
+      await session.connect();
+
+      await connection.send(fundingUpdate({ id: 3_055_723_280_187_747 }));
+
+      await expect(waitForNextEvent(session)).resolves.toMatchObject({
+        done: false,
+        value: {
+          channel: 'funding',
+          payload: {
+            funding: '0.5',
+            id: 3_055_723_280_187_747,
+            instrumentId: 1,
+          },
+          sequence: 1,
+          type: 'funding',
+        },
+      });
+
+      await session.close();
+    });
   });
 
   describe('reconnects', () => {
@@ -1454,15 +1479,18 @@ describe('PerpsSession', () => {
       const session = createSession();
 
       const pages: string[][] = [];
+      const ids: number[] = [];
       for await (const page of session.listFundingPayments({
         end: 3000,
         start: 0,
       })) {
         pages.push(page.items.map((payment) => payment.funding));
+        ids.push(...page.items.map((payment) => payment.id));
         if (pages.length > MAX_EXPECTED_PAGES) break;
       }
 
       expect(pages.flat()).toEqual(['1', '2', '3']);
+      expect(ids).toEqual([1, 2, 3]);
       expect(requests.map((params) => params.get('end_timestamp'))).toEqual([
         '3000',
         '2000',
@@ -1842,6 +1870,23 @@ function fillsUpdate(request: { sequence: number; tradeIds: number[] }) {
   };
 }
 
+function fundingUpdate(request: { id: number }) {
+  return {
+    ch: 'funding',
+    data: {
+      fr: '0.0001',
+      fua: 'USDC',
+      fund: '0.5',
+      id: request.id,
+      iid: 1,
+      sz: '10.00',
+      ts: 1_700_000_000_000,
+    },
+    sq: 1,
+    ts: 1_700_000_000_000,
+  };
+}
+
 function orderUpdate(status: string) {
   return {
     ch: 'orders',
@@ -1927,6 +1972,7 @@ function fundingPayment(funding: string, timestamp: number) {
     funding,
     funding_asset: 'USDC',
     funding_rate: '0.0001',
+    id: Number(funding),
     instrument_id: 1,
     size: '1',
     timestamp,


### PR DESCRIPTION
Add a required `id` (branded `PerpsFundingPaymentId`) to the funding payment schemas for REST `/v1/account/funding` and the WS `funding` channel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Required new field on experimental perps bindings can break consumers or parsing if the platform omits `id`; scope is limited to schema and test updates.
> 
> **Overview**
> Perps funding payment payloads now require a platform-issued **`id`**, exposed as the branded **`PerpsFundingPaymentId`** type with a matching Zod schema in `@polymarket/bindings`.
> 
> REST funding history (`PerpsAccountFundingPaymentSchema`) and the compact WS funding entry shape (`PerpsAccountFundingPaymentEntrySchema`) both parse and surface **`id`** on the transformed objects. Client tests assert the WS **`funding`** channel forwards **`id`** and that **`listFundingPayments`** pagination returns ids from mocked REST responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38febcc3d908a3923a4b577a594b0caa264f5f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->