### PR TITLE
fix(examples): support V2 market prices

### DIFF
--- a/examples/scripts/src/market-prices.ts
+++ b/examples/scripts/src/market-prices.ts
@@ -11,20 +11,22 @@ const {
   })
   .firstPage();
 
-const tokenId =
-  market?.outcomes.yes.tokenId ?? never('No YES token found for market');
+const assetId =
+  market?.outcomes.yes.tokenId ??
+  market?.outcomes.yes.positionId ??
+  never('No YES asset found for market');
 
 const [orderBook, buyPrice, midpoint, spread, lastTrade] = await Promise.all([
-  client.fetchOrderBook({ tokenId }),
-  client.fetchPrice({ tokenId, side: OrderSide.BUY }),
-  client.fetchMidpoint({ tokenId }),
-  client.fetchSpread({ tokenId }),
-  client.fetchLastTradePrice({ tokenId }),
+  client.fetchOrderBook({ assetId }),
+  client.fetchPrice({ assetId, side: OrderSide.BUY }),
+  client.fetchMidpoint({ assetId }),
+  client.fetchSpread({ assetId }),
+  client.fetchLastTradePrice({ assetId }),
 ]);
 
 console.table({
   market: market?.question ?? market?.slug ?? market?.id ?? never(),
-  tokenId,
+  assetId,
   bids: orderBook.bids.length,
   asks: orderBook.asks.length,
   buyPrice,


### PR DESCRIPTION
Use assetId in the market-prices example, falling back from the V1 tokenId to the V2 positionId. Updates every market-price query and the console output. Closes #331. Validation: workspace typecheck and targeted Biome check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/example-only change with no production or auth impact.
> 
> **Overview**
> Updates the **market-prices** example so it works for both V1 and V2 markets instead of assuming a YES **tokenId** only.
> 
> The script resolves a single **`assetId`** from `outcomes.yes.tokenId`, falling back to **`positionId`** when needed, and passes that identifier to all price/order-book calls (`fetchOrderBook`, `fetchPrice`, `fetchMidpoint`, `fetchSpread`, `fetchLastTradePrice`). Console output labels the resolved id as **`assetId`** rather than **`tokenId`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c1c63b1fb62abbac6d08542658141adc6bfb49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->