### PR TITLE
fix(gamma): preserve team ordering

### DIFF
--- a/.changeset/dev-615-team-ordering.md
+++ b/.changeset/dev-615-team-ordering.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": patch
+"@polymarket/client": patch
+---
+
+Preserve each team's `ordering` value on event and team-list responses.

--- a/packages/bindings/src/gamma/event.test.ts
+++ b/packages/bindings/src/gamma/event.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { EventSchema } from './event';
+import { EventSchema, TeamOrdering } from './event';
 
 describe('EventSchema', () => {
   it('exposes parentEventId as a string event id', () => {
@@ -16,5 +16,20 @@ describe('EventSchema', () => {
     expect(
       EventSchema.parse({ id: '570146', parentEventId: null }).parentEventId,
     ).toBeNull();
+  });
+
+  it('preserves typed team ordering', () => {
+    const event = EventSchema.parse({
+      id: '570146',
+      teams: [
+        { id: 114315, ordering: 'home' },
+        { id: 114317, ordering: 'away' },
+      ],
+    });
+
+    expect(event.sports.teams.map((team) => team.ordering)).toEqual([
+      TeamOrdering.Home,
+      TeamOrdering.Away,
+    ]);
   });
 });

--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -207,6 +207,7 @@ export const TeamSchema = z.object({
   updatedAt: IsoDateTimeStringSchema.nullish(),
   providerId: z.number().int().nullish(),
   color: z.string().nullish(),
+  ordering: z.string().nullish(),
 });
 
 export const SportsMetadataSchema = z.object({

--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -195,6 +195,11 @@ export const BestLineSchema = z.object({
   line: z.number().nullish(),
 });
 
+export enum TeamOrdering {
+  Home = 'home',
+  Away = 'away',
+}
+
 export const TeamSchema = z.object({
   id: TeamIdSchema,
   name: z.string().nullish(),
@@ -207,7 +212,7 @@ export const TeamSchema = z.object({
   updatedAt: IsoDateTimeStringSchema.nullish(),
   providerId: z.number().int().nullish(),
   color: z.string().nullish(),
-  ordering: z.string().nullish(),
+  ordering: z.enum(TeamOrdering).nullish(),
 });
 
 export const SportsMetadataSchema = z.object({

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,7 +10,7 @@ export {
 export type * from '@polymarket/bindings/data';
 export { ActivityType } from '@polymarket/bindings/data';
 export type * from '@polymarket/bindings/gamma';
-export { WalletType } from '@polymarket/bindings/gamma';
+export { TeamOrdering, WalletType } from '@polymarket/bindings/gamma';
 export type * from '@polymarket/bindings/perps';
 export {
   PerpsDepositStatus,


### PR DESCRIPTION
## Summary

- preserve per-team `ordering` values at the response validation boundary
- expose `TeamOrdering.Home` / `TeamOrdering.Away` from `@polymarket/client`
- expose the typed field through event sports metadata and `listTeams`
- add patch changesets for bindings and client

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:bindings` (115 passed)
- dependency-ordered builds for types, bindings, and client
- generated declaration and runtime export checks

[DEV-615](https://linear.app/polymarket/issue/DEV-615)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, optional schema field on sports team DTOs with no auth or persistence changes.
> 
> **Overview**
> Adds a typed **`ordering`** field (`home` / `away`) to gamma **team** objects so API values survive `EventSchema` and **`listTeams`** parsing instead of being dropped at the Zod boundary.
> 
> Introduces the **`TeamOrdering`** enum in bindings and re-exports it from **`@polymarket/client`** for consumers. A bindings test asserts parsed event sports teams keep `TeamOrdering.Home` and `TeamOrdering.Away`. Patch changesets cover bindings and client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b8fd0cdb7f25b6f50873d1508e36af61e9bbbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->