### PR TITLE
feat(client): maker HTTP quote lifecycle (submit, cancel, confirm)

### DIFF
--- a/.changeset/dev-593-maker-rest-quote-lifecycle.md
+++ b/.changeset/dev-593-maker-rest-quote-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": minor
+"@polymarket/client": minor
+---
+
+Adds the maker-side HTTP quote lifecycle: submitMakerQuote, cancelMakerQuote, and submitMakerConfirmation on the secure client, as the request/response alternative to the streaming quoter session. Quote identifiers are client-generated and returned from submitMakerQuote; last-look confirmation requests still arrive only over the streaming session, with submitMakerConfirmation as the response channel.

--- a/packages/bindings/src/combos/index.ts
+++ b/packages/bindings/src/combos/index.ts
@@ -1,3 +1,4 @@
 export * from './builder-rfq';
+export * from './maker-rest';
 export * from './plan';
 export * from './rfq';

--- a/packages/bindings/src/combos/maker-rest.test.ts
+++ b/packages/bindings/src/combos/maker-rest.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MakerConfirmationResultSchema,
+  MakerExecutionHandoffSchema,
+  MakerRfqSnapshotSchema,
+  MakerRfqStatus,
+} from './maker-rest';
+
+const wireRequest = {
+  rfq_id: 'rfq-123',
+  auth_address: '0x1111111111111111111111111111111111111111',
+  signer_address: '0x1111111111111111111111111111111111111111',
+  maker_address: '0x2222222222222222222222222222222222222222',
+  signature_type: 0,
+  leg_position_ids: ['101', '102'],
+  condition_id: `0x03${'0'.repeat(60)}`,
+  yes_position_id: '201',
+  no_position_id: '202',
+  direction: 'BUY',
+  side: 'YES',
+  requested_size: { unit: 'notional', value_e6: '250000000' },
+  size_includes_fees: true,
+  created_at: 1_755_600_000_000,
+};
+
+const wireSnapshot = {
+  request: wireRequest,
+  status: 'COLLECTING_QUOTES',
+  competition_started_at: 1_755_600_000_100,
+  competition_ends_at: 1_755_600_003_100,
+  quote_id: 'quote_legacybundlefield',
+  bundle: {
+    requested_shares_e6: '400000000',
+    blended_price_e6: '625000',
+    requested_notional_e6: '250000000',
+    total_required_e6: '251000000',
+    allocations: [
+      {
+        maker_quote_id: 'quote_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        signer_address: '0x3333333333333333333333333333333333333333',
+        maker_address: '0x4444444444444444444444444444444444444444',
+        size_e6: '150000000',
+        price_e6: '625000',
+        received_at: 1_755_600_001_000,
+      },
+    ],
+  },
+  maker_confirmations: [
+    {
+      quote_id: 'quote_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      signer_address: '0x3333333333333333333333333333333333333333',
+      maker_address: '0x4444444444444444444444444444444444444444',
+      decision: 'TIMED_OUT',
+      reason: 'TIMED_OUT',
+      responded_at: 1_755_600_004_000,
+    },
+  ],
+};
+
+describe('MakerRfqSnapshotSchema', () => {
+  it('parses the engine snapshot into camelCase with human decimals', () => {
+    const snapshot = MakerRfqSnapshotSchema.parse(wireSnapshot);
+
+    expect(snapshot.status).toBe(MakerRfqStatus.CollectingQuotes);
+    expect(snapshot.request.rfqId).toBe('rfq-123');
+    expect(snapshot.request.direction).toBe('BUY');
+    expect(snapshot.request.requestedSize).toEqual({
+      unit: 'notional',
+      value: '250',
+    });
+    expect(snapshot.request.sizeIncludesFees).toBe(true);
+    expect(snapshot.competitionStartedAt).toBe(1_755_600_000_100);
+    expect(snapshot.bundle?.requestedShares).toBe('400');
+    expect(snapshot.bundle?.blendedPrice).toBe('0.625');
+    expect(snapshot.bundle?.totalRequired).toBe('251');
+    expect(snapshot.bundle?.allocations).toEqual([
+      {
+        makerAddress: '0x4444444444444444444444444444444444444444',
+        makerQuoteId: 'quote_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        price: '0.625',
+        receivedAt: 1_755_600_001_000,
+        signerAddress: '0x3333333333333333333333333333333333333333',
+        size: '150',
+      },
+    ]);
+    expect(snapshot.makerConfirmations?.[0]?.decision).toBe('TIMED_OUT');
+  });
+
+  it('does not surface the legacy top-level quote_id', () => {
+    const snapshot = MakerRfqSnapshotSchema.parse(wireSnapshot);
+
+    expect(snapshot).not.toHaveProperty('quoteId');
+    expect(snapshot).not.toHaveProperty('quote_id');
+  });
+
+  it('omits absent optional keys instead of emitting undefined', () => {
+    const snapshot = MakerRfqSnapshotSchema.parse({
+      request: {
+        rfq_id: 'rfq-min',
+        direction: 'SELL',
+        leg_position_ids: ['1'],
+        signature_type: 0,
+        side: 'YES',
+      },
+      status: 'CREATED',
+    });
+
+    expect(Object.keys(snapshot).sort()).toEqual(['request', 'status']);
+    expect(Object.keys(snapshot.request).sort()).toEqual([
+      'direction',
+      'legPositionIds',
+      'rfqId',
+    ]);
+  });
+
+  it('rejects an unknown status', () => {
+    expect(() =>
+      MakerRfqSnapshotSchema.parse({
+        ...wireSnapshot,
+        status: 'SOMETHING_NEW',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('MakerExecutionHandoffSchema', () => {
+  it('models the maker-relevant subset and ignores engine internals', () => {
+    const handoff = MakerExecutionHandoffSchema.parse({
+      execution_id: 'exec-1',
+      request: wireRequest,
+      quote_id: 'quote_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      bundle: {
+        requested_shares_e6: '400000000',
+        blended_price_e6: '625000',
+        allocations: [],
+      },
+      requester_acceptance: { quote_id: 'quote_x', signed_order: {} },
+      maker_quotes: [{ quote_id: 'quote_y' }],
+      reservations: [{ wallet: '0x0' }],
+      ready_at: 1_755_600_005_000,
+    });
+
+    expect(handoff.executionId).toBe('exec-1');
+    expect(handoff.quoteId).toBe('quote_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
+    expect(handoff.readyAt).toBe(1_755_600_005_000);
+    expect(handoff).not.toHaveProperty('makerQuotes');
+    expect(handoff).not.toHaveProperty('requesterAcceptance');
+    expect(handoff).not.toHaveProperty('reservations');
+  });
+});
+
+describe('MakerConfirmationResultSchema', () => {
+  it('parses a snapshot-only result (non-final confirm or decline)', () => {
+    const result = MakerConfirmationResultSchema.parse({
+      snapshot: wireSnapshot,
+    });
+
+    expect(result.snapshot?.status).toBe(MakerRfqStatus.CollectingQuotes);
+    expect(result.execution).toBeUndefined();
+  });
+
+  it('parses an execution-only result (final confirming maker)', () => {
+    const result = MakerConfirmationResultSchema.parse({
+      execution: {
+        execution_id: 'exec-2',
+        quote_id: 'quote_cccccccccccccccccccccccccccccccc',
+        bundle: {
+          requested_shares_e6: '1000000',
+          blended_price_e6: '500000',
+          allocations: null,
+        },
+      },
+    });
+
+    expect(result.execution?.executionId).toBe('exec-2');
+    expect(result.execution?.bundle.allocations).toEqual([]);
+    expect(result.snapshot).toBeUndefined();
+  });
+
+  it('parses an empty result without inventing keys', () => {
+    expect(MakerConfirmationResultSchema.parse({})).toEqual({});
+  });
+});

--- a/packages/bindings/src/combos/maker-rest.ts
+++ b/packages/bindings/src/combos/maker-rest.ts
@@ -1,0 +1,361 @@
+import { z } from 'zod';
+import type { SignatureType } from '../clob/signature-type';
+import type {
+  ComboConditionId,
+  DecimalString,
+  EpochMilliseconds,
+  EvmAddress,
+  PositionId,
+  RfqId,
+  RfqQuoteId,
+} from '../shared';
+import {
+  ComboConditionIdSchema,
+  E6BigIntStringToDecimalStringSchema,
+  EpochMillisecondsSchema,
+  EvmAddressSchema,
+  PositionIdSchema,
+  RfqIdSchema,
+  RfqQuoteIdSchema,
+} from '../shared';
+import {
+  RfqConfirmationDecision,
+  RfqDirection,
+  type RfqRequestedSize,
+  RfqRequestedSizeUnit,
+  type RfqSignedOrder,
+} from './rfq';
+
+/**
+ * Lifecycle status of an RFQ as reported by the maker quote endpoints.
+ *
+ * Strict on purpose: an unknown status is a contract change the SDK must
+ * fail loudly on, unlike error codes which evolve independently.
+ */
+export enum MakerRfqStatus {
+  Created = 'CREATED',
+  CollectingQuotes = 'COLLECTING_QUOTES',
+  AwaitingRequesterAcceptance = 'AWAITING_REQUESTER_ACCEPTANCE',
+  AwaitingMakerConfirmation = 'AWAITING_MAKER_CONFIRMATION',
+  Executing = 'EXECUTING',
+  Filled = 'FILLED',
+  Failed = 'FAILED',
+  Expired = 'EXPIRED',
+  Canceled = 'CANCELED',
+  Rejected = 'REJECTED',
+}
+
+const MakerRfqStatusSchema = z.enum(MakerRfqStatus);
+
+export type MakerRfqRequest = {
+  rfqId: RfqId;
+  direction: RfqDirection;
+  legPositionIds: PositionId[];
+  conditionId?: ComboConditionId;
+  yesPositionId?: PositionId;
+  noPositionId?: PositionId;
+  requestedSize?: RfqRequestedSize;
+  /** Whether the requested size already includes taker fees. */
+  sizeIncludesFees?: boolean;
+  createdAt?: EpochMilliseconds;
+};
+
+const RequestedSizeSchema = z
+  .discriminatedUnion('unit', [
+    z.object({
+      unit: z.literal(RfqRequestedSizeUnit.Notional),
+      value_e6: E6BigIntStringToDecimalStringSchema,
+    }),
+    z.object({
+      unit: z.literal(RfqRequestedSizeUnit.Shares),
+      value_e6: E6BigIntStringToDecimalStringSchema,
+    }),
+  ])
+  .transform(
+    (size): RfqRequestedSize => ({
+      unit: size.unit,
+      value: size.value_e6,
+    }),
+  );
+
+const MakerRfqRequestSchema = z
+  .object({
+    rfq_id: RfqIdSchema,
+    direction: z.enum(RfqDirection),
+    leg_position_ids: z.array(PositionIdSchema),
+    condition_id: ComboConditionIdSchema.optional(),
+    yes_position_id: PositionIdSchema.optional(),
+    no_position_id: PositionIdSchema.optional(),
+    requested_size: RequestedSizeSchema.optional(),
+    size_includes_fees: z.boolean().optional(),
+    created_at: EpochMillisecondsSchema.optional(),
+  })
+  .transform(
+    (request): MakerRfqRequest => ({
+      direction: request.direction,
+      legPositionIds: request.leg_position_ids,
+      rfqId: request.rfq_id,
+      ...(request.condition_id === undefined
+        ? {}
+        : { conditionId: request.condition_id }),
+      ...(request.yes_position_id === undefined
+        ? {}
+        : { yesPositionId: request.yes_position_id }),
+      ...(request.no_position_id === undefined
+        ? {}
+        : { noPositionId: request.no_position_id }),
+      ...(request.requested_size === undefined
+        ? {}
+        : { requestedSize: request.requested_size }),
+      ...(request.size_includes_fees === undefined
+        ? {}
+        : { sizeIncludesFees: request.size_includes_fees }),
+      ...(request.created_at === undefined
+        ? {}
+        : { createdAt: request.created_at }),
+    }),
+  );
+
+export type MakerFillAllocation = {
+  makerQuoteId: RfqQuoteId;
+  signerAddress: EvmAddress;
+  makerAddress: EvmAddress;
+  /** Accepted fill size in outcome shares. Can be below the quoted size. */
+  size: DecimalString;
+  price: DecimalString;
+  receivedAt?: EpochMilliseconds;
+};
+
+const MakerFillAllocationSchema = z
+  .object({
+    maker_quote_id: RfqQuoteIdSchema,
+    signer_address: EvmAddressSchema,
+    maker_address: EvmAddressSchema,
+    size_e6: E6BigIntStringToDecimalStringSchema,
+    price_e6: E6BigIntStringToDecimalStringSchema,
+    received_at: EpochMillisecondsSchema.optional(),
+  })
+  .transform(
+    (allocation): MakerFillAllocation => ({
+      makerAddress: allocation.maker_address,
+      makerQuoteId: allocation.maker_quote_id,
+      price: allocation.price_e6,
+      signerAddress: allocation.signer_address,
+      size: allocation.size_e6,
+      ...(allocation.received_at === undefined
+        ? {}
+        : { receivedAt: allocation.received_at }),
+    }),
+  );
+
+export type MakerFillBundle = {
+  requestedShares: DecimalString;
+  blendedPrice: DecimalString;
+  requestedNotional?: DecimalString;
+  /** Total collateral the requester must hold to accept, fees included. */
+  totalRequired?: DecimalString;
+  /** Exact collateral proceeds after fees. Present only for SELL requests. */
+  netReceive?: DecimalString;
+  allocations: MakerFillAllocation[];
+};
+
+const MakerFillBundleSchema = z
+  .object({
+    requested_shares_e6: E6BigIntStringToDecimalStringSchema,
+    blended_price_e6: E6BigIntStringToDecimalStringSchema,
+    requested_notional_e6: E6BigIntStringToDecimalStringSchema.optional(),
+    total_required_e6: E6BigIntStringToDecimalStringSchema.optional(),
+    net_receive_e6: E6BigIntStringToDecimalStringSchema.optional(),
+    allocations: z.array(MakerFillAllocationSchema).nullish(),
+  })
+  .transform(
+    (bundle): MakerFillBundle => ({
+      allocations: bundle.allocations ?? [],
+      blendedPrice: bundle.blended_price_e6,
+      requestedShares: bundle.requested_shares_e6,
+      ...(bundle.requested_notional_e6 === undefined
+        ? {}
+        : { requestedNotional: bundle.requested_notional_e6 }),
+      ...(bundle.total_required_e6 === undefined
+        ? {}
+        : { totalRequired: bundle.total_required_e6 }),
+      ...(bundle.net_receive_e6 === undefined
+        ? {}
+        : { netReceive: bundle.net_receive_e6 }),
+    }),
+  );
+
+export type MakerConfirmationEntry = {
+  quoteId: RfqQuoteId;
+  signerAddress: EvmAddress;
+  makerAddress: EvmAddress;
+  /**
+   * Absent while the maker has not responded. `TIMED_OUT` is assigned by the
+   * server when the confirmation window lapses; it is never a valid input.
+   */
+  decision?: RfqConfirmationDecision | 'TIMED_OUT';
+  reason?: string;
+  respondedAt?: EpochMilliseconds;
+};
+
+const MakerConfirmationEntrySchema = z
+  .object({
+    quote_id: RfqQuoteIdSchema,
+    signer_address: EvmAddressSchema,
+    maker_address: EvmAddressSchema,
+    decision: z
+      .union([z.enum(RfqConfirmationDecision), z.literal('TIMED_OUT')])
+      .optional(),
+    reason: z.string().optional(),
+    responded_at: EpochMillisecondsSchema.optional(),
+  })
+  .transform(
+    (entry): MakerConfirmationEntry => ({
+      makerAddress: entry.maker_address,
+      quoteId: entry.quote_id,
+      signerAddress: entry.signer_address,
+      ...(entry.decision === undefined ? {} : { decision: entry.decision }),
+      ...(entry.reason === undefined ? {} : { reason: entry.reason }),
+      ...(entry.responded_at === undefined
+        ? {}
+        : { respondedAt: entry.responded_at }),
+    }),
+  );
+
+export type MakerRfqSnapshot = {
+  request: MakerRfqRequest;
+  status: MakerRfqStatus;
+  competitionStartedAt?: EpochMilliseconds;
+  competitionEndsAt?: EpochMilliseconds;
+  confirmationStartedAt?: EpochMilliseconds;
+  confirmationEndsAt?: EpochMilliseconds;
+  bundle?: MakerFillBundle;
+  makerConfirmations?: MakerConfirmationEntry[];
+};
+
+/**
+ * The engine snapshot returned by the maker quote submit and cancel
+ * endpoints.
+ *
+ * The wire body also carries a top-level `quote_id`, which is a bundle-level
+ * legacy field rather than the submitted quote's identifier; it is
+ * deliberately not modeled so callers key on the id they generated.
+ */
+export const MakerRfqSnapshotSchema = z
+  .object({
+    request: MakerRfqRequestSchema,
+    status: MakerRfqStatusSchema,
+    competition_started_at: EpochMillisecondsSchema.optional(),
+    competition_ends_at: EpochMillisecondsSchema.optional(),
+    confirmation_started_at: EpochMillisecondsSchema.optional(),
+    confirmation_ends_at: EpochMillisecondsSchema.optional(),
+    bundle: MakerFillBundleSchema.optional(),
+    maker_confirmations: z.array(MakerConfirmationEntrySchema).nullish(),
+  })
+  .transform(
+    (snapshot): MakerRfqSnapshot => ({
+      request: snapshot.request,
+      status: snapshot.status,
+      ...(snapshot.competition_started_at === undefined
+        ? {}
+        : { competitionStartedAt: snapshot.competition_started_at }),
+      ...(snapshot.competition_ends_at === undefined
+        ? {}
+        : { competitionEndsAt: snapshot.competition_ends_at }),
+      ...(snapshot.confirmation_started_at === undefined
+        ? {}
+        : { confirmationStartedAt: snapshot.confirmation_started_at }),
+      ...(snapshot.confirmation_ends_at === undefined
+        ? {}
+        : { confirmationEndsAt: snapshot.confirmation_ends_at }),
+      ...(snapshot.bundle === undefined ? {} : { bundle: snapshot.bundle }),
+      ...(snapshot.maker_confirmations == null
+        ? {}
+        : { makerConfirmations: snapshot.maker_confirmations }),
+    }),
+  );
+
+export type MakerExecutionHandoff = {
+  executionId: string;
+  quoteId: RfqQuoteId;
+  bundle: MakerFillBundle;
+  readyAt?: EpochMilliseconds;
+};
+
+/**
+ * Execution handoff returned to the final confirming maker.
+ *
+ * The wire body additionally carries the raw request, the requester's
+ * acceptance, every maker's signed quote order, and wallet reservations;
+ * those are deliberately not modeled — they are engine-internal detail, and
+ * exposing other makers' signed orders would invite coupling the SDK should
+ * not encourage.
+ */
+export const MakerExecutionHandoffSchema = z
+  .object({
+    execution_id: z.string(),
+    quote_id: RfqQuoteIdSchema,
+    bundle: MakerFillBundleSchema,
+    ready_at: EpochMillisecondsSchema.optional(),
+  })
+  .transform(
+    (handoff): MakerExecutionHandoff => ({
+      bundle: handoff.bundle,
+      executionId: handoff.execution_id,
+      quoteId: handoff.quote_id,
+      ...(handoff.ready_at === undefined ? {} : { readyAt: handoff.ready_at }),
+    }),
+  );
+
+export type MakerConfirmationResult = {
+  /** Present on a non-final CONFIRM and on DECLINE (the failed RFQ). */
+  snapshot?: MakerRfqSnapshot;
+  /** Present only when this confirmation completed the bundle. */
+  execution?: MakerExecutionHandoff;
+};
+
+export const MakerConfirmationResultSchema = z
+  .object({
+    snapshot: MakerRfqSnapshotSchema.optional(),
+    execution: MakerExecutionHandoffSchema.optional(),
+  })
+  .transform(
+    (result): MakerConfirmationResult => ({
+      ...(result.snapshot === undefined ? {} : { snapshot: result.snapshot }),
+      ...(result.execution === undefined
+        ? {}
+        : { execution: result.execution }),
+    }),
+  );
+
+/** Wire body for `POST /v1/maker/quotes`. Constructed by the SDK. */
+export type MakerQuoteSubmitRequest = {
+  quote_id: string;
+  rfq_id: RfqId;
+  signer_address: EvmAddress;
+  maker_address: EvmAddress;
+  signature_type: SignatureType;
+  price_e6: string;
+  size_e6: string;
+  valid_until?: number;
+  signed_order: RfqSignedOrder;
+};
+
+/** Wire body for `POST /v1/maker/quotes/cancel`. Constructed by the SDK. */
+export type MakerQuoteCancelRequest = {
+  rfq_id: RfqId;
+  quote_id: RfqQuoteId;
+  signer_address: EvmAddress;
+  maker_address: EvmAddress;
+  signature_type: SignatureType;
+};
+
+/** Wire body for `POST /v1/maker/confirmations`. Constructed by the SDK. */
+export type MakerConfirmationRequest = {
+  rfq_id: RfqId;
+  quote_id: RfqQuoteId;
+  signer_address: EvmAddress;
+  maker_address: EvmAddress;
+  signature_type: SignatureType;
+  decision: RfqConfirmationDecision;
+};

--- a/packages/client/src/actions/rfq.test.ts
+++ b/packages/client/src/actions/rfq.test.ts
@@ -2,7 +2,11 @@ import { OrderSide } from '@polymarket/bindings';
 import {
   ComboAcceptFailureReason,
   ComboQuoteUnavailableReason,
+  MakerRfqStatus,
+  RfqConfirmationDecision,
+  RfqDirection,
   RfqRejectionCode,
+  RfqRequestedSizeUnit,
   RfqStatus,
 } from '@polymarket/bindings/combos';
 import { WalletType } from '@polymarket/bindings/gamma';
@@ -26,9 +30,13 @@ import type { Signer } from '../types';
 import {
   type AcceptComboQuoteParams,
   acceptComboQuote,
+  cancelMakerQuote,
   type RequestComboQuoteParams,
+  RfqCancelQuoteRejectedError,
   RfqRequestRejectedError,
   requestComboQuote,
+  submitMakerConfirmation,
+  submitMakerQuote,
   waitForComboFill,
 } from './rfq';
 
@@ -615,6 +623,7 @@ type CreateClientOptions = {
   getResults?: GatewayResult[];
   hasBuilderApiKey?: boolean;
   postResults?: GatewayResult[];
+  secureRfqPostResults?: GatewayResult[];
 };
 
 function createClient(options: CreateClientOptions = {}) {
@@ -629,6 +638,12 @@ function createClient(options: CreateClientOptions = {}) {
   const gatewayGet = vi.fn(() => {
     const next = getQueue.shift();
     if (next === undefined) throw new Error('Unexpected gateway GET');
+    return next;
+  });
+  const secureRfqQueue = [...(options.secureRfqPostResults ?? [])];
+  const secureRfqPost = vi.fn(() => {
+    const next = secureRfqQueue.shift();
+    if (next === undefined) throw new Error('Unexpected secureRfq POST');
     return next;
   });
   const signTypedData = vi.fn(async () => SIGNATURE);
@@ -649,10 +664,11 @@ function createClient(options: CreateClientOptions = {}) {
     builderGateway: { get: gatewayGet, post: gatewayPost },
     environment: production,
     hasBuilderApiKey: options.hasBuilderApiKey ?? true,
+    secureRfq: { post: secureRfqPost },
     signer,
   } as unknown as BaseSecureClient;
 
-  return { client, gatewayGet, gatewayPost, signTypedData };
+  return { client, gatewayGet, gatewayPost, secureRfqPost, signTypedData };
 }
 
 function jsonResponse(payload: unknown): Response {
@@ -660,3 +676,177 @@ function jsonResponse(payload: unknown): Response {
     headers: { 'content-type': 'application/json' },
   });
 }
+
+const makerSnapshotWire = {
+  request: {
+    rfq_id: 'rfq-77',
+    direction: 'BUY',
+    leg_position_ids: ['101', '102'],
+    signature_type: 0,
+    side: 'YES',
+    requested_size: { unit: 'notional', value_e6: '90000000' },
+  },
+  status: 'COLLECTING_QUOTES',
+};
+
+describe('submitMakerQuote', () => {
+  it('signs, generates a quote id, and posts the wire body', async () => {
+    const { client, secureRfqPost } = createClient({
+      secureRfqPostResults: [okAsync(jsonResponse(makerSnapshotWire))],
+    });
+
+    const result = await submitMakerQuote(client, {
+      direction: RfqDirection.Buy,
+      noPositionId: '202',
+      price: 0.45,
+      rfqId: 'rfq-77',
+      size: 20,
+      validUntil: 1_755_600_000_000,
+      yesPositionId: '201',
+    });
+
+    expect(result.quoteId).toMatch(/^quote_[0-9a-f]{32}$/);
+    expect(result.snapshot.status).toBe(MakerRfqStatus.CollectingQuotes);
+
+    expect(secureRfqPost).toHaveBeenCalledWith('/v1/maker/quotes', {
+      json: expect.objectContaining({
+        maker_address: SIGNER,
+        price_e6: '450000',
+        quote_id: result.quoteId,
+        rfq_id: 'rfq-77',
+        signature_type: 0,
+        signer_address: SIGNER,
+        size_e6: '20000000',
+        valid_until: 1_755_600_000_000,
+      }),
+    });
+    const [, options] = secureRfqPost.mock.calls[0] as unknown as [
+      string,
+      { json: { signed_order: { builder?: string }; responded_at?: unknown } },
+    ];
+    expect(options.json.signed_order).toBeDefined();
+    expect(options.json.signed_order.builder).toBe(`0x${'0'.repeat(64)}`);
+  });
+
+  it('defaults the size from the requested RFQ size', async () => {
+    const { client, secureRfqPost } = createClient({
+      secureRfqPostResults: [okAsync(jsonResponse(makerSnapshotWire))],
+    });
+
+    await submitMakerQuote(client, {
+      direction: RfqDirection.Buy,
+      noPositionId: '202',
+      price: 0.45,
+      requestedSize: { unit: RfqRequestedSizeUnit.Notional, value: 90 },
+      rfqId: 'rfq-77',
+      yesPositionId: '201',
+    });
+
+    const [, options] = secureRfqPost.mock.calls[0] as unknown as [
+      string,
+      { json: { size_e6: string } },
+    ];
+    // 90 pUSD notional at 0.45 = 200 shares.
+    expect(options.json.size_e6).toBe('200000000');
+  });
+
+  it('rejects when neither size nor requestedSize is given', async () => {
+    const { client } = createClient();
+
+    await expect(
+      submitMakerQuote(client, {
+        direction: RfqDirection.Buy,
+        noPositionId: '202',
+        price: 0.45,
+        rfqId: 'rfq-77',
+        yesPositionId: '201',
+      }),
+    ).rejects.toBeInstanceOf(UserInputError);
+  });
+});
+
+describe('cancelMakerQuote', () => {
+  it('posts the cancel body and parses the snapshot', async () => {
+    const { client, secureRfqPost } = createClient({
+      secureRfqPostResults: [okAsync(jsonResponse(makerSnapshotWire))],
+    });
+
+    const snapshot = await cancelMakerQuote(client, {
+      quoteId: `quote_${'a'.repeat(32)}`,
+      rfqId: 'rfq-77',
+    });
+
+    expect(snapshot.status).toBe(MakerRfqStatus.CollectingQuotes);
+    expect(secureRfqPost).toHaveBeenCalledWith('/v1/maker/quotes/cancel', {
+      json: {
+        maker_address: SIGNER,
+        quote_id: `quote_${'a'.repeat(32)}`,
+        rfq_id: 'rfq-77',
+        signature_type: 0,
+        signer_address: SIGNER,
+      },
+    });
+  });
+
+  it('maps a codeless rejection body onto the cancel rejection error', async () => {
+    const { client } = createClient({
+      secureRfqPostResults: [
+        errAsync(
+          new RequestRejectedError('submission window closed (url)', {
+            status: 409,
+          }),
+        ),
+      ],
+    });
+
+    const failure = await cancelMakerQuote(client, {
+      quoteId: `quote_${'a'.repeat(32)}`,
+      rfqId: 'rfq-77',
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(RfqCancelQuoteRejectedError);
+    const rejection = failure as RfqCancelQuoteRejectedError;
+    expect(rejection.code).toBeUndefined();
+    expect(rejection.rfqId).toBe('rfq-77');
+    expect(rejection.quoteId).toBe(`quote_${'a'.repeat(32)}`);
+  });
+});
+
+describe('submitMakerConfirmation', () => {
+  it('posts the decision without responded_at and parses the handoff', async () => {
+    const { client, secureRfqPost } = createClient({
+      secureRfqPostResults: [
+        okAsync(
+          jsonResponse({
+            execution: {
+              execution_id: 'exec-9',
+              quote_id: `quote_${'b'.repeat(32)}`,
+              bundle: {
+                requested_shares_e6: '1000000',
+                blended_price_e6: '500000',
+                allocations: [],
+              },
+            },
+          }),
+        ),
+      ],
+    });
+
+    const result = await submitMakerConfirmation(client, {
+      decision: RfqConfirmationDecision.Confirm,
+      quoteId: `quote_${'b'.repeat(32)}`,
+      rfqId: 'rfq-77',
+    });
+
+    expect(result.execution?.executionId).toBe('exec-9');
+    expect(result.snapshot).toBeUndefined();
+
+    const [path, options] = secureRfqPost.mock.calls[0] as unknown as [
+      string,
+      { json: Record<string, unknown> },
+    ];
+    expect(path).toBe('/v1/maker/confirmations');
+    expect(options.json).not.toHaveProperty('responded_at');
+    expect(options.json.decision).toBe('CONFIRM');
+  });
+});

--- a/packages/client/src/actions/rfq.ts
+++ b/packages/client/src/actions/rfq.ts
@@ -6,6 +6,7 @@ import type {
   TxHash,
 } from '@polymarket/bindings';
 import {
+  DecimalishSchema,
   OrderSide,
   OrderSideSchema,
   toBaseUnits,
@@ -39,6 +40,14 @@ import {
   BuilderRfqStatusResponseSchema,
   ComboAcceptFailureReason,
   ComboQuoteUnavailableReason,
+  type MakerConfirmationRequest,
+  type MakerConfirmationResult,
+  MakerConfirmationResultSchema,
+  type MakerQuoteCancelRequest,
+  type MakerQuoteSubmitRequest,
+  type MakerRfqSnapshot,
+  MakerRfqSnapshotSchema,
+  RfqConfirmationDecision,
   RfqDirection,
   RfqExecutionStatus,
   RfqKnownErrorCode,
@@ -74,10 +83,22 @@ import {
 import { parseUserInput } from '../input';
 import { validateWith } from '../response';
 import { resolveOrderIdentity } from '../wallet';
+import { createRfqQuote, parseRfqQuoteResponse } from '../websockets/rfq/quote';
 
+export type {
+  BuilderRfqError,
+  MakerConfirmationEntry,
+  MakerConfirmationResult,
+  MakerExecutionHandoff,
+  MakerFillAllocation,
+  MakerFillBundle,
+  MakerRfqRequest,
+  MakerRfqSnapshot,
+} from '@polymarket/bindings/combos';
 export {
   ComboAcceptFailureReason,
   ComboQuoteUnavailableReason,
+  MakerRfqStatus,
   RfqConfirmationDecision,
   RfqDirection,
   RfqExecutionStatus,
@@ -88,7 +109,6 @@ export {
   RfqStatus,
 } from '@polymarket/bindings/combos';
 export type {
-  BuilderRfqError,
   RfqConfirmationRequest,
   RfqErrorCode,
   RfqExecutionUpdate,
@@ -1418,4 +1438,404 @@ export function fetchRfqStatus(
       .andThen(validateWith(BuilderRfqStatusResponseSchema))
       .mapErr(toRfqRequestRejection),
   );
+}
+
+const MAKER_QUOTES_PATH = '/v1/maker/quotes';
+const MAKER_QUOTES_CANCEL_PATH = '/v1/maker/quotes/cancel';
+const MAKER_CONFIRMATIONS_PATH = '/v1/maker/confirmations';
+
+/**
+ * Generates a client-side maker quote identifier.
+ *
+ * @remarks
+ * Unlike the streaming session, where the server assigns quote identifiers,
+ * the maker quote endpoints require a client-generated one and do not echo it
+ * back; the generated identifier is the key later cancellation and
+ * confirmation calls use. The format mirrors the server's own identifiers.
+ */
+function generateMakerQuoteId(): RfqQuoteId {
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  const hex = Array.from(bytes, (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+
+  return toRfqQuoteId(`quote_${hex}`);
+}
+
+/** User-facing requested-size input for {@link submitMakerQuote}. */
+export type MakerRequestedSizeInput = {
+  unit: RfqRequestedSizeUnit;
+  value: number | string;
+};
+
+const RequestedSizeInputSchema = z.object({
+  unit: z.enum(RfqRequestedSizeUnit),
+  value: DecimalishSchema,
+});
+
+const SubmitMakerQuoteParamsSchema = z
+  .strictObject({
+    rfqId: z.string().min(1).transform(toRfqId),
+    direction: z.enum(RfqDirection),
+    yesPositionId: z.string().min(1).transform(toPositionId),
+    noPositionId: z.string().min(1).transform(toPositionId),
+    requestedSize: RequestedSizeInputSchema.optional(),
+    price: z.union([z.number(), z.string()]),
+    size: z.union([z.number(), z.string()]).optional(),
+    source: z.enum(['collateral', 'inventory']).optional(),
+    validUntil: z.number().int().positive().optional(),
+  })
+  .refine(
+    (params) => params.size !== undefined || params.requestedSize !== undefined,
+    {
+      message: 'Either size or requestedSize is required.',
+    },
+  );
+
+export type SubmitMakerQuoteParams = {
+  /** RFQ identifier the quote responds to. */
+  rfqId: string;
+  /** Direction of the RFQ request being quoted. */
+  direction: RfqDirection;
+  /** YES-outcome position identifier of the RFQ's combo. */
+  yesPositionId: string;
+  /** NO-outcome position identifier of the RFQ's combo. */
+  noPositionId: string;
+  /**
+   * Requested RFQ size, used to quote the full requested size when `size` is
+   * omitted. Required when `size` is not provided. A streaming session
+   * event's `requestedSize` can be passed as-is.
+   */
+  requestedSize?: MakerRequestedSizeInput;
+  /** Quote price in pUSD per outcome token, for example `0.45` or `"0.45"`. */
+  price: number | string;
+  /** Quote size in outcome tokens. Defaults to the full requested size. */
+  size?: number | string;
+  /**
+   * How the maker wants to fund the quote. Defaults to `collateral`. See
+   * {@link RfqQuoteResponse.source} for the funding semantics.
+   */
+  source?: RfqQuoteSource;
+  /** Optional quote expiry as a unix-milliseconds timestamp. */
+  validUntil?: number;
+};
+
+export type SubmitMakerQuoteResult = {
+  /**
+   * The client-generated quote identifier. Keep it: cancellation and
+   * confirmation calls key on it, and the snapshot does not echo it.
+   */
+  quoteId: RfqQuoteId;
+  /** Engine snapshot of the RFQ after the quote was accepted. */
+  snapshot: MakerRfqSnapshot;
+};
+
+export type SubmitMakerQuoteError =
+  | RateLimitError
+  | RfqQuoteRejectedError
+  | SigningError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const SubmitMakerQuoteError = makeErrorGuard(
+  RateLimitError,
+  RfqQuoteRejectedError,
+  SigningError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Submits a maker quote for an open RFQ over HTTP.
+ *
+ * @remarks
+ * This is the request/response alternative to quoting through
+ * {@link openRfqSession}. Quote submission and cancellation work fully over
+ * HTTP, but last-look confirmation requests are only delivered over the
+ * streaming session: a maker quoting over HTTP alone cannot observe the
+ * confirmation window (roughly one second in production) and will time out,
+ * which fails the RFQ and counts toward the maker's decline limits. Keep a
+ * streaming session open to receive confirmation requests, and respond with
+ * either the session event or {@link submitMakerConfirmation}.
+ *
+ * There is no endpoint for listing resting quotes; track submitted quote
+ * identifiers locally.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client
+ * instance API.
+ *
+ * @throws {@link SubmitMakerQuoteError}
+ * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const { quoteId, snapshot } = await submitMakerQuote(client, {
+ *   rfqId: event.rfqId,
+ *   direction: event.direction,
+ *   yesPositionId: event.yesPositionId,
+ *   noPositionId: event.noPositionId,
+ *   requestedSize: event.requestedSize,
+ *   price: 0.45,
+ * });
+ *
+ * console.log(quoteId, snapshot.status);
+ * ```
+ */
+export async function submitMakerQuote(
+  client: BaseSecureClient,
+  params: SubmitMakerQuoteParams,
+): Promise<SubmitMakerQuoteResult> {
+  const input = parseUserInput(params, SubmitMakerQuoteParamsSchema);
+  const response = parseRfqQuoteResponse({
+    price: input.price,
+    ...(input.size === undefined ? {} : { size: input.size }),
+    ...(input.source === undefined ? {} : { source: input.source }),
+  });
+  const quote = await createRfqQuote({
+    account: client.account,
+    chainId: client.environment.chainId,
+    exchange: client.environment.contracts.exchangeV3,
+    request: {
+      direction: input.direction,
+      noPositionId: input.noPositionId,
+      yesPositionId: input.yesPositionId,
+      ...(input.requestedSize === undefined
+        ? {}
+        : { requestedSize: input.requestedSize }),
+    },
+    response,
+    signer: client.signer,
+  });
+  const identity = resolveOrderIdentity(client.account);
+  const quoteId = generateMakerQuoteId();
+  const request: MakerQuoteSubmitRequest = {
+    maker_address: identity.maker,
+    price_e6: quote.price.toString(),
+    quote_id: quoteId,
+    rfq_id: input.rfqId,
+    signature_type: identity.signatureType,
+    signed_order: quote.signedOrder,
+    signer_address: identity.signer,
+    size_e6: quote.size.toString(),
+    ...(input.validUntil === undefined
+      ? {}
+      : { valid_until: input.validUntil }),
+  };
+
+  const snapshot = await unwrap(
+    client.secureRfq
+      .post(MAKER_QUOTES_PATH, { json: request })
+      .andThen(validateWith(MakerRfqSnapshotSchema))
+      .mapErr((error) =>
+        toMakerRejection(error, RfqQuoteRejectedError, input.rfqId, quoteId),
+      ),
+  );
+
+  return { quoteId, snapshot };
+}
+
+const CancelMakerQuoteParamsSchema = z.strictObject({
+  rfqId: z.string().min(1).transform(toRfqId),
+  quoteId: z.string().min(1).transform(toRfqQuoteId),
+});
+
+export type CancelMakerQuoteParams = {
+  /** RFQ identifier the quote belongs to. */
+  rfqId: string;
+  /** Quote identifier returned by {@link submitMakerQuote}. */
+  quoteId: string;
+};
+
+export type CancelMakerQuoteError =
+  | RateLimitError
+  | RfqCancelQuoteRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const CancelMakerQuoteError = makeErrorGuard(
+  RateLimitError,
+  RfqCancelQuoteRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Cancels a resting maker quote over HTTP.
+ *
+ * @remarks
+ * Cancellation succeeds while the RFQ is still collecting quotes and is
+ * idempotent there. Once the maker's quote has been selected and last look
+ * has started, a cancellation is treated as a decline: it fails the entire
+ * RFQ and counts toward the maker's decline limits. After the requester has
+ * accepted or execution has started, cancellation is rejected.
+ *
+ * The identity fields sent with the cancellation must match the credentials
+ * that submitted the quote, whether it was submitted over HTTP or through a
+ * streaming session.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client
+ * instance API.
+ *
+ * @throws {@link CancelMakerQuoteError}
+ * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const snapshot = await cancelMakerQuote(client, {
+ *   rfqId: 'rfq-123',
+ *   quoteId,
+ * });
+ *
+ * console.log(snapshot.status);
+ * ```
+ */
+export async function cancelMakerQuote(
+  client: BaseSecureClient,
+  params: CancelMakerQuoteParams,
+): Promise<MakerRfqSnapshot> {
+  const input = parseUserInput(params, CancelMakerQuoteParamsSchema);
+  const identity = resolveOrderIdentity(client.account);
+  const request: MakerQuoteCancelRequest = {
+    maker_address: identity.maker,
+    quote_id: input.quoteId,
+    rfq_id: input.rfqId,
+    signature_type: identity.signatureType,
+    signer_address: identity.signer,
+  };
+
+  return unwrap(
+    client.secureRfq
+      .post(MAKER_QUOTES_CANCEL_PATH, { json: request })
+      .andThen(validateWith(MakerRfqSnapshotSchema))
+      .mapErr((error) =>
+        toMakerRejection(
+          error,
+          RfqCancelQuoteRejectedError,
+          input.rfqId,
+          input.quoteId,
+        ),
+      ),
+  );
+}
+
+const SubmitMakerConfirmationParamsSchema = z.strictObject({
+  rfqId: z.string().min(1).transform(toRfqId),
+  quoteId: z.string().min(1).transform(toRfqQuoteId),
+  decision: z.enum(RfqConfirmationDecision),
+});
+
+export type SubmitMakerConfirmationParams = {
+  /** RFQ identifier awaiting the maker's confirmation. */
+  rfqId: string;
+  /** Quote identifier the confirmation request names. */
+  quoteId: string;
+  /** Whether to confirm or decline the fill. */
+  decision: RfqConfirmationDecision;
+};
+
+export type SubmitMakerConfirmationError =
+  | RateLimitError
+  | RfqConfirmationRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const SubmitMakerConfirmationError = makeErrorGuard(
+  RateLimitError,
+  RfqConfirmationRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Responds to a last-look confirmation request over HTTP.
+ *
+ * @remarks
+ * Confirmation requests themselves are only delivered through
+ * {@link openRfqSession}; this endpoint is the response channel. The
+ * confirmation window is short (roughly one second in production), so
+ * respond immediately. A non-final confirmation returns a snapshot; the
+ * final confirming maker receives the execution handoff instead. Declining
+ * fails the entire RFQ.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client
+ * instance API.
+ *
+ * @throws {@link SubmitMakerConfirmationError}
+ * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const result = await submitMakerConfirmation(client, {
+ *   rfqId: request.rfqId,
+ *   quoteId,
+ *   decision: RfqConfirmationDecision.Confirm,
+ * });
+ *
+ * if (result.execution) {
+ *   console.log('final confirmation', result.execution.executionId);
+ * }
+ * ```
+ */
+export async function submitMakerConfirmation(
+  client: BaseSecureClient,
+  params: SubmitMakerConfirmationParams,
+): Promise<MakerConfirmationResult> {
+  const input = parseUserInput(params, SubmitMakerConfirmationParamsSchema);
+  const identity = resolveOrderIdentity(client.account);
+  // responded_at is deliberately not sent: the server treats a non-zero
+  // client value as the response time for confirmation-window accounting.
+  const request: MakerConfirmationRequest = {
+    decision: input.decision,
+    maker_address: identity.maker,
+    quote_id: input.quoteId,
+    rfq_id: input.rfqId,
+    signature_type: identity.signatureType,
+    signer_address: identity.signer,
+  };
+
+  return unwrap(
+    client.secureRfq
+      .post(MAKER_CONFIRMATIONS_PATH, { json: request })
+      .andThen(validateWith(MakerConfirmationResultSchema))
+      .mapErr((error) =>
+        toMakerRejection(
+          error,
+          RfqConfirmationRejectedError,
+          input.rfqId,
+          input.quoteId,
+        ),
+      ),
+  );
+}
+
+type MakerRejectionClass<T> = new (
+  message: string,
+  options: ErrorOptions & { quoteId: RfqQuoteId; rfqId: RfqId },
+) => T;
+
+// Maker endpoint error bodies carry a message but no machine code, unlike
+// the streaming session and the builder gateway, so the rejection keeps the
+// message and leaves `code` unset.
+function toMakerRejection<T>(
+  error:
+    | RateLimitError
+    | RequestRejectedError
+    | TransportError
+    | UnexpectedResponseError,
+  RejectionClass: MakerRejectionClass<T>,
+  rfqId: RfqId,
+  quoteId: RfqQuoteId,
+): T | RateLimitError | TransportError | UnexpectedResponseError {
+  if (error instanceof RequestRejectedError) {
+    return new RejectionClass(error.message, { cause: error, quoteId, rfqId });
+  }
+
+  return error;
 }

--- a/packages/client/src/clients.ts
+++ b/packages/client/src/clients.ts
@@ -581,6 +581,11 @@ class BaseSecureClient<
         }),
         root: config.environment.clob.rest,
       }),
+      secureRfq: new ServiceClient({
+        headers: config.environment.combos.headers,
+        resolveHeaders: (request) => this.#createL2Headers(request),
+        root: config.environment.combos.rest,
+      }),
       combos: new ServiceClient({
         headers: config.environment.combos.collateralReturn.headers,
         resolveHeaders: (request) => this.resolveRelayerHeaders(request),
@@ -662,6 +667,11 @@ class BaseSecureClient<
   /** @internal */
   get secureClob(): ServiceClient {
     return this.context.secureClob;
+  }
+
+  /** @internal */
+  get secureRfq(): ServiceClient {
+    return this.context.secureRfq;
   }
 
   /** @internal */
@@ -839,6 +849,8 @@ type SecureContext = PublicContext & {
   signer: Signer;
   /** @internal */
   secureClob: ServiceClient;
+  /** @internal */
+  secureRfq: ServiceClient;
   /** @internal */
   combos: ServiceClient;
   /** @internal */

--- a/packages/client/src/decorators/rfq.ts
+++ b/packages/client/src/decorators/rfq.ts
@@ -1,16 +1,25 @@
 import type {
   AcceptComboQuoteParams,
   AcceptComboQuoteResult,
+  CancelMakerQuoteParams,
+  MakerConfirmationResult,
+  MakerRfqSnapshot,
   RequestComboQuoteParams,
   RequestComboQuoteResult,
   RfqSession,
+  SubmitMakerConfirmationParams,
+  SubmitMakerQuoteParams,
+  SubmitMakerQuoteResult,
   WaitForComboFillParams,
   WaitForComboFillResult,
 } from '../actions';
 import {
   acceptComboQuote,
+  cancelMakerQuote,
   openRfqSession,
   requestComboQuote,
+  submitMakerConfirmation,
+  submitMakerQuote,
   waitForComboFill,
 } from '../actions';
 import type { BaseSecureClient } from '../clients';
@@ -19,6 +28,11 @@ export type {
   BuilderRfqError,
   ComboQuote,
   FetchRfqStatusParams,
+  MakerConfirmationEntry,
+  MakerExecutionHandoff,
+  MakerFillAllocation,
+  MakerFillBundle,
+  MakerRfqRequest,
   RfqCancelQuoteAck,
   RfqCancelQuoteRejectedErrorOptions,
   RfqConfirmationAck,
@@ -45,9 +59,11 @@ export type {
 } from '../actions/rfq';
 export {
   AcceptComboQuoteError,
+  CancelMakerQuoteError,
   ComboAcceptFailureReason,
   ComboQuoteUnavailableReason,
   FetchRfqStatusError,
+  MakerRfqStatus,
   OpenRfqSessionError,
   RequestComboQuoteError,
   RfqCancelQuoteError,
@@ -65,13 +81,21 @@ export {
   RfqRequestRejectedError,
   RfqSide,
   RfqStatus,
+  SubmitMakerConfirmationError,
+  SubmitMakerQuoteError,
   WaitForComboFillError,
 } from '../actions/rfq';
 export type {
   AcceptComboQuoteParams,
   AcceptComboQuoteResult,
+  CancelMakerQuoteParams,
+  MakerConfirmationResult,
+  MakerRfqSnapshot,
   RequestComboQuoteParams,
   RequestComboQuoteResult,
+  SubmitMakerConfirmationParams,
+  SubmitMakerQuoteParams,
+  SubmitMakerQuoteResult,
   WaitForComboFillParams,
   WaitForComboFillResult,
 };
@@ -315,6 +339,79 @@ export type SecureRfqActions = {
   waitForComboFill(
     params: WaitForComboFillParams,
   ): Promise<WaitForComboFillResult>;
+
+  /**
+   * Submits a maker quote for an open RFQ over HTTP.
+   *
+   * @remarks
+   * The request/response alternative to quoting through
+   * {@link SecureRfqActions.openRfqSession | openRfqSession}. Quote
+   * submission and cancellation work fully over HTTP, but last-look
+   * confirmation requests are only delivered through the streaming session;
+   * keep one open to observe them. There is no endpoint for listing resting
+   * quotes; keep the returned `quoteId`, later calls key on it.
+   *
+   * @throws {@link SubmitMakerQuoteError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const { quoteId, snapshot } = await client.submitMakerQuote({
+   *   rfqId: event.rfqId,
+   *   direction: event.direction,
+   *   yesPositionId: event.yesPositionId,
+   *   noPositionId: event.noPositionId,
+   *   requestedSize: event.requestedSize,
+   *   price: 0.45,
+   * });
+   * ```
+   */
+  submitMakerQuote(
+    params: SubmitMakerQuoteParams,
+  ): Promise<SubmitMakerQuoteResult>;
+
+  /**
+   * Cancels a resting maker quote over HTTP.
+   *
+   * @remarks
+   * Clean and idempotent while the RFQ is collecting quotes. Once last look
+   * has started, cancellation is treated as a decline: it fails the entire
+   * RFQ and counts toward the maker's decline limits.
+   *
+   * @throws {@link CancelMakerQuoteError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const snapshot = await client.cancelMakerQuote({ rfqId, quoteId });
+   * ```
+   */
+  cancelMakerQuote(params: CancelMakerQuoteParams): Promise<MakerRfqSnapshot>;
+
+  /**
+   * Responds to a last-look confirmation request over HTTP.
+   *
+   * @remarks
+   * Confirmation requests are delivered through the streaming session; this
+   * is the response channel. The window is short, so respond immediately.
+   * The final confirming maker receives the execution handoff instead of a
+   * snapshot.
+   *
+   * @throws {@link SubmitMakerConfirmationError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const result = await client.submitMakerConfirmation({
+   *   rfqId,
+   *   quoteId,
+   *   decision: RfqConfirmationDecision.Confirm,
+   * });
+   * ```
+   */
+  submitMakerConfirmation(
+    params: SubmitMakerConfirmationParams,
+  ): Promise<MakerConfirmationResult>;
 };
 
 export function rfqActions(client: BaseSecureClient): SecureRfqActions {
@@ -330,6 +427,15 @@ export function rfqActions(client: BaseSecureClient): SecureRfqActions {
     },
     waitForComboFill(params: WaitForComboFillParams) {
       return waitForComboFill(client, params);
+    },
+    submitMakerQuote(params: SubmitMakerQuoteParams) {
+      return submitMakerQuote(client, params);
+    },
+    cancelMakerQuote(params: CancelMakerQuoteParams) {
+      return cancelMakerQuote(client, params);
+    },
+    submitMakerConfirmation(params: SubmitMakerConfirmationParams) {
+      return submitMakerConfirmation(client, params);
     },
   };
 }

--- a/packages/client/src/websockets/rfq/quote.ts
+++ b/packages/client/src/websockets/rfq/quote.ts
@@ -40,11 +40,24 @@ export type ParsedRfqQuoteResponse = {
   source: RfqQuoteSource;
 };
 
+/**
+ * The subset of an RFQ request the quote math needs. The WS session passes
+ * its full {@link RfqQuoteRequest}; the maker REST actions construct it from
+ * caller-supplied fields. `requestedSize` is only consulted when the
+ * response omits an explicit size.
+ */
+export type QuoteOrderInputs = Pick<
+  RfqQuoteRequest,
+  'direction' | 'noPositionId' | 'yesPositionId'
+> & {
+  requestedSize?: RfqRequestedSize;
+};
+
 export type CreateRfqQuoteParams = {
   account: AccountIdentity;
   chainId: number;
   exchange: EvmAddress;
-  request: RfqQuoteRequest;
+  request: QuoteOrderInputs;
   response: ParsedRfqQuoteResponse;
   signer: Signer;
 };
@@ -67,7 +80,7 @@ export async function createRfqQuote(
   const price = params.response.price;
   const size =
     params.response.size === undefined
-      ? defaultQuoteSize(params.request.requestedSize, price)
+      ? defaultQuoteSizeFromRequest(params.request.requestedSize, price)
       : params.response.size;
   const signedOrder = await signRfqQuoteOrder({
     account: params.account,
@@ -84,7 +97,7 @@ export async function createRfqQuote(
 }
 
 function quoteOrderTokenId(
-  request: RfqQuoteRequest,
+  request: QuoteOrderInputs,
   source: RfqQuoteSource,
 ): PositionId {
   if (request.direction === RfqDirection.Buy) {
@@ -97,7 +110,7 @@ function quoteOrderTokenId(
 }
 
 function quoteOrderPrice(
-  request: RfqQuoteRequest,
+  request: QuoteOrderInputs,
   source: RfqQuoteSource,
   price: bigint,
 ): bigint {
@@ -110,6 +123,19 @@ function quoteOrderPrice(
 
 function quoteOrderSide(source: RfqQuoteSource): OrderSide {
   return source === 'collateral' ? OrderSide.BUY : OrderSide.SELL;
+}
+
+function defaultQuoteSizeFromRequest(
+  requestedSize: RfqRequestedSize | undefined,
+  price: bigint,
+): bigint {
+  if (requestedSize === undefined) {
+    throw new UserInputError(
+      'A quote size is required when the requested RFQ size is not provided.',
+    );
+  }
+
+  return defaultQuoteSize(requestedSize, price);
 }
 
 function defaultQuoteSize(


### PR DESCRIPTION
## Summary

Adds the maker-side HTTP quote lifecycle as the request/response alternative to the quoter WebSocket session: `submitMakerQuote`, `cancelMakerQuote`, and `submitMakerConfirmation` on the secure client, posting to `/v1/maker/quotes`, `/v1/maker/quotes/cancel`, and `/v1/maker/confirmations` with the CLOB L2 headers (new `secureRfq` service client, same split as `clob`/`secureClob`).

The docs already show these REST endpoints on the market-makers page with no SDK methods next to them; this closes that gap.

## Design points worth review attention

* **HTTP is a hybrid channel, not a replacement.** Last-look confirmation requests are only delivered over the streaming session, and the production window is about one second. The TSDoc positions `submitMakerConfirmation` as the response channel and points long-lived makers at `openRfqSession()`. There is also no REST endpoint to list resting quotes, so `submitMakerQuote` returns the generated `quoteId` and the docs say to keep it.
* **Quote ids are client-generated on this path.** The server only checks non-emptiness and never echoes the id back (the snapshot's top-level `quote_id` is an unrelated legacy field, deliberately not modeled). Ids are `quote_` + 16 random bytes hex, matching the server's own format and the SDK's `getRandomValues` convention.
* **Response schemas are written from the engine's custom JSON marshalers, not its struct tags.** E6 amounts are decimal strings on the wire, timestamps are epoch millis omitted when zero. The snapshot models the maker-relevant subset; the execution handoff deliberately omits engine internals (other makers' signed orders, reservations).
* **`MakerConfirmationResult` is `{snapshot?, execution?}`** — a non-final CONFIRM returns a snapshot, the final confirming maker gets the execution handoff instead.
* **These endpoints return codeless error bodies** (`{"error": "message"}`), unlike the session and the builder gateway, so rejections map by message/status into the existing `Rfq*RejectedError` classes with `code` unset.
* **`responded_at` is never sent** on confirmations: the server trusts a non-zero client value for confirmation-window accounting.
* **Cancel semantics documented on the method**: idempotent while collecting quotes; a cancel during last look converts to a decline that fails the whole RFQ and counts toward the maker's decline limits.

## Reuse

The order math and signing are the existing session paths (`createRfqQuote`/`signRfqQuoteOrder`) — the only change to shipped code is widening the quote-math input type (`QuoteOrderInputs`) plus a guard when neither a size nor the requested size is known, so both channels produce identical signed orders.

## Testing

* 8 schema fixture tests (wire transforms, strict status enum rejection, legacy `quote_id` exclusion, empty/execution-only confirmation results)
* 6 action tests (wire bodies and paths, id format, size defaulting from the requested notional, codeless-rejection mapping, `responded_at` absence)
* `pnpm build`, `typecheck`, `test:bindings` (122), `test:client` (344), `lint` all green

Refs DEV-593. Python port follows as DEV-596.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signed maker quotes and L2-authenticated RFQ endpoints, so wire-shape or confirmation-window mistakes can fail fills or count as declines. Existing session signing is reused rather than rewritten.
> 
> **Overview**
> Makers can now submit, cancel, and confirm RFQ quotes over HTTP on the secure client (`submitMakerQuote`, `cancelMakerQuote`, `submitMakerConfirmation`), posting to `/v1/maker/quotes*` with CLOB L2 headers via a new `secureRfq` client.
> 
> This is a hybrid channel, not a WS replacement: last-look requests still arrive only on `openRfqSession`. Quote IDs are client-generated (`quote_` + 16 random bytes) and returned from submit because the snapshot does not echo them. Confirmations omit `responded_at`; the final confirming maker gets an execution handoff instead of a snapshot.
> 
> Bindings parse engine snapshots into camelCase decimals and drop legacy/internal fields (top-level `quote_id`, other makers’ signed orders). Codeless HTTP errors map onto existing `Rfq*RejectedError` types with `code` unset. Quote math/signing reuses the session path, widened to `QuoteOrderInputs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455397a87e943f6ee22e834daec58e1893eb7c18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->