### PR TITLE
feat!: remove legacy AMM and upstream-removed fields from gamma models

### DIFF
--- a/.changeset/remove-legacy-amm-fields.md
+++ b/.changeset/remove-legacy-amm-fields.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": minor
+"@polymarket/client": minor
+---
+
+Remove legacy AMM-era fields that the API no longer returns: `marketMakerAddress`, `ammType`, `fpmmLive`, `volumeAmm`, `volume24hrAmm`, `volume1wkAmm`, `volume1moAmm`, `volume1yrAmm`, and `liquidityAmm` from the raw market schema, `liquidityAmm` from the raw event schema, `volumeAmm` from `MarketMetrics`, and `liquidityAmm` from `EventMetrics`. Also remove the internal `pagerDutyNotificationEnabled` market field and `requiresTranslation` from market, event, series, and tag models, and drop the `marketMakerAddresses` filter from `listMarkets`. Responses that still carry any of these fields keep parsing; the values are ignored.

--- a/packages/bindings/src/gamma/common.ts
+++ b/packages/bindings/src/gamma/common.ts
@@ -65,7 +65,6 @@ export const TagReferenceSchema = z.object({
   updatedAt: IsoDateTimeStringSchema.nullish(),
   forceHide: z.boolean().nullish(),
   isCarousel: z.boolean().nullish(),
-  requiresTranslation: z.boolean().nullish(),
   activeEventsCount: z.number().int().nullish(),
 });
 

