### PR TITLE
test(client): cap rewards pagination coverage

### DIFF
--- a/packages/client/tests/integration/clob.test.ts
+++ b/packages/client/tests/integration/clob.test.ts
@@ -5,6 +5,8 @@ import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from './fixtures';
 import { expectPageWindow } from './helpers';
 
+const REWARD_PAGE_WINDOW = 10;
+
 let liquidClobTokenIdPromise: Promise<TokenId> | undefined;
 
 describe('CLOB', () => {
@@ -188,7 +190,7 @@ describe('CLOB', () => {
       const paginator = publicClient.listCurrentRewards();
       const firstPage = await paginator.firstPage();
 
-      await expectPageWindow(paginator, firstPage, 99);
+      await expectPageWindow(paginator, firstPage, REWARD_PAGE_WINDOW - 1);
     });
   });
 
@@ -226,7 +228,7 @@ describe('CLOB', () => {
           conditionId: currentReward.conditionId,
         }),
         result,
-        99,
+        REWARD_PAGE_WINDOW - 1,
       );
     });
   });


### PR DESCRIPTION
Caps CLOB rewards integration coverage at 10 pages so the live test remains representative without scanning the full dataset and timing out. Tested with workspace typecheck, scoped lint, and both live rewards integration tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to pagination depth in integration tests; no production or API behavior changes.
> 
> **Overview**
> Caps how far live CLOB rewards integration tests walk paginators so they stay fast and stable instead of paging through nearly the full rewards dataset.
> 
> Introduces `REWARD_PAGE_WINDOW = 10` and uses it in **`listCurrentRewards`** and **`listMarketRewards`** via `expectPageWindow(..., REWARD_PAGE_WINDOW - 1)`, replacing the hard-coded **`99`** additional pages (100 pages total) with **9** additional pages (**10** pages total).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e6a3c8ab1102fd25fbdd38015a186a35cab5c2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->