### PR TITLE
ci: run integration tests on Data API v2 branch

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,9 @@
 name: Integration Tests
 
 on:
+  push:
+    branches:
+      - integration/data-api-v2
   workflow_call:
     inputs:
       test_file_pattern:


### PR DESCRIPTION
## What

Run the integration test workflow on every push to `integration/data-api-v2`.

## Why

This gives the Data API v2 integration branch continuous live integration coverage without triggering the release and publishing jobs that are scoped to `main`.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `actionlint -ignore 'label.*is unknown' .github/workflows/integration-tests.yml`
- `pnpm changeset status --since=origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow trigger change with no application or secret-handling logic changes.
> 
> **Overview**
> Adds a **`push`** trigger to the **Integration Tests** workflow so it runs automatically on commits to **`integration/data-api-v2`**, in addition to existing **`workflow_call`** and **`workflow_dispatch`** entry points.
> 
> This gives the Data API v2 integration line continuous integration test coverage without pulling in release or publish jobs that stay tied to **`main`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d178ef8c6ed3d7f38f1e988d4cbde3cc2e1acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->