### PR TITLE
feat(gamma): expose market combo status

### DIFF
--- a/.changeset/expose-market-combo-status.md
+++ b/.changeset/expose-market-combo-status.md
@@ -3,4 +3,5 @@
 '@polymarket/client': minor
 ---
 
-Expose each market's Combo eligibility status as `market.state.comboStatus`.
+Expose each market's Combo eligibility status as `market.state.comboStatus`,
+while passing newly introduced status values through as strings.

--- a/.changeset/expose-market-combo-status.md
+++ b/.changeset/expose-market-combo-status.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': minor
+'@polymarket/client': minor
+---
+
+Expose each market's Combo eligibility status as `market.state.comboStatus`.

--- a/packages/bindings/src/gamma/market.test.ts
+++ b/packages/bindings/src/gamma/market.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  ComboStatus,
   ListMarketsKeysetResponseSchema,
   ListMarketsResponseSchema,
   MarketSchema,
@@ -29,8 +30,12 @@ const rawMultiOutcomeMarket = {
 
 describe('MarketSchema', () => {
   it('normalizes binary outcomes', () => {
-    const market = MarketSchema.parse(rawBinaryMarket);
+    const market = MarketSchema.parse({
+      ...rawBinaryMarket,
+      comboStatus: 'enabled',
+    });
 
+    expect(market.state.comboStatus).toBe(ComboStatus.Enabled);
     expect(market.outcomes).toEqual({
       yes: {
         label: 'Yes',

--- a/packages/bindings/src/gamma/market.test.ts
+++ b/packages/bindings/src/gamma/market.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
-  ComboStatus,
+  ComboKnownStatus,
   ListMarketsKeysetResponseSchema,
   ListMarketsResponseSchema,
   MarketSchema,
@@ -35,7 +35,7 @@ describe('MarketSchema', () => {
       comboStatus: 'enabled',
     });
 
-    expect(market.state.comboStatus).toBe(ComboStatus.Enabled);
+    expect(market.state.comboStatus).toBe(ComboKnownStatus.Enabled);
     expect(market.outcomes).toEqual({
       yes: {
         label: 'Yes',
@@ -50,6 +50,15 @@ describe('MarketSchema', () => {
         price: '0.6',
       },
     });
+  });
+
+  it('passes unknown Combo statuses through as strings', () => {
+    const market = MarketSchema.parse({
+      ...rawBinaryMarket,
+      comboStatus: 'not-a-status-yet',
+    });
+
+    expect(market.state.comboStatus).toBe('not-a-status-yet');
   });
 
   it.each([

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -62,13 +62,26 @@ const PositionIdArraySchema = z
   .preprocess(parseJsonString, z.array(PositionIdSchema).nullish())
   .transform((value) => value ?? []);
 
-export enum ComboStatus {
+/**
+ * Known Combo eligibility statuses.
+ *
+ * The service evolves this set independently of released clients, so market
+ * parsing accepts unknown statuses as plain strings; see {@link ComboStatus}.
+ */
+export enum ComboKnownStatus {
   Pending = 'pending',
   Enabled = 'enabled',
   Disabled = 'disabled',
 }
 
-const ComboStatusSchema = z.enum(ComboStatus);
+/**
+ * A Combo eligibility status. Known statuses are enumerated in
+ * {@link ComboKnownStatus}; newly introduced statuses flow through as plain
+ * strings so they can be handled before a client release enumerates them.
+ */
+export type ComboStatus = ComboKnownStatus | (string & {});
+
+const ComboStatusSchema = z.string().transform((value): ComboStatus => value);
 
 export enum UmaResolutionStatus {
   Disputed = 'disputed',

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -62,6 +62,14 @@ const PositionIdArraySchema = z
   .preprocess(parseJsonString, z.array(PositionIdSchema).nullish())
   .transform((value) => value ?? []);
 
+export enum ComboStatus {
+  Pending = 'pending',
+  Enabled = 'enabled',
+  Disabled = 'disabled',
+}
+
+const ComboStatusSchema = z.enum(ComboStatus);
+
 export enum UmaResolutionStatus {
   Disputed = 'disputed',
   Proposed = 'proposed',
@@ -76,6 +84,8 @@ export type MarketState = {
   active?: boolean | null;
   closed?: boolean | null;
   archived?: boolean | null;
+  /** Whether the market is available for combo bets. */
+  comboStatus?: ComboStatus | null;
   acceptingOrders?: boolean | null;
   enableOrderBook?: boolean | null;
   negRisk?: boolean | null;
@@ -282,6 +292,7 @@ export const GammaMarketSchema = z.object({
   gameStartTime: IsoDateTimeStringSchema.nullish(),
   secondsDelay: z.number().int().nullish(),
   clobTokenIds: TokenIdArraySchema,
+  comboStatus: ComboStatusSchema.nullish(),
   positionIds: PositionIdArraySchema,
   disqusThread: z.string().nullish(),
   shortOutcomes: z.string().nullish(),
@@ -440,6 +451,7 @@ export function normalizeMarket(market: GammaMarket): Market {
       active: market.active,
       closed: market.closed,
       archived: market.archived,
+      comboStatus: market.comboStatus,
       acceptingOrders: market.acceptingOrders,
       enableOrderBook: market.enableOrderBook,
       negRisk: market.negRisk,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,7 +10,7 @@ export {
 export type * from '@polymarket/bindings/data';
 export { ActivityType } from '@polymarket/bindings/data';
 export type * from '@polymarket/bindings/gamma';
-export { ComboStatus, WalletType } from '@polymarket/bindings/gamma';
+export { ComboKnownStatus, WalletType } from '@polymarket/bindings/gamma';
 export type * from '@polymarket/bindings/perps';
 export {
   PerpsDepositStatus,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,7 +10,7 @@ export {
 export type * from '@polymarket/bindings/data';
 export { ActivityType } from '@polymarket/bindings/data';
 export type * from '@polymarket/bindings/gamma';
-export { WalletType } from '@polymarket/bindings/gamma';
+export { ComboStatus, WalletType } from '@polymarket/bindings/gamma';
 export type * from '@polymarket/bindings/perps';
 export {
   PerpsDepositStatus,


### PR DESCRIPTION
## Summary
- add ComboKnownStatus for pending, enabled, and disabled
- expose the open ComboStatus response type as market.state.comboStatus
- pass newly introduced status strings through instead of rejecting the market response
- export ComboKnownStatus from the public client entry point
- add a minor changeset for bindings and client

## Testing
- pnpm build
- pnpm lint
- pnpm typecheck
- pnpm test (116 bindings tests and 399 client tests passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema and type changes with permissive string parsing; no changes to auth, trading, or critical infrastructure paths.
> 
> **Overview**
> Gamma market parsing now surfaces **Combo eligibility** on normalized markets as `market.state.comboStatus`, sourced from the API’s `comboStatus` field.
> 
> Known values are represented by a new **`ComboKnownStatus`** enum (`pending`, `enabled`, `disabled`). Unknown future statuses are accepted as plain strings so market responses still parse when the service adds values before clients ship—same forward-compat approach used elsewhere in bindings.
> 
> **`ComboKnownStatus`** is re-exported from `@polymarket/client`. Bindings and client get a **minor** changeset bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70177043b8abc61ed6145a3b1ec3cd23b0b14ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->