### PR TITLE
feat(sdk): normalize Data API identifiers for PolyV2

### DIFF
--- a/.changeset/dev-544-data-api-identifiers.md
+++ b/.changeset/dev-544-data-api-identifiers.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': minor
+'@polymarket/client': minor
+---
+
+Add protocol-neutral `assetId` and `conditionId` fields to Data API responses while retaining deprecated identifier aliases.

--- a/examples/scripts/src/list-positions.ts
+++ b/examples/scripts/src/list-positions.ts
@@ -22,7 +22,7 @@ for await (const page of positions) {
       curPrice: position.curPrice ?? '',
       redeemable: position.redeemable ?? false,
       mergeable: position.mergeable ?? false,
-      tokenId: position.tokenId ?? '',
+      assetId: position.assetId ?? '',
     })),
   );
 }

--- a/packages/bindings/src/data/activity.test.ts
+++ b/packages/bindings/src/data/activity.test.ts
@@ -3,6 +3,34 @@ import { ActivitySchema } from './activity';
 import { ActivityType } from './common';
 
 describe('ActivitySchema', () => {
+  it('normalizes ordinary trade assets without assuming the protocol', () => {
+    const assetId = '456';
+    const activity = ActivitySchema.parse({
+      proxyWallet: `0x${'1'.repeat(40)}`,
+      timestamp: 1_700_000_000,
+      type: ActivityType.TRADE,
+      side: 'BUY',
+      size: 10,
+      usdcSize: 5,
+      price: 0.5,
+      asset: assetId,
+      conditionId: `0x${'a'.repeat(64)}`,
+      outcome: 'Yes',
+      outcomeIndex: 0,
+      title: 'Will this normalize?',
+      slug: 'will-this-normalize',
+      eventSlug: 'normalization-event',
+      transactionHash: `0x${'b'.repeat(64)}`,
+    });
+
+    expect(activity).toMatchObject({
+      type: ActivityType.TRADE,
+      isCombo: false,
+      assetId,
+      tokenId: assetId,
+    });
+  });
+
   it.each([
     ActivityType.DEPOSIT,
     ActivityType.WITHDRAWAL,

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -1,3 +1,4 @@
+import type { EvmAddress } from '@polymarket/types';
 import { z } from 'zod';
 import {
   ClobAssetIdSchema,
@@ -11,6 +12,7 @@ import {
   type DecimalString,
   type EpochMilliseconds,
   EpochSecondsToMillisecondsSchema,
+  EvmAddressSchema,
   emptyStringToNull,
   type IsoDateTimeString,
   IsoDateTimeStringSchema,
@@ -24,8 +26,6 @@ import {
 import {
   ActivityType,
   ActivityTypeSchema,
-  type Address,
-  AddressSchema,
   type Side,
   SideSchema,
 } from './common';
@@ -45,7 +45,7 @@ const ComboActivityTypeSchema = z.enum(ComboActivityType);
 
 export type ActivityBase = {
   /** Wallet address whose account history contains this activity. */
-  wallet: Address;
+  wallet: EvmAddress;
   /** Activity time as Unix epoch milliseconds. */
   timestamp: EpochMilliseconds;
   /** Polygon transaction hash that produced or records this activity. */
@@ -248,7 +248,7 @@ type ComboActivityBase = {
   /** Normalized lifecycle activity type. */
   type: ComboActivityType;
   /** Wallet address whose account history contains this activity. */
-  wallet: Address;
+  wallet: EvmAddress;
   /** Combo condition id involved in this activity. */
   conditionId: ComboConditionId;
   /** Combo module id. */
@@ -313,7 +313,7 @@ export type ComboActivity =
 const RawComboActivitySchema = z.object({
   id: ComboActivityIdSchema,
   type: ComboActivityTypeSchema,
-  user_address: AddressSchema,
+  user_address: EvmAddressSchema,
   combo_condition_id: ComboConditionIdSchema,
   combo_position_id: PositionIdSchema,
   module_id: z.number().int(),
@@ -336,7 +336,7 @@ const OptionalTextSchema = z.preprocess(
 );
 
 export type Trade = {
-  wallet: Address | null | undefined;
+  wallet: EvmAddress | null | undefined;
   /** Outcome identifier for a CTF token or Polymarket V2 position. */
   assetId: TokenId | PositionId | null | undefined;
   /** @deprecated Use `assetId`. */
@@ -362,7 +362,7 @@ export type Trade = {
 
 export const TradeSchema = z
   .object({
-    proxyWallet: AddressSchema.nullish(),
+    proxyWallet: EvmAddressSchema.nullish(),
     side: SideSchema.nullish(),
     asset: ClobAssetIdSchema.nullish(),
     conditionId: ConditionIdSchema.nullish(),
@@ -390,7 +390,7 @@ export const TradeSchema = z
   })) satisfies z.ZodType<Trade>;
 
 const RawActivitySchema = z.object({
-  proxyWallet: AddressSchema.nullish(),
+  proxyWallet: EvmAddressSchema.nullish(),
   timestamp: EpochSecondsToMillisecondsSchema.nullish(),
   conditionId: z.preprocess(
     (value) => (value === '' ? undefined : value),
@@ -430,7 +430,7 @@ export const ActivitySchema: z.ZodType<Activity> =
   RawActivitySchema.transform(normalizeActivity);
 
 export const TradedSchema = z.object({
-  user: AddressSchema.nullish(),
+  user: EvmAddressSchema.nullish(),
   traded: z.number().int().nullish(),
 });
 

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+  ClobAssetIdSchema,
   type ComboActivityId,
   ComboActivityIdSchema,
   type ComboConditionId,
@@ -17,7 +18,6 @@ import {
   type PositionId,
   PositionIdSchema,
   type TokenId,
-  TokenIdSchema,
   type TxHash,
   TxHashSchema,
 } from '../shared';
@@ -63,9 +63,9 @@ export type ActivityBase = {
 };
 
 type TradeActivityBase = ActivityBase & {
-  /** A directional outcome-token trade. */
+  /** A directional outcome trade. */
   type: ActivityType.TRADE;
-  /** Whether this trade is for a Combo position instead of a binary market token. */
+  /** Whether this trade is for a Combo position instead of an ordinary market. */
   isCombo: boolean;
   /** Direction of the wallet's trade. */
   side: Side;
@@ -82,15 +82,17 @@ type TradeActivityBase = ActivityBase & {
 };
 
 export type ClobTradeActivity = TradeActivityBase & {
-  /** CLOB market trades are binary market outcome-token trades. */
+  /** Ordinary market trades are distinct from Combo position trades. */
   isCombo: false;
   /** Condition id of the market traded by the wallet. */
   conditionId: ConditionId;
-  /** Outcome token id bought or sold by the wallet. */
-  tokenId: TokenId;
-  /** Display label of the outcome token traded by the wallet. */
+  /** Outcome identifier for a CTF token or Polymarket V2 position. */
+  assetId: TokenId | PositionId;
+  /** @deprecated Use `assetId`. */
+  tokenId: TokenId | PositionId;
+  /** Display label of the outcome traded by the wallet. */
   outcome: string;
-  /** Zero-based index of the outcome token in the market's outcome list. */
+  /** Zero-based index of the outcome in the market's outcome list. */
   outcomeIndex: number;
   /** URL slug of the market traded by the wallet. */
   slug: string;
@@ -333,11 +335,36 @@ const OptionalTextSchema = z.preprocess(
   z.string().optional(),
 );
 
+export type Trade = {
+  wallet: Address | null | undefined;
+  /** Outcome identifier for a CTF token or Polymarket V2 position. */
+  assetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `assetId`. */
+  tokenId: TokenId | PositionId | null | undefined;
+  side?: Side | null;
+  conditionId?: ConditionId | null;
+  size?: DecimalString | null;
+  price?: DecimalString | null;
+  timestamp?: EpochMilliseconds | null;
+  title?: string | null;
+  slug?: string | null;
+  icon?: string | null;
+  eventSlug?: string | null;
+  outcome?: string | null;
+  outcomeIndex?: number | null;
+  name?: string | null;
+  pseudonym?: string | null;
+  bio?: string | null;
+  profileImage?: string | null;
+  profileImageOptimized?: string | null;
+  transactionHash?: string | null;
+};
+
 export const TradeSchema = z
   .object({
     proxyWallet: AddressSchema.nullish(),
     side: SideSchema.nullish(),
-    asset: TokenIdSchema.nullish(),
+    asset: ClobAssetIdSchema.nullish(),
     conditionId: ConditionIdSchema.nullish(),
     size: DecimalishSchema.nullish(),
     price: DecimalishSchema.nullish(),
@@ -358,15 +385,16 @@ export const TradeSchema = z
   .transform(({ asset, proxyWallet, ...rest }) => ({
     ...rest,
     wallet: proxyWallet,
+    assetId: asset,
     tokenId: asset,
-  }));
+  })) satisfies z.ZodType<Trade>;
 
 const RawActivitySchema = z.object({
   proxyWallet: AddressSchema.nullish(),
   timestamp: EpochSecondsToMillisecondsSchema.nullish(),
   conditionId: z.preprocess(
     (value) => (value === '' ? undefined : value),
-    z.string().optional(),
+    ConditionIdSchema.optional(),
   ),
   type: ActivityTypeSchema,
   size: DecimalishSchema.nullish(),
@@ -375,7 +403,7 @@ const RawActivitySchema = z.object({
   price: DecimalishSchema.nullish(),
   asset: z.preprocess(
     (value) => (value === '' ? undefined : value),
-    z.string().optional(),
+    ClobAssetIdSchema.optional(),
   ),
   side: z.preprocess(
     (value) => (value === '' ? undefined : value),
@@ -428,7 +456,6 @@ export const ListComboActivityResponseSchema = z
     },
   }));
 
-export type Trade = z.infer<typeof TradeSchema>;
 export type Traded = z.infer<typeof TradedSchema>;
 export type ListTradesResponse = z.infer<typeof ListTradesResponseSchema>;
 export type ListActivityResponse = z.infer<typeof ListActivityResponseSchema>;
@@ -497,9 +524,7 @@ function normalizeActivity(activity: RawActivity): Activity {
       return {
         ...base,
         type: activity.type,
-        conditionId: ConditionIdSchema.parse(
-          expectPresent(activity.conditionId, 'conditionId'),
-        ),
+        conditionId: expectPresent(activity.conditionId, 'conditionId'),
         amount: inferAmount(activity),
         title: expectPresent(activity.title, 'title'),
         slug: expectPresent(activity.slug, 'slug'),
@@ -549,13 +574,14 @@ function normalizeTradeActivity(
     };
   }
 
+  const assetId = expectPresent(activity.asset, 'asset');
+
   return {
     ...trade,
     isCombo: false,
-    conditionId: ConditionIdSchema.parse(
-      expectPresent(activity.conditionId, 'conditionId'),
-    ),
-    tokenId: TokenIdSchema.parse(expectPresent(activity.asset, 'asset')),
+    conditionId: expectPresent(activity.conditionId, 'conditionId'),
+    assetId,
+    tokenId: assetId,
     outcome: expectPresent(activity.outcome, 'outcome'),
     outcomeIndex: expectPresent(activity.outcomeIndex, 'outcomeIndex'),
     slug: expectPresent(activity.slug, 'slug'),

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -1,3 +1,4 @@
+import type { EvmAddress } from '@polymarket/types';
 import { z } from 'zod';
 import {
   ClobAssetIdSchema,
@@ -5,13 +6,13 @@ import {
   ConditionIdSchema,
   DecimalishSchema,
   type DecimalString,
+  EvmAddressSchema,
   type PositionId,
   type TokenId,
 } from '../shared';
-import { type Address, AddressSchema } from './common';
 
 export type Holder = {
-  wallet: Address | null | undefined;
+  wallet: EvmAddress | null | undefined;
   /** Outcome identifier for a CTF token or Polymarket V2 position. */
   assetId: TokenId | PositionId | null | undefined;
   /** @deprecated Use `assetId`. */
@@ -28,7 +29,7 @@ export type Holder = {
 
 export const HolderSchema = z
   .object({
-    proxyWallet: AddressSchema.nullish(),
+    proxyWallet: EvmAddressSchema.nullish(),
     bio: z.string().nullish(),
     asset: ClobAssetIdSchema.nullish(),
     pseudonym: z.string().nullish(),

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -1,12 +1,36 @@
 import { z } from 'zod';
-import { DecimalishSchema, TokenIdSchema } from '../shared';
-import { AddressSchema, Hash64Schema } from './common';
+import {
+  ClobAssetIdSchema,
+  type ConditionId,
+  ConditionIdSchema,
+  DecimalishSchema,
+  type DecimalString,
+  type PositionId,
+  type TokenId,
+} from '../shared';
+import { type Address, AddressSchema } from './common';
+
+export type Holder = {
+  wallet: Address | null | undefined;
+  /** Outcome identifier for a CTF token or Polymarket V2 position. */
+  assetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `assetId`. */
+  tokenId: TokenId | PositionId | null | undefined;
+  bio?: string | null;
+  pseudonym?: string | null;
+  amount?: DecimalString | null;
+  displayUsernamePublic?: boolean | null;
+  outcomeIndex?: number | null;
+  name?: string | null;
+  profileImage?: string | null;
+  profileImageOptimized?: string | null;
+};
 
 export const HolderSchema = z
   .object({
     proxyWallet: AddressSchema.nullish(),
     bio: z.string().nullish(),
-    asset: TokenIdSchema.nullish(),
+    asset: ClobAssetIdSchema.nullish(),
     pseudonym: z.string().nullish(),
     amount: DecimalishSchema.nullish(),
     displayUsernamePublic: z.boolean().nullish(),
@@ -18,23 +42,66 @@ export const HolderSchema = z
   .transform(({ asset, proxyWallet, ...rest }) => ({
     ...rest,
     wallet: proxyWallet,
+    assetId: asset,
     tokenId: asset,
-  }));
+  })) satisfies z.ZodType<Holder>;
 
-export const MetaHolderSchema = z.object({
-  token: z.string().nullish(),
-  holders: z.array(HolderSchema).nullish(),
-});
+export type MetaHolder = {
+  /** Outcome identifier for a CTF token or Polymarket V2 position. */
+  assetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `assetId`. */
+  token: TokenId | PositionId | null | undefined;
+  holders?: Holder[] | null;
+};
 
-export const OpenInterestSchema = z.object({
-  market: Hash64Schema.nullish(),
-  value: DecimalishSchema.nullish(),
-});
+export const MetaHolderSchema = z
+  .object({
+    token: ClobAssetIdSchema.nullish(),
+    holders: z.array(HolderSchema).nullish(),
+  })
+  .transform(({ token, ...rest }) => ({
+    ...rest,
+    assetId: token,
+    token,
+  })) satisfies z.ZodType<MetaHolder>;
 
-export const MarketVolumeSchema = z.object({
-  market: Hash64Schema.nullish(),
-  value: DecimalishSchema.nullish(),
-});
+export type OpenInterest = {
+  /** Condition ID of the market whose open interest is reported. */
+  conditionId: ConditionId | null | undefined;
+  /** @deprecated Use `conditionId`. */
+  market: ConditionId | null | undefined;
+  value?: DecimalString | null;
+};
+
+export const OpenInterestSchema = z
+  .object({
+    market: ConditionIdSchema.nullish(),
+    value: DecimalishSchema.nullish(),
+  })
+  .transform(({ market, ...rest }) => ({
+    ...rest,
+    conditionId: market,
+    market,
+  })) satisfies z.ZodType<OpenInterest>;
+
+export type MarketVolume = {
+  /** Condition ID of the market whose live volume is reported. */
+  conditionId: ConditionId | null | undefined;
+  /** @deprecated Use `conditionId`. */
+  market: ConditionId | null | undefined;
+  value?: DecimalString | null;
+};
+
+export const MarketVolumeSchema = z
+  .object({
+    market: ConditionIdSchema.nullish(),
+    value: DecimalishSchema.nullish(),
+  })
+  .transform(({ market, ...rest }) => ({
+    ...rest,
+    conditionId: market,
+    market,
+  })) satisfies z.ZodType<MarketVolume>;
 
 export const LiveVolumeSchema = z.object({
   total: DecimalishSchema.nullish(),
@@ -45,10 +112,6 @@ export const ListMarketHoldersResponseSchema = z.array(MetaHolderSchema);
 export const ListOpenInterestResponseSchema = z.array(OpenInterestSchema);
 export const FetchEventLiveVolumeResponseSchema = z.array(LiveVolumeSchema);
 
-export type Holder = z.infer<typeof HolderSchema>;
-export type MetaHolder = z.infer<typeof MetaHolderSchema>;
-export type OpenInterest = z.infer<typeof OpenInterestSchema>;
-export type MarketVolume = z.infer<typeof MarketVolumeSchema>;
 export type LiveVolume = z.infer<typeof LiveVolumeSchema>;
 export type ListMarketHoldersResponse = z.infer<
   typeof ListMarketHoldersResponseSchema

--- a/packages/bindings/src/data/common.ts
+++ b/packages/bindings/src/data/common.ts
@@ -1,7 +1,5 @@
 import { z } from 'zod';
 
-export const AddressSchema = z.string();
-
 export enum ActivityType {
   TRADE = 'TRADE',
   SPLIT = 'SPLIT',
@@ -38,7 +36,6 @@ export const LeaderboardCategorySchema = z.enum([
 
 export const LeaderboardOrderBySchema = z.enum(['PNL', 'VOL']);
 
-export type Address = z.infer<typeof AddressSchema>;
 export type Side = z.infer<typeof SideSchema>;
 export type TimePeriod = z.infer<typeof TimePeriodSchema>;
 export type LeaderboardCategory = z.infer<typeof LeaderboardCategorySchema>;

--- a/packages/bindings/src/data/common.ts
+++ b/packages/bindings/src/data/common.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 export const AddressSchema = z.string();
-export const Hash64Schema = z.string();
 
 export enum ActivityType {
   TRADE = 'TRADE',
@@ -40,7 +39,6 @@ export const LeaderboardCategorySchema = z.enum([
 export const LeaderboardOrderBySchema = z.enum(['PNL', 'VOL']);
 
 export type Address = z.infer<typeof AddressSchema>;
-export type Hash64 = z.infer<typeof Hash64Schema>;
 export type Side = z.infer<typeof SideSchema>;
 export type TimePeriod = z.infer<typeof TimePeriodSchema>;
 export type LeaderboardCategory = z.infer<typeof LeaderboardCategorySchema>;

--- a/packages/bindings/src/data/leaderboard.ts
+++ b/packages/bindings/src/data/leaderboard.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
-import { DecimalishSchema, IsoDateTimeStringSchema } from '../shared';
-import { AddressSchema } from './common';
+import {
+  DecimalishSchema,
+  EvmAddressSchema,
+  IsoDateTimeStringSchema,
+} from '../shared';
 
 export const LeaderboardEntrySchema = z.object({
   rank: z.string().nullish(),
@@ -29,7 +32,7 @@ export const BuilderVolumeEntrySchema = z
 export const TraderLeaderboardEntrySchema = z
   .object({
     rank: z.string().nullish(),
-    proxyWallet: AddressSchema.nullish(),
+    proxyWallet: EvmAddressSchema.nullish(),
     userName: z.string().nullish(),
     vol: DecimalishSchema.nullish(),
     pnl: DecimalishSchema.nullish(),

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -1,3 +1,4 @@
+import type { EvmAddress } from '@polymarket/types';
 import { z } from 'zod';
 import {
   ClobAssetIdSchema,
@@ -8,6 +9,7 @@ import {
   type DecimalString,
   type EpochMilliseconds,
   EpochSecondsToMillisecondsSchema,
+  EvmAddressSchema,
   emptyStringToNull,
   type IsoCalendarDateString,
   IsoCalendarDateStringSchema,
@@ -19,7 +21,6 @@ import {
   PositionIdSchema,
   type TokenId,
 } from '../shared';
-import { type Address, AddressSchema } from './common';
 
 export enum ComboPositionStatus {
   Open = 'OPEN',
@@ -39,7 +40,7 @@ export enum ComboPositionOutcome {
 export const ComboPositionOutcomeSchema = z.enum(ComboPositionOutcome);
 
 export type Position = {
-  wallet: Address | null | undefined;
+  wallet: EvmAddress | null | undefined;
   /** Outcome identifier for a CTF token or Polymarket V2 position. */
   assetId: TokenId | PositionId | null | undefined;
   /** @deprecated Use `assetId`. */
@@ -75,7 +76,7 @@ export type Position = {
 
 export const PositionSchema = z
   .object({
-    proxyWallet: AddressSchema.nullish(),
+    proxyWallet: EvmAddressSchema.nullish(),
     asset: ClobAssetIdSchema.nullish(),
     conditionId: ConditionIdSchema,
     size: DecimalishSchema.nullish(),
@@ -112,7 +113,7 @@ export const PositionSchema = z
   })) satisfies z.ZodType<Position>;
 
 export type ClosedPosition = {
-  wallet: Address | null | undefined;
+  wallet: EvmAddress | null | undefined;
   /** Outcome identifier for a CTF token or Polymarket V2 position. */
   assetId: TokenId | PositionId | null | undefined;
   /** @deprecated Use `assetId`. */
@@ -139,7 +140,7 @@ export type ClosedPosition = {
 
 export const ClosedPositionSchema = z
   .object({
-    proxyWallet: AddressSchema.nullish(),
+    proxyWallet: EvmAddressSchema.nullish(),
     asset: ClobAssetIdSchema.nullish(),
     conditionId: ConditionIdSchema.nullish(),
     avgPrice: DecimalishSchema.nullish(),
@@ -167,12 +168,12 @@ export const ClosedPositionSchema = z
   })) satisfies z.ZodType<ClosedPosition>;
 
 export const ValueSchema = z.object({
-  user: AddressSchema.nullish(),
+  user: EvmAddressSchema.nullish(),
   value: DecimalishSchema.nullish(),
 });
 
 export type MarketPosition = {
-  wallet: Address | null | undefined;
+  wallet: EvmAddress | null | undefined;
   /** Outcome identifier for a CTF token or Polymarket V2 position. */
   assetId: TokenId | PositionId | null | undefined;
   /** @deprecated Use `assetId`. */
@@ -195,7 +196,7 @@ export type MarketPosition = {
 
 export const MarketPositionSchema = z
   .object({
-    proxyWallet: AddressSchema.nullish(),
+    proxyWallet: EvmAddressSchema.nullish(),
     name: z.string().nullish(),
     profileImage: z.string().nullish(),
     verified: z.boolean().nullish(),
@@ -316,7 +317,7 @@ export const ComboPositionSchema = z
     combo_position_id: PositionIdSchema,
     side: ComboPositionOutcomeSchema,
     module_id: z.number().int(),
-    user_address: AddressSchema,
+    user_address: EvmAddressSchema,
     shares_balance: DecimalishSchema,
     entry_avg_price_usdc: DecimalishSchema.nullish(),
     entry_cost_usdc: DecimalishSchema.nullish(),

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -1,18 +1,25 @@
 import { z } from 'zod';
 import {
+  ClobAssetIdSchema,
   ComboConditionIdSchema,
+  type ConditionId,
   ConditionIdSchema,
   DecimalishSchema,
+  type DecimalString,
+  type EpochMilliseconds,
   EpochSecondsToMillisecondsSchema,
   emptyStringToNull,
+  type IsoCalendarDateString,
   IsoCalendarDateStringSchema,
   IsoDateTimeStringSchema,
+  type MixedDateTimeString,
   MixedDateTimeStringSchema,
   PaginationCursorSchema,
+  type PositionId,
   PositionIdSchema,
-  TokenIdSchema,
+  type TokenId,
 } from '../shared';
-import { AddressSchema } from './common';
+import { type Address, AddressSchema } from './common';
 
 export enum ComboPositionStatus {
   Open = 'OPEN',
@@ -31,10 +38,45 @@ export enum ComboPositionOutcome {
 
 export const ComboPositionOutcomeSchema = z.enum(ComboPositionOutcome);
 
+export type Position = {
+  wallet: Address | null | undefined;
+  /** Outcome identifier for a CTF token or Polymarket V2 position. */
+  assetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `assetId`. */
+  tokenId: TokenId | PositionId | null | undefined;
+  conditionId: ConditionId;
+  size?: DecimalString | null;
+  avgPrice?: DecimalString | null;
+  initialValue?: DecimalString | null;
+  currentValue?: DecimalString | null;
+  cashPnl?: DecimalString | null;
+  percentPnl?: number | null;
+  totalBought?: DecimalString | null;
+  realizedPnl?: DecimalString | null;
+  percentRealizedPnl?: number | null;
+  curPrice?: DecimalString | null;
+  redeemable?: boolean | null;
+  mergeable?: boolean | null;
+  title?: string | null;
+  slug?: string | null;
+  icon?: string | null;
+  eventId?: string | null;
+  eventSlug?: string | null;
+  outcome?: string | null;
+  outcomeIndex?: number | null;
+  oppositeOutcome?: string | null;
+  /** Opposite outcome identifier for a CTF token or Polymarket V2 position. */
+  oppositeAssetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `oppositeAssetId`. */
+  oppositeTokenId: TokenId | PositionId | null | undefined;
+  endDate?: IsoCalendarDateString | null;
+  negativeRisk?: boolean | null;
+};
+
 export const PositionSchema = z
   .object({
     proxyWallet: AddressSchema.nullish(),
-    asset: TokenIdSchema.nullish(),
+    asset: ClobAssetIdSchema.nullish(),
     conditionId: ConditionIdSchema,
     size: DecimalishSchema.nullish(),
     avgPrice: DecimalishSchema.nullish(),
@@ -56,21 +98,49 @@ export const PositionSchema = z
     outcome: z.string().nullish(),
     outcomeIndex: z.number().int().nullish(),
     oppositeOutcome: z.string().nullish(),
-    oppositeAsset: TokenIdSchema.nullish(),
+    oppositeAsset: ClobAssetIdSchema.nullish(),
     endDate: IsoCalendarDateStringSchema.nullish(),
     negativeRisk: z.boolean().nullish(),
   })
   .transform(({ asset, oppositeAsset, proxyWallet, ...rest }) => ({
     ...rest,
     wallet: proxyWallet,
+    assetId: asset,
     tokenId: asset,
+    oppositeAssetId: oppositeAsset,
     oppositeTokenId: oppositeAsset,
-  }));
+  })) satisfies z.ZodType<Position>;
+
+export type ClosedPosition = {
+  wallet: Address | null | undefined;
+  /** Outcome identifier for a CTF token or Polymarket V2 position. */
+  assetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `assetId`. */
+  tokenId: TokenId | PositionId | null | undefined;
+  conditionId?: ConditionId | null;
+  avgPrice?: DecimalString | null;
+  totalBought?: DecimalString | null;
+  realizedPnl?: DecimalString | null;
+  curPrice?: DecimalString | null;
+  timestamp?: EpochMilliseconds | null;
+  title?: string | null;
+  slug?: string | null;
+  icon?: string | null;
+  eventSlug?: string | null;
+  outcome?: string | null;
+  outcomeIndex?: number | null;
+  oppositeOutcome?: string | null;
+  /** Opposite outcome identifier for a CTF token or Polymarket V2 position. */
+  oppositeAssetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `oppositeAssetId`. */
+  oppositeTokenId: TokenId | PositionId | null | undefined;
+  endDate?: MixedDateTimeString | null;
+};
 
 export const ClosedPositionSchema = z
   .object({
     proxyWallet: AddressSchema.nullish(),
-    asset: TokenIdSchema.nullish(),
+    asset: ClobAssetIdSchema.nullish(),
     conditionId: ConditionIdSchema.nullish(),
     avgPrice: DecimalishSchema.nullish(),
     totalBought: DecimalishSchema.nullish(),
@@ -84,20 +154,44 @@ export const ClosedPositionSchema = z
     outcome: z.string().nullish(),
     outcomeIndex: z.number().int().nullish(),
     oppositeOutcome: z.string().nullish(),
-    oppositeAsset: TokenIdSchema.nullish(),
+    oppositeAsset: ClobAssetIdSchema.nullish(),
     endDate: MixedDateTimeStringSchema.nullish(),
   })
   .transform(({ asset, oppositeAsset, proxyWallet, ...rest }) => ({
     ...rest,
     wallet: proxyWallet,
+    assetId: asset,
     tokenId: asset,
+    oppositeAssetId: oppositeAsset,
     oppositeTokenId: oppositeAsset,
-  }));
+  })) satisfies z.ZodType<ClosedPosition>;
 
 export const ValueSchema = z.object({
   user: AddressSchema.nullish(),
   value: DecimalishSchema.nullish(),
 });
+
+export type MarketPosition = {
+  wallet: Address | null | undefined;
+  /** Outcome identifier for a CTF token or Polymarket V2 position. */
+  assetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `assetId`. */
+  tokenId: TokenId | PositionId | null | undefined;
+  name?: string | null;
+  profileImage?: string | null;
+  verified?: boolean | null;
+  conditionId?: ConditionId | null;
+  avgPrice?: DecimalString | null;
+  size?: DecimalString | null;
+  currPrice?: DecimalString | null;
+  currentValue?: DecimalString | null;
+  cashPnl?: DecimalString | null;
+  totalBought?: DecimalString | null;
+  realizedPnl?: DecimalString | null;
+  totalPnl?: DecimalString | null;
+  outcome?: string | null;
+  outcomeIndex?: number | null;
+};
 
 export const MarketPositionSchema = z
   .object({
@@ -105,7 +199,7 @@ export const MarketPositionSchema = z
     name: z.string().nullish(),
     profileImage: z.string().nullish(),
     verified: z.boolean().nullish(),
-    asset: TokenIdSchema.nullish(),
+    asset: ClobAssetIdSchema.nullish(),
     conditionId: ConditionIdSchema.nullish(),
     avgPrice: DecimalishSchema.nullish(),
     size: DecimalishSchema.nullish(),
@@ -121,13 +215,28 @@ export const MarketPositionSchema = z
   .transform(({ asset, proxyWallet, ...rest }) => ({
     ...rest,
     wallet: proxyWallet,
+    assetId: asset,
     tokenId: asset,
-  }));
+  })) satisfies z.ZodType<MarketPosition>;
 
-export const MetaMarketPositionSchema = z.object({
-  token: z.string().nullish(),
-  positions: z.array(MarketPositionSchema).nullish(),
-});
+export type MetaMarketPosition = {
+  /** Outcome identifier for a CTF token or Polymarket V2 position. */
+  assetId: TokenId | PositionId | null | undefined;
+  /** @deprecated Use `assetId`. */
+  token: TokenId | PositionId | null | undefined;
+  positions?: MarketPosition[] | null;
+};
+
+export const MetaMarketPositionSchema = z
+  .object({
+    token: ClobAssetIdSchema.nullish(),
+    positions: z.array(MarketPositionSchema).nullish(),
+  })
+  .transform(({ token, ...rest }) => ({
+    ...rest,
+    assetId: token,
+    token,
+  })) satisfies z.ZodType<MetaMarketPosition>;
 
 export const ComboPositionMarketEventSchema = z
   .object({
@@ -290,11 +399,7 @@ export const ListMarketPositionsResponseSchema = z.array(
   MetaMarketPositionSchema,
 );
 
-export type Position = z.infer<typeof PositionSchema>;
-export type ClosedPosition = z.infer<typeof ClosedPositionSchema>;
 export type Value = z.infer<typeof ValueSchema>;
-export type MarketPosition = z.infer<typeof MarketPositionSchema>;
-export type MetaMarketPosition = z.infer<typeof MetaMarketPositionSchema>;
 export type ComboPositionMarketEvent = z.infer<
   typeof ComboPositionMarketEventSchema
 >;

--- a/packages/client/tests/integration/orders.test.ts
+++ b/packages/client/tests/integration/orders.test.ts
@@ -95,14 +95,14 @@ describe('Orders', { timeout: 60_000 }, () => {
       }
 
       const position = page.items.find(
-        (candidate) => candidate.tokenId === market.outcomes.yes.tokenId,
+        (candidate) => candidate.assetId === market.outcomes.yes.tokenId,
       );
 
       await secureClient
         .placeMarketOrder({
           side: OrderSide.SELL,
           shares: expectPresent(position?.size),
-          tokenId: expectPresent(position?.tokenId),
+          tokenId: expectPresent(market.outcomes.yes.tokenId),
         })
         .then(expectAcceptedOrderResponse);
     });
@@ -121,7 +121,7 @@ describe('Orders', { timeout: 60_000 }, () => {
           .firstPage();
         const existingPosition = positions.items.find(
           (candidate) =>
-            candidate.tokenId === yesTokenId && Number(candidate.size ?? 0) > 0,
+            candidate.assetId === yesTokenId && Number(candidate.size ?? 0) > 0,
         );
 
         if (existingPosition !== undefined) {


### PR DESCRIPTION
## Summary

- expose protocol-neutral assetId values across Data API positions, trades, activity, holders, and analytics
- retain deprecated token-named compatibility aliases
- normalize Data API market identifiers as conditionId while preserving compatibility aliases
- replace the redundant Data Address aliases with shared EVM address primitives

## Verification

- pnpm lint
- pnpm typecheck
- pnpm test:bindings

Linear: DEV-544

Stacked on #309.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Minor semver bump on widely consumed `@polymarket/bindings` / `@polymarket/client` response shapes; behavior is mostly additive but stricter parsing (`ConditionIdSchema`, `ClobAssetIdSchema`) could reject previously loose API values.
> 
> **Overview**
> **Data API bindings** now expose **`assetId`** (and **`oppositeAssetId`** on positions) as the canonical outcome identifier, mapped from wire `asset` via **`ClobAssetIdSchema`** so values can be CTF tokens or PolyV2 position IDs. **`tokenId`** / **`oppositeTokenId`** remain populated as **deprecated** mirrors for compatibility.
> 
> **Market-scoped analytics** (`OpenInterest`, `MarketVolume`, meta holder/position groupings) gain **`conditionId`** / **`assetId`** while keeping deprecated **`market`** / **`token`** aliases. Trades, activity, portfolio, and holder schemas follow the same pattern; activity trade normalization sets both **`assetId`** and **`tokenId`**.
> 
> Wallet fields move from local **`AddressSchema`** to shared **`EvmAddressSchema`**; redundant **`Address`** / **`Hash64`** helpers are removed from data **`common`**. Example **`list-positions`** and integration order tests match positions with **`assetId`** instead of **`tokenId`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9e7e2c80f4e1cf03247c0ad280571ec85a15d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->