### PR TITLE
feat(client): support multi-status combo position filters

### DIFF
--- a/.changeset/dev-441-combo-multi-status.md
+++ b/.changeset/dev-441-combo-multi-status.md
@@ -1,5 +1,5 @@
 ---
-"@polymarket/client": patch
+"@polymarket/client": minor
 ---
 
 Support filtering combo positions by one or multiple statuses.

--- a/.changeset/dev-441-combo-multi-status.md
+++ b/.changeset/dev-441-combo-multi-status.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Support filtering combo positions by one or multiple statuses.

--- a/packages/client/src/actions/portfolio.test-d.ts
+++ b/packages/client/src/actions/portfolio.test-d.ts
@@ -1,0 +1,44 @@
+import { ComboPositionStatus } from '@polymarket/bindings/data';
+import { describe, it } from 'vitest';
+import type { PublicClient } from '../clients';
+import type { ListComboPositionsRequest } from './portfolio';
+
+const user = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
+
+describe('combo position status filter types', () => {
+  const publicClient = undefined as unknown as PublicClient;
+
+  it('accepts a scalar or readonly non-empty status array', () => {
+    const statuses = [
+      ComboPositionStatus.ResolvedWin,
+      ComboPositionStatus.ResolvedPartial,
+    ] as const;
+    const scalarRequest = {
+      user,
+      status: ComboPositionStatus.Open,
+    } satisfies ListComboPositionsRequest;
+    const multiRequest = {
+      user,
+      status: statuses,
+    } satisfies ListComboPositionsRequest;
+
+    publicClient.listComboPositions(scalarRequest);
+    publicClient.listComboPositions(multiRequest);
+  });
+
+  it('rejects raw comma strings and empty arrays', () => {
+    const commaSeparatedRequest = {
+      user,
+      // @ts-expect-error Pass multiple statuses as a non-empty array.
+      status: `${ComboPositionStatus.Open},${ComboPositionStatus.Partial}`,
+    } satisfies ListComboPositionsRequest;
+    const emptyRequest = {
+      user,
+      // @ts-expect-error Status arrays must be non-empty.
+      status: [] as const,
+    } satisfies ListComboPositionsRequest;
+
+    void commaSeparatedRequest;
+    void emptyRequest;
+  });
+});

--- a/packages/client/src/actions/portfolio.test-d.ts
+++ b/packages/client/src/actions/portfolio.test-d.ts
@@ -1,13 +1,10 @@
 import { ComboPositionStatus } from '@polymarket/bindings/data';
 import { describe, it } from 'vitest';
