### PR TITLE
fix(sdk): align PolyV2 identifier APIs

### DIFF
--- a/.changeset/dev-544-condition-id-runtime-cleanup.md
+++ b/.changeset/dev-544-condition-id-runtime-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/bindings': patch
+---
+
+Remove unused CTF-specific runtime condition ID aliases in favor of the protocol-neutral condition ID APIs. The deprecated `CtfConditionId` type alias remains available for source compatibility.

--- a/packages/bindings/src/shared.test.ts
+++ b/packages/bindings/src/shared.test.ts
@@ -4,15 +4,10 @@ import {
   type ConditionId,
   ConditionIdSchema,
   type CtfConditionId,
-  CtfConditionIdSchema,
   EvmAddressSchema,
-  OptionalConditionIdSchema,
-  OptionalCtfConditionIdSchema,
   QuestionIdSchema,
   TxHashSchema,
   toComboConditionId,
-  toConditionId,
-  toCtfConditionId,
 } from './shared';
 
 const CANONICAL_COMBO_CONDITION_ID =
@@ -49,12 +44,6 @@ describe('shared ID parsers', () => {
 
     it('keeps CtfConditionId as an exact compatibility alias', () => {
       expectTypeOf<ConditionId>().toEqualTypeOf<CtfConditionId>();
-    });
-
-    it('keeps deprecated CTF runtime exports as compatibility aliases', () => {
-      expect(CtfConditionIdSchema).toBe(ConditionIdSchema);
-      expect(OptionalCtfConditionIdSchema).toBe(OptionalConditionIdSchema);
-      expect(toCtfConditionId).toBe(toConditionId);
     });
   });
 

--- a/packages/bindings/src/shared.ts
+++ b/packages/bindings/src/shared.ts
@@ -149,9 +149,6 @@ export function toConditionId(value: string): ConditionId {
   return value as ConditionId;
 }
 