--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -129,7 +129,6 @@ export const SeriesReferenceSchema = z.object({
   cgAssetName: z.string().nullish(),
   score: z.number().int().nullish(),
   commentCount: z.number().int().nullish(),
-  requiresTranslation: z.boolean().nullish(),
 });
 
 export const TemplateReferenceSchema = z.object({
@@ -245,7 +244,6 @@ export type EventState = {
   ended?: boolean | null;
   automaticallyActive?: boolean | null;
   commentsEnabled?: boolean | null;
-  requiresTranslation?: boolean | null;
 };
 
 export type EventSchedule = {
@@ -261,7 +259,6 @@ export type EventSchedule = {
 
 export type EventMetrics = {
   liquidity?: DecimalString | null;
-  liquidityAmm?: DecimalString | null;
   liquidityClob?: DecimalString | null;
   volume?: DecimalString | null;
   volume24hr?: DecimalString | null;
@@ -448,7 +445,6 @@ export const GammaEventSchema = z.object({
   disqusThread: z.string().nullish(),
   parentEventId: EventIdSchema.nullish(),
   enableOrderBook: z.boolean().nullish(),
-  liquidityAmm: DecimalishSchema.nullish(),
   liquidityClob: DecimalishSchema.nullish(),
   negRisk: z.boolean().nullish(),
   negRiskMarketID: z.string().nullish(),
@@ -511,7 +507,6 @@ export const GammaEventSchema = z.object({
   bestLines: z.array(BestLineSchema).nullish(),
   homeTeamName: z.string().nullish(),
   awayTeamName: z.string().nullish(),
-  requiresTranslation: z.boolean().nullish(),
   turnProviderId: z.string().nullish(),
   lastHighlight: z.string().nullish(),
   lastHighlightType: z.string().nullish(),
@@ -594,7 +589,6 @@ function normalizeEvent(event: GammaEvent): Event {
       ended: event.ended,
       automaticallyActive: event.automaticallyActive,
       commentsEnabled: event.commentsEnabled,
-      requiresTranslation: event.requiresTranslation,
     },
     schedule: {
       startDate: event.startDate,
@@ -608,7 +602,6 @@ function normalizeEvent(event: GammaEvent): Event {
     },
     metrics: {
       liquidity: event.liquidity,
-      liquidityAmm: event.liquidityAmm,
       liquidityClob: event.liquidityClob,
       volume: event.volume,
       volume24hr: event.volume24hr,

--- a/packages/bindings/src/gamma/market.test.ts
+++ b/packages/bindings/src/gamma/market.test.ts
@@ -7,7 +7,6 @@ import {
 
 const rawBinaryMarket = {
   id: '1',
-  marketMakerAddress: '0x0000000000000000000000000000000000000000',
   outcomes: '["Yes", "No"]',
   outcomePrices: '["0.4", "0.6"]',
 };
@@ -23,7 +22,6 @@ const UNKNOWN_MODULE_CONDITION_ID =
 // who-will-the-world-s-richest-person-be-on-february-27-2021.
 const rawMultiOutcomeMarket = {
   id: '2',
-  marketMakerAddress: '0x0000000000000000000000000000000000000000',
   outcomes: '["Jeff Bezos", "Elon Musk", "Other"]',
 };
 
@@ -120,6 +118,25 @@ describe('MarketSchema', () => {
     const result = MarketSchema.safeParse(rawMultiOutcomeMarket);
 
     expect(result.success).toBe(false);
+  });
+
+  // Gamma stopped returning these fields, but historical AMM markets and
+  // not-yet-migrated responses may still carry them.
+  it('ignores removed legacy fields still present in raw responses', () => {
+    const market = MarketSchema.parse({
+      ...rawBinaryMarket,
+      marketMakerAddress: '0x0000000000000000000000000000000000000000',
+      ammType: 'fpmm',
+      fpmmLive: true,
+      volumeAmm: '123.45',
+      volume24hrAmm: '1.5',
+      liquidityAmm: '67.89',
+      pagerDutyNotificationEnabled: true,
+      requiresTranslation: true,
+    });
+
+    expect(market.id).toBe('1');
+    expect('volumeAmm' in market.metrics).toBe(false);
   });
 });
 

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -111,7 +111,6 @@ export type MarketMetrics = {
   volume1wk?: DecimalString | null;
   volume1mo?: DecimalString | null;
   volume1yr?: DecimalString | null;
-  volumeAmm?: DecimalString | null;
   volumeClob?: DecimalString | null;
   liquidity?: DecimalString | null;
   liquidityNum?: DecimalString | null;
@@ -208,7 +207,6 @@ export const GammaMarketSchema = z.object({
   resolutionSource: z.string().nullish(),
   endDate: IsoDateTimeStringSchema.nullish(),
   category: z.string().nullish(),
-  ammType: z.string().nullish(),
   liquidity: DecimalStringSchema.nullish(),
   sponsorName: z.string().nullish(),
   sponsorImage: z.string().nullish(),
@@ -231,7 +229,6 @@ export const GammaMarketSchema = z.object({
   lowerBoundDate: IsoCalendarDateStringSchema.nullish(),
   upperBoundDate: IsoCalendarDateStringSchema.nullish(),
   closed: z.boolean().nullish(),
-  marketMakerAddress: z.string(),
   createdBy: z.number().int().nullish(),
   updatedBy: z.number().int().nullish(),
   createdAt: IsoDateTimeStringSchema.nullish(),
@@ -289,18 +286,11 @@ export const GammaMarketSchema = z.object({
   teamBID: z.string().nullish(),
   umaBond: DecimalStringSchema.nullish(),
   umaReward: DecimalStringSchema.nullish(),
-  fpmmLive: z.boolean().nullish(),
-  volume24hrAmm: DecimalishSchema.nullish(),
-  volume1wkAmm: DecimalishSchema.nullish(),
-  volume1moAmm: DecimalishSchema.nullish(),
-  volume1yrAmm: DecimalishSchema.nullish(),
   volume24hrClob: DecimalishSchema.nullish(),
   volume1wkClob: DecimalishSchema.nullish(),
   volume1moClob: DecimalishSchema.nullish(),
   volume1yrClob: DecimalishSchema.nullish(),
-  volumeAmm: DecimalishSchema.nullish(),
   volumeClob: DecimalishSchema.nullish(),
-  liquidityAmm: DecimalishSchema.nullish(),
   liquidityClob: DecimalishSchema.nullish(),
   makerBaseFee: z.number().nullish(),
   takerBaseFee: z.number().nullish(),
@@ -329,7 +319,6 @@ export const GammaMarketSchema = z.object({
   tags: z.array(TagReferenceSchema).nullish(),
   cyom: z.boolean().nullish(),
   competitive: z.number().nullish(),
-  pagerDutyNotificationEnabled: z.boolean().nullish(),
   approved: z.boolean().nullish(),
   clobRewards: z.array(ClobRewardsSchema).nullish(),
   rewardsMinSize: DecimalishSchema.nullish(),
@@ -366,7 +355,6 @@ export const GammaMarketSchema = z.object({
   internalUsers: z.array(InternalUserSchema).nullish(),
   holdingRewardsEnabled: z.boolean().nullish(),
   feesEnabled: z.boolean().nullish(),
-  requiresTranslation: z.boolean().nullish(),
   makerRebatesFeeShareBps: z.number().nullish(),
   // Legacy raw fee fields are superseded by feeSchedule in normalized output.
   // feeRate: DecimalishSchema.nullish(),
@@ -455,7 +443,6 @@ export function normalizeMarket(market: GammaMarket): Market {
       volume1wk: market.volume1wk,
       volume1mo: market.volume1mo,
       volume1yr: market.volume1yr,
-      volumeAmm: market.volumeAmm,
       volumeClob: market.volumeClob,
       liquidity: market.liquidity,
       liquidityNum: market.liquidityNum,

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -64,7 +64,6 @@ const ListMarketsRequestSchema = z.object({
   liquidityNumMax: z.number().optional(),
   liquidityNumMin: z.number().optional(),
   locale: z.string().optional(),
-  marketMakerAddresses: z.array(z.string()).optional(),
   order: z.string().optional(),
   positionIds: z.array(PositionIdSchema).optional(),
   questionIds: z.array(z.string()).optional(),
@@ -623,7 +622,6 @@ function toMarketsSearchParams(params: ListMarketsParams): URLSearchParams {
     snakeCase<ListMarketsParams>({
       cursor: 'after_cursor',
       ids: 'id',
-      marketMakerAddresses: 'market_maker_address',
       pageSize: 'limit',
     }),
   );

--- a/packages/client/src/validation.test.ts
+++ b/packages/client/src/validation.test.ts
@@ -64,7 +64,7 @@ describe('validation', () => {
   describe('formatResponseZodError', () => {
     it('includes the endpoint context', () => {
       const schema = z.object({
-        marketMakerAddress: z.string(),
+        conditionId: z.string(),
       });
 
       const result = schema.safeParse({});
@@ -84,7 +84,7 @@ describe('validation', () => {
         Endpoint: https://gamma.polymarket.com/markets/123
         This usually means the API response shape changed in a breaking way or the SDK is outdated.
         Fix the following issues:
-        - marketMakerAddress: Invalid input: expected string, received undefined"
+        - conditionId: Invalid input: expected string, received undefined"
       `);
     });
   });
@@ -117,7 +117,7 @@ describe('validation', () => {
   describe('UnexpectedResponseError', () => {
     it('formats Zod failures through the factory', () => {
       const schema = z.object({
-        marketMakerAddress: z.string(),
+        conditionId: z.string(),
       });
 
       const result = schema.safeParse({});
@@ -138,7 +138,7 @@ describe('validation', () => {
         Endpoint: https://gamma.polymarket.com/markets
         This usually means the API response shape changed in a breaking way or the SDK is outdated.
         Fix the following issues:
-        - marketMakerAddress: Invalid input: expected string, received undefined"
+        - conditionId: Invalid input: expected string, received undefined"
       `);
     });
   });


### PR DESCRIPTION
## Why

Gamma is cleaning the consumer-facing event and market models to improve data transfer speed:

- `market.marketMakerAddress` will be omitted from responses (still returned for historical AMM markets)
- `market.pagerDutyNotificationEnabled` is removed from responses
- `(event, market, series, tags).requiresTranslation` is removed from responses
- `event.eventMetadata` context keys move to `GET events/{id}/insights` (no SDK impact: parsed as an open record)

`marketMakerAddress` was **required** in `GammaMarketSchema`, so once the API omits it every market parse would throw `UnexpectedResponseError`. 

## What changed

**`@polymarket/bindings`**

- `GammaMarketSchema`: removed `marketMakerAddress`, `ammType`, `fpmmLive`, `volumeAmm`, `volume24hrAmm`, `volume1wkAmm`, `volume1moAmm`, `volume1yrAmm`, `liquidityAmm`, `pagerDutyNotificationEnabled`, `requiresTranslation`
- `GammaEventSchema`: removed `liquidityAmm`, `requiresTranslation`
- `SeriesReferenceSchema`, `TagReferenceSchema`: removed `requiresTranslation`
- Normalized models: removed `MarketMetrics.volumeAmm`, `EventMetrics.liquidityAmm`, `EventState.requiresTranslation`

**`@polymarket/client`**

- `listMarkets`: removed the `marketMakerAddresses` filter (maps to the `market_maker_address` query param, which is being dropped)
- Error-formatting tests: renamed the example field so the removed field name no longer appears in the repo

## Compatibility

Responses that still carry any of these fields keep parsing: `z.object` strips unknown keys silently, so historical AMM markets and not-yet-migrated responses are tolerated without surfacing the values. A regression test covers this (`market.test.ts`: "ignores removed legacy fields still present in raw responses").

Changeset: minor for both packages.

## Test plan

- `pnpm lint` clean
- `pnpm typecheck` clean (all packages incl. examples)
- `pnpm build` clean
- `pnpm test`: bindings 116 passed, client 399 passed, no type errors


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes TypeScript surface area and a markets list filter that downstream apps may still use, but avoids mass `UnexpectedResponseError` when Gamma omits formerly required `marketMakerAddress`.
> 
> **Overview**
> Aligns **`@polymarket/bindings`** and **`@polymarket/client`** with Gamma’s slimmer market/event payloads by dropping legacy AMM fields, internal flags, and translation metadata from Zod schemas and normalized types.
> 
> **Bindings:** Raw market schema no longer models `marketMakerAddress` (previously **required**), `ammType`, `fpmmLive`, AMM volume/liquidity fields, `pagerDutyNotificationEnabled`, or `requiresTranslation`. Events lose `liquidityAmm` and `requiresTranslation`; tags/series lose `requiresTranslation`. Normalized **`MarketMetrics`** / **`EventMetrics`** and event state mapping no longer expose AMM metrics or `requiresTranslation`.
> 
> **Client:** **`listMarkets`** no longer accepts **`marketMakerAddresses`** / `market_maker_address`. Tests were updated to stop using removed field names in error examples.
> 
> **Compatibility:** Payloads that still include these keys continue to parse; Zod strips unknown properties so values are not surfaced on SDK types. A new market test asserts legacy keys are ignored and `volumeAmm` is absent from `metrics`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01438a1fe522f601875bf0120d52fc69e36525df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->