-import type { PublicClient } from '../clients';
 import type { ListComboPositionsRequest } from './portfolio';
 
 const user = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
 
 describe('combo position status filter types', () => {
-  const publicClient = undefined as unknown as PublicClient;
-
   it('accepts a scalar or readonly non-empty status array', () => {
     const statuses = [
       ComboPositionStatus.ResolvedWin,
@@ -22,8 +19,8 @@ describe('combo position status filter types', () => {
       status: statuses,
     } satisfies ListComboPositionsRequest;
 
-    publicClient.listComboPositions(scalarRequest);
-    publicClient.listComboPositions(multiRequest);
+    void scalarRequest;
+    void multiRequest;
   });
 
   it('rejects raw comma strings and empty arrays', () => {

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -5,6 +5,7 @@ import {
 import {
   type ClosedPosition,
   type ComboPosition,
+  type ComboPositionStatus,
   ComboPositionStatusSchema,
   FetchPortfolioValueResponseSchema,
   ListClosedPositionsResponseSchema,
@@ -302,20 +303,36 @@ const ComboConditionIdFilterSchema = z.union([
   z.array(ComboConditionIdSchema),
 ]);
 
+/**
+ * One status or a non-empty ordered list of statuses for filtering combo positions.
+ * Pass multiple statuses as an array rather than a comma-separated string.
+ */
+export type ComboPositionStatusFilter =
+  | ComboPositionStatus
+  | readonly [ComboPositionStatus, ...ComboPositionStatus[]];
+
+const ComboPositionStatusFilterSchema = z.union([
+  ComboPositionStatusSchema,
+  z.tuple([ComboPositionStatusSchema], ComboPositionStatusSchema),
+]) satisfies z.ZodType<ComboPositionStatusFilter>;
+
 const ListComboPositionsRequestSchema = z.object({
   cursor: PaginationCursorSchema.optional(),
   user: z.string(),
   pageSize: PageSizeSchema.default(20),
-  status: ComboPositionStatusSchema.optional(),
+  status: ComboPositionStatusFilterSchema.optional(),
   sort: ComboPositionSortSchema.optional(),
   conditionId: ComboConditionIdFilterSchema.optional(),
   updatedAfter: z.number().int().min(0).optional(),
   updatedBefore: z.number().int().min(0).optional(),
 });
 
-export type ListComboPositionsRequest = z.input<
-  typeof ListComboPositionsRequestSchema
->;
+export type ListComboPositionsRequest = Omit<
+  z.input<typeof ListComboPositionsRequestSchema>,
+  'status'
+> & {
+  status?: ComboPositionStatusFilter;
+};
 
 export type ListComboPositionsError =
   | RateLimitError
@@ -366,6 +383,20 @@ export const ListComboPositionsError = makeErrorGuard(
  * ```
  *
  * @example
+ * Filter to any of several resolved statuses. Pass multiple statuses as an
+ * array rather than a comma-separated string:
+ * ```ts
+ * const result = listComboPositions(client, {
+ *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+ *   status: [
+ *     ComboPositionStatus.ResolvedWin,
+ *     ComboPositionStatus.ResolvedPartial,
+ *     ComboPositionStatus.ResolvedLoss,
+ *   ],
+ * });
+ * ```
+ *
+ * @example
  * Incrementally sync changed combo positions:
  * ```ts
  * const result = listComboPositions(client, {
@@ -380,7 +411,7 @@ export function listComboPositions(
   client: BaseClient,
   request: ListComboPositionsRequest,
 ): Paginated<ComboPosition[]> {
-  const { cursor, pageSize, conditionId, ...params } = parseUserInput(
+  const { cursor, pageSize, conditionId, status, ...params } = parseUserInput(
     request,
     ListComboPositionsRequestSchema,
   );
@@ -399,6 +430,7 @@ export function listComboPositions(
     );
 
     appendConditionId(searchParams, conditionId);
+    appendStatus(searchParams, status);
 
     return client.data
       .get('/v1/positions/combos', {
@@ -428,6 +460,20 @@ function appendConditionId(
   searchParams.append(
     'market_id',
     Array.isArray(conditionId) ? conditionId.join(',') : conditionId,
+  );
+}
+
+function appendStatus(
+  searchParams: URLSearchParams,
+  status: z.output<typeof ComboPositionStatusFilterSchema> | undefined,
+): void {
+  if (status === undefined) {
+    return;
+  }
+
+  searchParams.append(
+    'status',
+    typeof status === 'string' ? status : status.join(','),
   );
 }
 

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -207,6 +207,19 @@ export type PublicAccountActions = Prettify<
      *
      * const firstPage = await paginator.firstPage();
      * ```
+     *
+     * @example
+     * Filter to any of several resolved statuses:
+     * ```ts
+     * const paginator = client.listComboPositions({
+     *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+     *   status: [
+     *     ComboPositionStatus.ResolvedWin,
+     *     ComboPositionStatus.ResolvedPartial,
+     *     ComboPositionStatus.ResolvedLoss,
+     *   ],
+     * });
+     * ```
      */
     listComboPositions(
       request: ListComboPositionsRequest,
@@ -357,6 +370,17 @@ export type SecureAccountActions = Prettify<
      *
      * @throws {@link ListComboPositionsError}
      * Thrown on failure.
+     *
+     * @example
+     * Filter the authenticated account's positions to multiple statuses:
+     * ```ts
+     * const paginator = client.listComboPositions({
+     *   status: [
+     *     ComboPositionStatus.ResolvedWin,
+     *     ComboPositionStatus.ResolvedPartial,
+     *   ],
+     * });
+     * ```
      */
     listComboPositions(
       request?: SecureListComboPositionsRequest,
@@ -573,6 +597,7 @@ export {
   ListPositionsError,
 } from '../actions';
 export { ComboActivityType } from '../actions/activity';
+export type { ComboPositionStatusFilter } from '../actions/portfolio';
 export {
   ComboPositionOutcome,
   ComboPositionSort,

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -1,15 +1,21 @@
 import {
   ComboPositionOutcome,
   ComboPositionSort,
+  ComboPositionStatus,
   UserInputError,
 } from '@polymarket/client';
-import { isSameEvmAddress } from '@polymarket/types';
+import { expectPresent, isSameEvmAddress } from '@polymarket/types';
+import { afterEach, type MockInstance, vi } from 'vitest';
 import { describe, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
 
 describe('Portfolio', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('listPositions', () => {
     it('lists positions for a wallet', async ({ publicClient }) => {
       const paginator = publicClient.listPositions({
@@ -123,6 +129,89 @@ describe('Portfolio', () => {
 
       expect(filtered.items[0].conditionId).toBe(result.items[0].conditionId);
     });
+
+    it('filters by one status', async ({ publicClient }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      const result = await publicClient
+        .listComboPositions({
+          user: TEST_USER,
+          pageSize: 10,
+          status: ComboPositionStatus.ResolvedWin,
+        })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      for (const position of result.items) {
+        expect(position.status).toBe(ComboPositionStatus.ResolvedWin);
+      }
+
+      const requests = comboPositionRequests(fetchSpy);
+      expect(requests).toHaveLength(1);
+      expect(expectPresent(requests[0]).getAll('status')).toEqual([
+        ComboPositionStatus.ResolvedWin,
+      ]);
+    });
+
+    it('serializes multiple statuses once and retains them across pages', async ({
+      publicClient,
+    }) => {
+      const statuses = [
+        ComboPositionStatus.ResolvedWin,
+        ComboPositionStatus.ResolvedPartial,
+        ComboPositionStatus.ResolvedLoss,
+      ] as const;
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      const paginator = publicClient.listComboPositions({
+        user: TEST_USER,
+        pageSize: 1,
+        status: statuses,
+      });
+      const firstPage = await paginator.firstPage().then(expectNonEmptyPage);
+      const secondPage = await paginator
+        .from(firstPage.nextCursor)
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      for (const position of [...firstPage.items, ...secondPage.items]) {
+        expect(statuses).toContain(position.status);
+      }
+
+      const requests = comboPositionRequests(fetchSpy);
+      expect(requests).toHaveLength(2);
+
+      for (const request of requests) {
+        expect(request.getAll('status')).toEqual([statuses.join(',')]);
+      }
+
+      expect(expectPresent(requests[0]).get('cursor')).toBeNull();
+      expect(expectPresent(requests[1]).get('cursor')).toBe(
+        firstPage.nextCursor,
+      );
+    });
+
+    it('rejects invalid status filters before transport', ({
+      publicClient,
+    }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const invalidStatuses = [
+        `${ComboPositionStatus.Open},${ComboPositionStatus.Partial}`,
+        [],
+        [ComboPositionStatus.Open, 'UNKNOWN'],
+      ];
+
+      for (const status of invalidStatuses) {
+        expect(() =>
+          publicClient.listComboPositions({
+            user: TEST_USER,
+            status: status as never,
+          }),
+        ).toThrow(UserInputError);
+      }
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('fetchPortfolioValue', () => {
@@ -205,3 +294,12 @@ describe('Portfolio', () => {
     });
   });
 });
+
+function comboPositionRequests(
+  fetchSpy: MockInstance<typeof fetch>,
+): URLSearchParams[] {
+  return fetchSpy.mock.calls
+    .map(([input]) => (input instanceof Request ? input.url : String(input)))
+    .filter((url) => new URL(url).pathname === '/v1/positions/combos')
+    .map((url) => new URL(url).searchParams);
+}


### PR DESCRIPTION
[DEV-441](https://linear.app/polymarket/issue/DEV-441/combo-multi-status-filtering-in-ts-sdk)/[DEV-429](https://linear.app/polymarket/issue/DEV-429/support-multi-status-filtering-on-combo-positions-in-ts-and-python): Supports multi-status combo position filters in TypeScript.

Tests: lint, typecheck, build, unit PASS; public live PASS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> SDK request-shape change only: existing single-status usage stays valid; invalid filters fail client-side before transport.
> 
> **Overview**
> `listComboPositions` can now filter by **one or more** `ComboPositionStatus` values. Callers pass a scalar or a non-empty array; the client joins arrays into a single `status` query param (not a comma string in the request object).
> 
> Empty arrays, comma-separated strings, and unknown statuses are rejected as `UserInputError` before fetch. Pagination keeps the same serialized filter on later pages. `ComboPositionStatusFilter` is exported from the client package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11f5197a564e071fe434779e36e0968197ddfee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->