### PR TITLE
feat(repo): gate external contributions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Approved issue
+
+<!-- External pull requests must use the exact format below. -->
+Approved issue: #
+
+## Verification
+
+<!-- List the checks you ran and any relevant manual verification. -->
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] Tests added or updated where they protect user-facing behavior
+- [ ] Changeset added for user-facing package changes, or not applicable

--- a/.github/workflows/external-contribution-gate.yml
+++ b/.github/workflows/external-contribution-gate.yml
@@ -1,0 +1,130 @@
+name: External Contribution Gate
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate approved issue
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      # This privileged workflow must never check out or execute pull request code.
+      - name: Check contribution approval
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const marker = '<!-- external-contribution-gate -->';
+            const pullRequest = context.payload.pull_request;
+            const { data: access } =
+              await github.rest.repos.getCollaboratorPermissionLevel({
+                ...context.repo,
+                username: pullRequest.user.login,
+              });
+
+            if (['admin', 'write'].includes(access.permission)) {
+              core.info(`${pullRequest.user.login} has write access; skipping.`);
+              return;
+            }
+
+            const match = (pullRequest.body ?? '').match(
+              /^Approved issue:\s*#([1-9][0-9]*)\s*$/im,
+            );
+
+            let issueNumber;
+            let rejectionReason;
+
+            if (!match) {
+              rejectionReason =
+                'the pull request description does not contain `Approved issue: #123`';
+            } else {
+              issueNumber = Number(match[1]);
+
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  ...context.repo,
+                  issue_number: issueNumber,
+                });
+
+                if (issue.pull_request) {
+                  rejectionReason = `#${issueNumber} is a pull request, not an issue`;
+                } else {
+                  const labels = issue.labels.map((label) =>
+                    typeof label === 'string' ? label : label.name,
+                  );
+
+                  if (!labels.includes('contribution-approved')) {
+                    rejectionReason =
+                      `#${issueNumber} does not have the \`contribution-approved\` label`;
+                  } else {
+                    const contributor = pullRequest.user.login.toLowerCase();
+                    const isAssigned = (issue.assignees ?? []).some(
+                      (assignee) => assignee.login.toLowerCase() === contributor,
+                    );
+
+                    if (!isAssigned) {
+                      rejectionReason =
+                        `${pullRequest.user.login} is not assigned to #${issueNumber}`;
+                    }
+                  }
+                }
+              } catch (error) {
+                if (error.status === 404) {
+                  rejectionReason = `#${issueNumber} does not exist in this repository`;
+                } else {
+                  throw error;
+                }
+              }
+            }
+
+            if (!rejectionReason) {
+              core.info(
+                `Contribution by ${pullRequest.user.login} approved in issue #${issueNumber}.`,
+              );
+              return;
+            }
+
+            const body = `${marker}
+            Thanks for taking the time to contribute. This pull request is being closed because ${rejectionReason}.
+
+            We discuss and approve external contributions before implementation so contributors do not spend time on changes that may not fit the SDK direction. Please read [CONTRIBUTING.md](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md), discuss the proposal in an issue, and wait for a maintainer to assign you and add the \`contribution-approved\` label.
+
+            Once the linked issue is approved, update this description and reopen the pull request.`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: pullRequest.number,
+              per_page: 100,
+            });
+            const previousComment = comments.find(
+              (comment) =>
+                comment.user?.type === 'Bot' && comment.body?.includes(marker),
+            );
+
+            if (previousComment) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: previousComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: pullRequest.number,
+                body,
+              });
+            }
+
+            await github.rest.pulls.update({
+              ...context.repo,
+              pull_number: pullRequest.number,
+              state: 'closed',
+            });
+
+            core.setFailed(rejectionReason);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,39 @@
 # Contributing
 
-We use GitHub Issues as the primary public feedback channel. Please open an issue for bug reports, feature requests, or general feedback.
+Thanks for your interest in improving the Polymarket TypeScript SDK.
 
-We are not broadly accepting external pull requests yet. Large changes should not be started without prior discussion and agreement with the Polymarket team.
+We use GitHub Issues as the primary public feedback channel. Please open an
+issue for bug reports, feature requests, or general feedback.
+
+## Before opening a pull request
+
+External pull requests must be discussed and approved in an issue before work
+begins. This keeps contributors from spending time on changes that do not fit
+the SDK direction and keeps the review queue focused.
+
+1. Open the appropriate issue, or join the discussion on an existing one.
+2. Agree on the scope and approach with a maintainer.
+3. Wait for a maintainer to assign the issue to you and add the
+   `contribution-approved` label.
+4. Fork the repository, make the agreed change, and open a pull request that
+   includes `Approved issue: #123` in its description.
+
+Pull requests from external contributors without write access are closed
+automatically unless the referenced issue has the `contribution-approved` label
+and is assigned to the pull request author. Once both conditions are met, a
+previously closed pull request can be reopened.
+
+Approval applies only to the scope agreed in the linked issue. It does not
+guarantee that a pull request will be merged.
+
+## Pull request expectations
+
+- Keep the change focused on the approved scope.
+- Make sure your agent loads the applicable `AGENTS.md` or `CLAUDE.md` file.
+- Keep the description concise and specific to the change. If you use AI to
+  help write it, review and edit the result carefully, and include only claims
+  you have personally verified.
+- Include tests when they protect user-facing behavior or prevent a regression.
+- Run `pnpm lint` and `pnpm typecheck` before submitting.
+- Add a changeset for user-facing package changes.
+- Be prepared to revise the change based on review feedback.


### PR DESCRIPTION
## Summary

- document the approved-issue workflow for external contributors
- add a pull request template that links the approved issue
- automatically close unapproved fork PRs while bypassing same-repository and write-access contributors
- keep the privileged gate metadata-only and pin its action dependency by full commit SHA

## Verification

- `actionlint .github/workflows/external-contribution-gate.yml`
- `pnpm lint`
- `pnpm typecheck`

## Repository settings required before rollout

- create the `contribution-approved` label
- allow pull requests from external contributors
- limit users without write access to one concurrent open PR
- require approval before external fork workflows run
- keep fork workflow tokens read-only and do not expose secrets