### PR TITLE
fix(client): stop revocation after registry removal

### DIFF
--- a/.changeset/swift-keys-rest.md
+++ b/.changeset/swift-keys-rest.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/client': minor
+---
+
+Return from `revokeSessionKey` once the session key is removed from the active-key registry instead of waiting for on-chain confirmation. The method now returns `Promise<void>`, and `RevokeSessionKeyResult` has been removed.

--- a/packages/client/src/actions/session-keys.ts
+++ b/packages/client/src/actions/session-keys.ts
@@ -417,6 +417,8 @@ export async function revokeSessionKey(
     kind: 'revocation',
     status: response.status,
   });
+  // This eager return is intentional; the backend continues the remaining
+  // revocation work after the key leaves the active-key registry.
   await waitForRevokedSessionKey(client, parsedRequest.address);
 }
 
@@ -424,6 +426,9 @@ async function waitForRevokedSessionKey(
   client: BaseSecureClient,
   address: EvmAddress,
 ): Promise<void> {
+  // This revocation readiness check deliberately reuses the relayer transaction
+  // polling limits instead of introducing revocation-specific configuration.
+  // The defaults allow about 200 seconds (100 polls every two seconds).
   for (
     let pollCount = 0;
     pollCount < client.environment.relayerMaxPolls;

--- a/packages/client/src/actions/session-keys.ts
+++ b/packages/client/src/actions/session-keys.ts
@@ -35,7 +35,7 @@ import {
 } from '../errors';
 import { parseUserInput } from '../input';
 import { validateWith } from '../response';
-import type { TransactionOutcome } from '../types';
+import type { TransactionHandle, TransactionOutcome } from '../types';
 import { SignerType } from '../wallet';
 import { completeWith } from '../workflow';
 import {
@@ -334,10 +334,10 @@ const RevokeSessionKeyRequestSchema = z
     }),
   ) satisfies z.ZodType<ParsedRevokeSessionKeyRequest, RevokeSessionKeyRequest>;
 
-/** Result of a confirmed session-key revocation. */
+/** Result of a session-key revocation. */
 export type RevokeSessionKeyResult = {
-  /** Confirmed transaction that applied the revocation. */
-  transaction: TransactionOutcome;
+  /** Submitted transaction. Call `wait()` to await on-chain confirmation. */
+  transaction: TransactionHandle;
 };
 
 export type RevokeSessionKeyError =
@@ -346,7 +346,6 @@ export type RevokeSessionKeyError =
   | RequestRejectedError
   | SigningError
   | TimeoutError
