### PR TITLE
feat(client): add required PolyV2 module approvals

### DIFF
--- a/.changeset/dev-592-polyv2-approvals.md
+++ b/.changeset/dev-592-polyv2-approvals.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/client': minor
+---
+
+Include the PolyV2 binary and negative-risk modules in the protocol-neutral trading approval workflow.

--- a/packages/client/src/actions/approvals.test.ts
+++ b/packages/client/src/actions/approvals.test.ts
@@ -25,10 +25,10 @@ describe('prepareTradingApprovals', () => {
   it('submits every missing approval and waits after each EOA transaction', async () => {
     const { client } = createClient([
       ...Array<HexString>(7).fill(FALSE_RESULT),
-      ...Array<HexString>(8).fill(FALSE_RESULT),
+      ...Array<HexString>(10).fill(FALSE_RESULT),
     ]);
     const workflow = await prepareTradingApprovals(client);
-    const handles = Array.from({ length: 15 }, createTransactionHandle);
+    const handles = Array.from({ length: 17 }, createTransactionHandle);
     let result = await workflow.next();
 
     for (const handle of handles) {
@@ -48,7 +48,7 @@ describe('prepareTradingApprovals', () => {
   it('completes without transactions when approvals are already set', async () => {
     const { client, ethCallBatch } = createClient([
       ...Array<HexString>(7).fill(MAX_UINT256_RESULT),
-      ...Array<HexString>(8).fill(TRUE_RESULT),
+      ...Array<HexString>(10).fill(TRUE_RESULT),
     ]);
 
     const workflow = await prepareTradingApprovals(client);
@@ -60,18 +60,21 @@ describe('prepareTradingApprovals', () => {
       value: undefined,
     });
     expect(ethCallBatch).toHaveBeenCalledTimes(1);
-    expect(ethCallBatch.mock.calls[0]?.[0]).toHaveLength(15);
+    expect(ethCallBatch.mock.calls[0]?.[0]).toHaveLength(17);
   });
 
   it('submits only missing approvals', async () => {
     const { client } = createClient([
       ...Array<HexString>(6).fill(MAX_UINT256_RESULT),
       FALSE_RESULT,
+      ...Array<HexString>(5).fill(TRUE_RESULT),
       FALSE_RESULT,
-      ...Array<HexString>(7).fill(TRUE_RESULT),
+      FALSE_RESULT,
+      ...Array<HexString>(3).fill(TRUE_RESULT),
     ]);
     const firstHandle = createTransactionHandle();
     const secondHandle = createTransactionHandle();
+    const thirdHandle = createTransactionHandle();
     const workflow = await prepareTradingApprovals(client);
 
     let result = await workflow.next();
@@ -101,7 +104,7 @@ describe('prepareTradingApprovals', () => {
           chainId: production.chainId,
           ...erc1155ApprovalForAllCall(
             production.contracts.conditionalTokens,
-            production.contracts.standardExchange,
+            production.contracts.binaryModule,
             true,
           ),
         },
@@ -111,11 +114,29 @@ describe('prepareTradingApprovals', () => {
     result = await workflow.next(secondHandle);
 
     expect(result).toEqual({
+      done: false,
+      value: {
+        kind: 'sendErc1155ApprovalForAllTransaction',
+        request: {
+          chainId: production.chainId,
+          ...erc1155ApprovalForAllCall(
+            production.contracts.conditionalTokens,
+            production.contracts.negRiskModule,
+            true,
+          ),
+        },
+      },
+    });
+
+    result = await workflow.next(thirdHandle);
+
+    expect(result).toEqual({
       done: true,
       value: undefined,
     });
     expect(firstHandle.wait).toHaveBeenCalledTimes(1);
     expect(secondHandle.wait).toHaveBeenCalledTimes(1);
+    expect(thirdHandle.wait).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/client/src/actions/approvals.ts
+++ b/packages/client/src/actions/approvals.ts
@@ -521,6 +521,14 @@ function getRequiredTradingApprovals(
         tokenAddress: contracts.conditionalTokens,
       },
       {
+        operatorAddress: contracts.binaryModule,
+        tokenAddress: contracts.conditionalTokens,
+      },
+      {
+        operatorAddress: contracts.negRiskModule,
+        tokenAddress: contracts.conditionalTokens,
+      },
+      {
         operatorAddress: contracts.protocolV2Router,
         tokenAddress: contracts.positionManager,
       },

--- a/packages/client/src/environments.ts
+++ b/packages/client/src/environments.ts
@@ -47,6 +47,8 @@ export type EnvironmentContracts = {
   negRiskExchange: EvmAddress;
   exchangeV3: EvmAddress;
   protocolV2Router: EvmAddress;
+  binaryModule: EvmAddress;
+  negRiskModule: EvmAddress;
   combinatorialModule: EvmAddress;
   positionManager: EvmAddress;
   autoRedeemOperator: EvmAddress;
@@ -164,6 +166,12 @@ export const production: EnvironmentConfig = {
     exchangeV3: expectEvmAddress('0xe3333700cA9d93003F00f0F71f8515005F6c00Aa'),
     protocolV2Router: expectEvmAddress(
       '0x12121212006e4CD160D18e3f00711DA5c3372600',
+    ),
+    binaryModule: expectEvmAddress(
+      '0x1000008dD9001B968442c1000017eaE6E0dA00Ba',
+    ),
+    negRiskModule: expectEvmAddress(
+      '0x200000900045e3B6259600682756002200028933',
     ),
     combinatorialModule: expectEvmAddress(
       '0x30000034706c7d8e12009dab006be20000c031a8',


### PR DESCRIPTION
## Summary

- add the deployed PolyV2 binary and negative-risk module addresses to environment contracts
- include Conditional Tokens approvals for both modules in setupTradingApprovals
- preserve the existing EOA and gasless execution paths and idempotent approval checks
- cover the exact two new approval calls in the existing workflow tests

## Verification

- pnpm exec vitest run packages/client/src/actions/approvals.test.ts --project client
- pnpm lint
- pnpm typecheck

Linear: DEV-592

Stacked on #311.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which operators receive Conditional Tokens approval during trading setup; incorrect addresses or ordering could block PolyV2 trading, though the change follows the existing approval pattern and is covered by workflow tests.
> 
> **Overview**
> Extends the **protocol-neutral trading approval workflow** so wallets also grant Conditional Tokens **ERC-1155 operator approval** to the deployed PolyV2 **binary module** and **negative-risk module**.
> 
> Production **environment contracts** now include `binaryModule` and `negRiskModule` addresses, and `getRequiredTradingApprovals` adds the two corresponding operators (17 on-chain checks total, up from 15). EOA and gasless paths stay the same: only missing approvals are submitted, with the same idempotent batch/read logic.
> 
> Tests in `approvals.test.ts` were updated for the larger checklist and to assert the new `binaryModule` and `negRiskModule` approval transactions when those checks fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851bff49b22421284889960cf73cd8c5c4e88b63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->