-/** @deprecated Use {@link toConditionId}. */
-export const toCtfConditionId = toConditionId;
-
 function normalizeComboConditionId(value: string): string | undefined {
   if (!isHexString(value)) {
     return undefined;
@@ -329,14 +326,6 @@ export const ConditionIdSchema = z
     'Expected a 31-byte or 32-byte hex string',
   )
   .transform((value) => value as ConditionId);
-/** @deprecated Use {@link ConditionIdSchema}. */
-export const CtfConditionIdSchema = ConditionIdSchema;
-export const OptionalConditionIdSchema = z.preprocess(
-  (value) => (value === '' ? undefined : value),
-  ConditionIdSchema.optional(),
-);
-/** @deprecated Use {@link OptionalConditionIdSchema}. */
-export const OptionalCtfConditionIdSchema = OptionalConditionIdSchema;
 // Unlike ConditionIdSchema, this validates hex syntax without constraining the
 // condition ID byte length.
 export const ConditionIdResponseSchema = z.custom<ConditionId>(

--- a/packages/client/src/actions/orders/asset.ts
+++ b/packages/client/src/actions/orders/asset.ts
@@ -11,18 +11,15 @@ import { ExchangeOrderProtocolVersion } from '../../exchange';
 
 /**
  * Identifies the asset to trade. Provide exactly one identifier.
- *
- * Use `tokenId` whenever the selected market outcome provides one. Use
- * `positionId` for position-backed outcomes where `tokenId` is unavailable.
  */
 export type OrderAsset =
   | {
-      /** Token-backed outcome identifier. Prefer this identifier when available. */
+      /** CTF token identifier. */
       tokenId: string;
       positionId?: never;
     }
   | {
-      /** Position-backed outcome identifier, used when `tokenId` is unavailable. */
+      /** Polymarket V2 position identifier. */
       positionId: string;
       tokenId?: never;
     };

--- a/packages/client/src/actions/orders/orders.test.ts
+++ b/packages/client/src/actions/orders/orders.test.ts
@@ -9,6 +9,7 @@ import { WalletType } from '@polymarket/bindings/gamma';
 import type { EvmAddress } from '@polymarket/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ExchangeOrderProtocolVersion } from '../../exchange';
+import type { OrderRouting } from './asset';
 import { createUnsignedOrder } from './orders';
 import type { OrderDraft } from './types';
 
@@ -100,8 +101,10 @@ describe('createUnsignedOrder', () => {
     const positionId = toPositionId('2');
     const order = createUnsignedOrder(
       createOrderDraft({
-        assetId: positionId,
-        exchangeVersion: ExchangeOrderProtocolVersion.V3,
+        routing: {
+          assetId: positionId,
+          exchangeVersion: ExchangeOrderProtocolVersion.V3,
+        },
         wallet: DEPOSIT_WALLET,
       }),
       {
@@ -116,18 +119,23 @@ describe('createUnsignedOrder', () => {
   });
 });
 
-type CreateOrderDraftParams = { wallet: EvmAddress } & Partial<OrderDraft>;
+type CreateOrderDraftParams = {
+  routing?: OrderRouting;
+  wallet: EvmAddress;
+};
 
 function createOrderDraft({
-  wallet,
-  ...overrides
-}: CreateOrderDraftParams): OrderDraft {
-  const draft: OrderDraft = {
+  routing = {
     assetId: toTokenId('1'),
+    exchangeVersion: ExchangeOrderProtocolVersion.V2,
+  },
+  wallet,
+}: CreateOrderDraftParams): OrderDraft {
+  return {
+    ...routing,
     chainId: 137,
     exchangeAddress: '0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e' as EvmAddress,
     expiration: 0,
-    exchangeVersion: ExchangeOrderProtocolVersion.V2,
     funderAddress: wallet,
     offeredAmount: 1000000n,
     orderType: OrderType.GTC,
@@ -135,6 +143,4 @@ function createOrderDraft({
     side: OrderSide.BUY,
     signer: SIGNER,
   };
-
-  return Object.assign(draft, overrides, { funderAddress: wallet });
 }

--- a/packages/client/src/actions/orders/orders.test.ts
+++ b/packages/client/src/actions/orders/orders.test.ts
@@ -9,7 +9,6 @@ import { WalletType } from '@polymarket/bindings/gamma';
 import type { EvmAddress } from '@polymarket/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ExchangeOrderProtocolVersion } from '../../exchange';
-import type { OrderRouting } from './asset';
 import { createUnsignedOrder } from './orders';
 import type { OrderDraft } from './types';
 
@@ -101,10 +100,8 @@ describe('createUnsignedOrder', () => {
     const positionId = toPositionId('2');
     const order = createUnsignedOrder(
       createOrderDraft({
-        routing: {
-          assetId: positionId,
-          exchangeVersion: ExchangeOrderProtocolVersion.V3,
-        },
+        assetId: positionId,
+        exchangeVersion: ExchangeOrderProtocolVersion.V3,
         wallet: DEPOSIT_WALLET,
       }),
       {
@@ -119,23 +116,18 @@ describe('createUnsignedOrder', () => {
   });
 });
 
-type CreateOrderDraftParams = {
-  routing?: OrderRouting;
-  wallet: EvmAddress;
-};
+type CreateOrderDraftParams = { wallet: EvmAddress } & Partial<OrderDraft>;
 
 function createOrderDraft({
-  routing = {
-    assetId: toTokenId('1'),
-    exchangeVersion: ExchangeOrderProtocolVersion.V2,
-  },
   wallet,
+  ...overrides
 }: CreateOrderDraftParams): OrderDraft {
-  return {
-    ...routing,
+  const draft: OrderDraft = {
+    assetId: toTokenId('1'),
     chainId: 137,
     exchangeAddress: '0x4bfb41d5b3570defd03c39a9a4d8de6bd8b8982e' as EvmAddress,
     expiration: 0,
+    exchangeVersion: ExchangeOrderProtocolVersion.V2,
     funderAddress: wallet,
     offeredAmount: 1000000n,
     orderType: OrderType.GTC,
@@ -143,4 +135,6 @@ function createOrderDraft({
     side: OrderSide.BUY,
     signer: SIGNER,
   };
+
+  return Object.assign(draft, overrides, { funderAddress: wallet });
 }


### PR DESCRIPTION
## Summary

- remove the unused CTF-specific runtime condition ID aliases from the internal bindings package
- retain `CtfConditionId` as a deprecated type alias for source compatibility
- restore explicit CTF token and Polymarket V2 position identifier documentation

## Context

This realigns the merged PolyV2 work with the agreed public API approach. Runtime parsing and conversion use the protocol-neutral `ConditionId` APIs, while the client continues to type-re-export the deprecated `CtfConditionId` alias. The published 0.6.0 changelog remains unchanged because it accurately records the aliases that release shipped.

The explicit `OrderRouting` test fixture introduced in #281 remains unchanged.

## Validation

- `pnpm --filter @polymarket/bindings build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:bindings --run` (114 tests)
- `pnpm test:client --run` (338 tests and type tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removing public bindings exports can break downstream imports that still use the deprecated schemas or `toCtfConditionId`; in-repo usage is already gone per tests.
> 
> **Overview**
> **@polymarket/bindings** drops deprecated CTF-specific **runtime** condition ID helpers (`toCtfConditionId`, `CtfConditionIdSchema`, `OptionalConditionIdSchema`, `OptionalCtfConditionIdSchema`) so parsing and validation go through the protocol-neutral `ConditionId` APIs only. The deprecated **`CtfConditionId` type alias** stays for source compatibility; tests no longer assert identity between the removed exports and their replacements.
> 
> **@polymarket/client** updates `OrderAsset` JSDoc to label **`tokenId`** as a CTF token identifier and **`positionId`** as a Polymarket V2 position identifier, replacing the longer “prefer tokenId when available” guidance.
> 
> A patch **changeset** records the bindings cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0d997aefef9528fcc5260fdffe41c744d697934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->