-  | TransactionFailedError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
@@ -356,7 +355,6 @@ export const RevokeSessionKeyError = makeErrorGuard(
   RequestRejectedError,
   SigningError,
   TimeoutError,
-  TransactionFailedError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,
@@ -365,8 +363,8 @@ export const RevokeSessionKeyError = makeErrorGuard(
 /**
  * Revokes a session key authorized for the Deposit Wallet.
  *
- * Revocation may take several minutes while existing activity is canceled and
- * the on-chain revocation is confirmed.
+ * Returns once the session key is removed from the active-key registry and can
+ * no longer be used. The on-chain transaction may still be pending.
  * Requires API-key authentication that supports gasless transactions.
  *
  * @remarks
@@ -423,14 +421,41 @@ export async function revokeSessionKey(
     kind: 'revocation',
     status: response.status,
   });
-  const transaction = await new GaslessTransactionHandle(client, {
+  const transaction = new GaslessTransactionHandle(client, {
     transactionHash: null,
     transactionId: response.transactionId,
-  }).wait();
+  });
+
+  await waitForRevokedSessionKey(client, parsedRequest.address);
 
   return {
     transaction,
   };
+}
+
+async function waitForRevokedSessionKey(
+  client: BaseSecureClient,
+  address: EvmAddress,
+): Promise<void> {
+  for (
+    let pollCount = 0;
+    pollCount < client.environment.relayerMaxPolls;
+    pollCount += 1
+  ) {
+    const isActive = (await fetchSessionKeys(client)).some((sessionKey) =>
+      isSameEvmAddress(sessionKey.address, address),
+    );
+
+    if (!isActive) {
+      return;
+    }
+
+    await delay(client.environment.relayerPollFrequencyMs);
+  }
+
+  throw new TimeoutError(
+    `Timed out waiting for session key ${address} to be revoked`,
+  );
 }
 
 async function waitForAuthorizedSessionKey(

--- a/packages/client/src/actions/session-keys.ts
+++ b/packages/client/src/actions/session-keys.ts
@@ -368,7 +368,7 @@ export const RevokeSessionKeyError = makeErrorGuard(
  *
  * @example
  * ```ts
- * const revocation = await revokeSessionKey(client, {
+ * await revokeSessionKey(client, {
  *   address: sessionAddress,
  * });
  * ```

--- a/packages/client/src/actions/session-keys.ts
+++ b/packages/client/src/actions/session-keys.ts
@@ -35,7 +35,7 @@ import {
 } from '../errors';
 import { parseUserInput } from '../input';
 import { validateWith } from '../response';
-import type { TransactionHandle, TransactionOutcome } from '../types';
+import type { TransactionOutcome } from '../types';
 import { SignerType } from '../wallet';
 import { completeWith } from '../workflow';
 import {
@@ -334,12 +334,6 @@ const RevokeSessionKeyRequestSchema = z
     }),
   ) satisfies z.ZodType<ParsedRevokeSessionKeyRequest, RevokeSessionKeyRequest>;
 
-/** Result of a session-key revocation. */
-export type RevokeSessionKeyResult = {
-  /** Submitted transaction. Call `wait()` to await on-chain confirmation. */
-  transaction: TransactionHandle;
-};
-
 export type RevokeSessionKeyError =
   | CancelledSigningError
   | RateLimitError
@@ -383,7 +377,7 @@ export const RevokeSessionKeyError = makeErrorGuard(
 export async function revokeSessionKey(
   client: BaseSecureClient,
   request: RevokeSessionKeyRequest,
-): Promise<RevokeSessionKeyResult> {
+): Promise<void> {
   assertOwnerDepositWallet(client);
 
   if (!client.supportsGasless) {
@@ -421,16 +415,7 @@ export async function revokeSessionKey(
     kind: 'revocation',
     status: response.status,
   });
-  const transaction = new GaslessTransactionHandle(client, {
-    transactionHash: null,
-    transactionId: response.transactionId,
-  });
-
   await waitForRevokedSessionKey(client, parsedRequest.address);
-
-  return {
-    transaction,
-  };
 }
 
 async function waitForRevokedSessionKey(

--- a/packages/client/src/actions/session-keys.ts
+++ b/packages/client/src/actions/session-keys.ts
@@ -340,6 +340,7 @@ export type RevokeSessionKeyError =
   | RequestRejectedError
   | SigningError
   | TimeoutError
+  | TransactionFailedError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
@@ -349,6 +350,7 @@ export const RevokeSessionKeyError = makeErrorGuard(
   RequestRejectedError,
   SigningError,
   TimeoutError,
+  TransactionFailedError,
   TransportError,
   UnexpectedResponseError,
   UserInputError,

--- a/packages/client/src/decorators/session-keys.ts
+++ b/packages/client/src/decorators/session-keys.ts
@@ -4,7 +4,6 @@ import {
   authorizeSessionKey,
   fetchSessionKeys,
   type RevokeSessionKeyRequest,
-  type RevokeSessionKeyResult,
   revokeSessionKey,
   type SessionKey,
 } from '../actions';
@@ -68,9 +67,7 @@ export type SessionKeyActions = {
    * @throws {@link RevokeSessionKeyError}
    * Thrown on failure.
    */
-  revokeSessionKey(
-    request: RevokeSessionKeyRequest,
-  ): Promise<RevokeSessionKeyResult>;
+  revokeSessionKey(request: RevokeSessionKeyRequest): Promise<void>;
 };
 
 export function sessionKeyActions(client: BaseSecureClient): SessionKeyActions {
@@ -85,7 +82,6 @@ export type {
   AuthorizeSessionKeyRequest,
   AuthorizeSessionKeyResult,
   RevokeSessionKeyRequest,
-  RevokeSessionKeyResult,
   SessionKey,
   SessionKeyScope,
 } from '../actions';

--- a/packages/client/src/decorators/session-keys.ts
+++ b/packages/client/src/decorators/session-keys.ts
@@ -54,8 +54,8 @@ export type SessionKeyActions = {
   /**
    * Revokes a session key authorized for the Deposit Wallet.
    *
-   * Revocation may take several minutes while existing activity is canceled and
-   * the on-chain revocation is confirmed.
+   * Returns once the session key is removed from the active-key registry and can
+   * no longer be used. The on-chain transaction may still be pending.
    * Requires API-key authentication that supports gasless transactions.
    *
    * @example

--- a/packages/client/src/decorators/session-keys.ts
+++ b/packages/client/src/decorators/session-keys.ts
@@ -59,7 +59,7 @@ export type SessionKeyActions = {
    *
    * @example
    * ```ts
-   * const revocation = await client.revokeSessionKey({
+   * await client.revokeSessionKey({
    *   address: sessionAddress,
    * });
    * ```

--- a/packages/client/tests/integration/session-keys.test.ts
+++ b/packages/client/tests/integration/session-keys.test.ts
@@ -140,16 +140,10 @@ describe('Session keys', { timeout: 600_000 }, () => {
       expect(cancellation.canceled).toContain(orderId);
       orderId = undefined;
 
-      const revocation = await secureClientWithDepositWallet.revokeSessionKey({
+      await secureClientWithDepositWallet.revokeSessionKey({
         address: sessionAddress,
       });
       revoked = true;
-
-      annotate(
-        `Revocation transaction ID: ${revocation.transaction.transactionId}`,
-      );
-      expect(revocation.transaction.transactionHash).toBeNull();
-      expect(revocation.transaction.transactionId).not.toBeNull();
 
       const remainingSessionKeys =
         await secureClientWithDepositWallet.fetchSessionKeys();

--- a/packages/client/tests/integration/session-keys.test.ts
+++ b/packages/client/tests/integration/session-keys.test.ts
@@ -146,11 +146,9 @@ describe('Session keys', { timeout: 600_000 }, () => {
       revoked = true;
 
       annotate(
-        `Revocation transaction: ${revocation.transaction.transactionHash}`,
+        `Revocation transaction ID: ${revocation.transaction.transactionId}`,
       );
-      expect(revocation.transaction.transactionHash).toMatch(
-        /^0x[0-9a-f]{64}$/i,
-      );
+      expect(revocation.transaction.transactionHash).toBeNull();
       expect(revocation.transaction.transactionId).not.toBeNull();
 
       const remainingSessionKeys =


### PR DESCRIPTION
Return from session-key revocation once the key leaves the wallet registry, without waiting for on-chain confirmation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API and changed completion semantics for session-key revocation; behavior still gates on registry removal so the key should be unusable before return, but callers no longer get on-chain confirmation.
> 
> **Overview**
> **`revokeSessionKey`** no longer blocks on relayer/on-chain confirmation. After the revocation is accepted by the relayer, it **polls active session keys** (reusing relayer poll limits, ~200s) until the address disappears from the registry, then resolves.
> 
> This is a **breaking API change** (minor bump): the method returns **`Promise<void>`**, **`RevokeSessionKeyResult`** is removed, and docs/examples no longer promise a confirmed transaction. Integration tests assert registry state instead of a revocation transaction hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd560b6cf7dc74f940162502b872ac36bf90ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->