### PR TITLE
feat(data): migrate portfolio summaries to v2

### DIFF
--- a/.changeset/data-v2-portfolio-summary.md
+++ b/.changeset/data-v2-portfolio-summary.md
@@ -3,4 +3,4 @@
 '@polymarket/client': minor
 ---
 
-**Breaking**: migrate `fetchPortfolioValue` to its `/v2` contract, returning one numeric `PortfolioValue` and accepting `conditionId` instead of the legacy `market` filter. Add `fetchUserStats` with numeric profile and lifetime PnL fields, and remove `fetchTradedMarketCount`; use `fetchUserStats().trades` for the exact distinct-market count. The accounting snapshot download remains available unchanged.
+**Breaking**: migrate `fetchPortfolioValue` to its `/v2` contract, returning one `PortfolioValue` with a decimal-string value and accepting `conditionId` instead of the legacy `market` filter. Add `fetchUserStats` with decimal-string money, size, and PnL fields, and remove `fetchTradedMarketCount`; use `fetchUserStats().trades` for the exact distinct-market count. The accounting snapshot download remains available unchanged.

--- a/.changeset/data-v2-portfolio-summary.md
+++ b/.changeset/data-v2-portfolio-summary.md
@@ -3,4 +3,4 @@
 '@polymarket/client': minor
 ---
 
-**Breaking**: migrate `fetchPortfolioValue` to its `/v2` contract, returning one `PortfolioValue` with a decimal-string value and accepting `conditionId` instead of the legacy `market` filter. Add `fetchUserStats` with decimal-string money, size, and PnL fields, and remove `fetchTradedMarketCount`; use `fetchUserStats().trades` for the exact distinct-market count. The accounting snapshot download remains available unchanged.
+**Breaking**: migrate `fetchPortfolioValue` to its `/v2` contract, returning one `PortfolioValue` with a decimal-string value and accepting `conditionIds` instead of the legacy `market` filter. Add `fetchUserStats` with decimal-string money, size, and PnL fields, and remove `fetchTradedMarketCount`; use `fetchUserStats().trades` for the exact distinct-market count. The accounting snapshot download remains available unchanged.

--- a/.changeset/data-v2-portfolio-summary.md
+++ b/.changeset/data-v2-portfolio-summary.md
@@ -3,4 +3,4 @@
 '@polymarket/client': minor
 ---
 
-**Breaking**: migrate `fetchPortfolioValue` to its `/v2` contract, returning one `PortfolioValue` with a decimal-string value and accepting `conditionIds` instead of the legacy `market` filter. Add `fetchUserStats` with decimal-string money, size, and PnL fields, and remove `fetchTradedMarketCount`; use `fetchUserStats().trades` for the exact distinct-market count. The accounting snapshot download remains available unchanged.
+**Breaking**: migrate `fetchPortfolioValue` to its `/v2` contract, returning one `PortfolioValue` with a decimal-string value and accepting `conditionIds` instead of the legacy `market` filter. Add `fetchUserStats` with decimal-string money, size, and PnL fields, and remove `fetchTradedMarketCount`; use `fetchUserStats().tradedMarketCount` for the exact distinct-market count. The accounting snapshot download remains available unchanged.

--- a/.changeset/data-v2-portfolio-summary.md
+++ b/.changeset/data-v2-portfolio-summary.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': minor
+'@polymarket/client': minor
+---
+
+**Breaking**: migrate `fetchPortfolioValue` to its `/v2` contract, returning one numeric `PortfolioValue` and accepting `conditionId` instead of the legacy `market` filter. Add `fetchUserStats` with numeric profile and lifetime PnL fields, and remove `fetchTradedMarketCount`; use `fetchUserStats().trades` for the exact distinct-market count. The accounting snapshot download remains available unchanged.

--- a/packages/bindings/src/data/activity.ts
+++ b/packages/bindings/src/data/activity.ts
@@ -471,17 +471,11 @@ const RawActivitySchema = z.object({
 export const ActivitySchema: z.ZodType<Activity> =
   RawActivitySchema.transform(normalizeActivity);
 
-export const TradedSchema = z.object({
-  user: EvmAddressSchema.nullish(),
-  traded: z.number().int().nullish(),
-});
-
 export const ListTradesResponseSchema = dataPageSchema(TradeSchema);
 export const ListActivityResponseSchema = dataPageSchema(ActivitySchema);
 export const ListComboActivityResponseSchema =
   dataPageSchema(ComboActivitySchema);
 
-export type Traded = z.infer<typeof TradedSchema>;
 export type ListTradesResponse = z.infer<typeof ListTradesResponseSchema>;
 export type ListActivityResponse = z.infer<typeof ListActivityResponseSchema>;
 export type ListComboActivityResponse = z.infer<

--- a/packages/bindings/src/data/portfolio.test.ts
+++ b/packages/bindings/src/data/portfolio.test.ts
@@ -45,7 +45,7 @@ describe('FetchUserStatsResponseSchema', () => {
 
     expect(stats).toMatchObject({
       wallet: WALLET,
-      trades: 42,
+      tradedMarketCount: 42,
       biggestWin: '123.456789',
       views: 7,
       joinDate: 1_700_000_000_000,
@@ -82,7 +82,7 @@ describe('FetchUserStatsResponseSchema', () => {
       }),
     ).toEqual({
       wallet: WALLET,
-      trades: 0,
+      tradedMarketCount: 0,
       biggestWin: '0',
       views: 0,
       joinDate: null,

--- a/packages/bindings/src/data/portfolio.test.ts
+++ b/packages/bindings/src/data/portfolio.test.ts
@@ -7,7 +7,7 @@ import {
 const WALLET = `0x${'1'.repeat(40)}`;
 
 describe('FetchPortfolioValueResponseSchema', () => {
-  it('unwraps a numeric portfolio value', () => {
+  it('normalizes a numeric portfolio value to a decimal string', () => {
     const value = FetchPortfolioValueResponseSchema.parse({
       data: {
         proxy_wallet: WALLET,
@@ -15,18 +15,18 @@ describe('FetchPortfolioValueResponseSchema', () => {
       },
     });
 
-    expect(value).toEqual({ wallet: WALLET, value: 12.3456 });
+    expect(value).toEqual({ wallet: WALLET, value: '12.3456' });
   });
 
-  it('rejects decimal strings', () => {
-    expect(() =>
+  it('accepts an already-string decimal value', () => {
+    expect(
       FetchPortfolioValueResponseSchema.parse({
         data: {
           proxy_wallet: WALLET,
           value: '12.3456',
         },
       }),
-    ).toThrow();
+    ).toEqual({ wallet: WALLET, value: '12.3456' });
   });
 });
 
@@ -46,21 +46,21 @@ describe('FetchUserStatsResponseSchema', () => {
     expect(stats).toMatchObject({
       wallet: WALLET,
       trades: 42,
-      biggestWin: 123.456789,
+      biggestWin: '123.456789',
       views: 7,
       joinDate: 1_700_000_000_000,
       allTimePnl: {
         timestamp: 1_700_000_100_000,
         sourceBlock: 12_345,
-        realizedMarketPnl: 10.123456,
-        realizedLpPnl: 2.5,
-        realizedComboPnl: -1.25,
-        realizedPnl: 11.373456,
+        realizedMarketPnl: '10.123456',
+        realizedLpPnl: '2.5',
+        realizedComboPnl: '-1.25',
+        realizedPnl: '11.373456',
         unrealizedPnl: null,
-        fees: -0.5,
-        feesPaid: -0.25,
-        volume: 1_000.123456,
-        volumeUsdc: 750.654321,
+        fees: '-0.5',
+        feesPaid: '-0.25',
+        volume: '1000.123456',
+        volumeUsdc: '750.654321',
         tradeCount: 99,
       },
     });
@@ -83,7 +83,7 @@ describe('FetchUserStatsResponseSchema', () => {
     ).toEqual({
       wallet: WALLET,
       trades: 0,
-      biggestWin: 0,
+      biggestWin: '0',
       views: 0,
       joinDate: null,
       allTimePnl: null,
@@ -115,7 +115,7 @@ function userPnlPoint() {
     trade_pnl: 10.873456,
     sponsored_income: 1.75,
     fees: -0.5,
-    fees_paid: -0.25,
+    fees_paid: '-0.25',
     cashflow_net: null,
     volume: 1_000.123456,
     volume_usdc: 750.654321,

--- a/packages/bindings/src/data/portfolio.test.ts
+++ b/packages/bindings/src/data/portfolio.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FetchPortfolioValueResponseSchema,
+  FetchUserStatsResponseSchema,
+} from './portfolio';
+
+const WALLET = `0x${'1'.repeat(40)}`;
+
+describe('FetchPortfolioValueResponseSchema', () => {
+  it('unwraps a numeric portfolio value', () => {
+    const value = FetchPortfolioValueResponseSchema.parse({
+      data: {
+        proxy_wallet: WALLET,
+        value: 12.3456,
+      },
+    });
+
+    expect(value).toEqual({ wallet: WALLET, value: 12.3456 });
+  });
+
+  it('rejects decimal strings', () => {
+    expect(() =>
+      FetchPortfolioValueResponseSchema.parse({
+        data: {
+          proxy_wallet: WALLET,
+          value: '12.3456',
+        },
+      }),
+    ).toThrow();
+  });
+});
+
+describe('FetchUserStatsResponseSchema', () => {
+  it('normalizes profile stats and the latest PnL point', () => {
+    const stats = FetchUserStatsResponseSchema.parse({
+      data: {
+        proxy_wallet: WALLET,
+        trades: 42,
+        biggest_win: 123.456789,
+        views: 7,
+        join_date: 1_700_000_000,
+        all_time_pnl: userPnlPoint(),
+      },
+    });
+
+    expect(stats).toMatchObject({
+      wallet: WALLET,
+      trades: 42,
+      biggestWin: 123.456789,
+      views: 7,
+      joinDate: 1_700_000_000_000,
+      allTimePnl: {
+        timestamp: 1_700_000_100_000,
+        sourceBlock: 12_345,
+        realizedMarketPnl: 10.123456,
+        realizedLpPnl: 2.5,
+        realizedComboPnl: -1.25,
+        realizedPnl: 11.373456,
+        unrealizedPnl: null,
+        fees: -0.5,
+        feesPaid: -0.25,
+        volume: 1_000.123456,
+        volumeUsdc: 750.654321,
+        tradeCount: 99,
+      },
+    });
+  });
+
+  it('preserves an unknown wallet as null', () => {
+    expect(FetchUserStatsResponseSchema.parse({ data: null })).toBeNull();
+  });
+
+  it('normalizes omitted optional profile fields to null', () => {
+    expect(
+      FetchUserStatsResponseSchema.parse({
+        data: {
+          proxy_wallet: WALLET,
+          trades: 0,
+          biggest_win: 0,
+          views: 0,
+        },
+      }),
+    ).toEqual({
+      wallet: WALLET,
+      trades: 0,
+      biggestWin: 0,
+      views: 0,
+      joinDate: null,
+      allTimePnl: null,
+    });
+  });
+});
+
+function userPnlPoint() {
+  return {
+    timestamp: 1_700_000_100,
+    source_block: 12_345,
+    realized_market_pnl: 10.123456,
+    realized_lp_pnl: 2.5,
+    realized_combo_pnl: -1.25,
+    unrealized_pnl: null,
+    fees_refunded: 0.25,
+    maker_rebate: 0.1,
+    taker_rebate: 0.2,
+    reward_income: 1,
+    yield_income: 0.5,
+    referral_income: 0.25,
+    deposits: null,
+    withdrawals: null,
+    realized_pnl: 11.373456,
+    wallet_income: 2.05,
+    position_pnl: null,
+    settled_pnl: 13.423456,
+    economic_pnl: null,
+    trade_pnl: 10.873456,
+    sponsored_income: 1.75,
+    fees: -0.5,
+    fees_paid: -0.25,
+    cashflow_net: null,
+    volume: 1_000.123456,
+    volume_usdc: 750.654321,
+    trade_count: 99,
+  };
+}

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -242,13 +242,13 @@ export const PositionSchema = z
 export type PortfolioValue = {
   wallet: EvmAddress;
   /** Total marked portfolio value, in USDC, rounded to four decimals. */
-  value: number;
+  value: DecimalString;
 };
 
 export const PortfolioValueSchema = z
   .object({
     proxy_wallet: EvmAddressSchema,
-    value: z.number(),
+    value: DecimalishSchema,
   })
   .transform(({ proxy_wallet, value }) => ({
     wallet: proxy_wallet,
@@ -256,8 +256,8 @@ export const PortfolioValueSchema = z
   })) satisfies z.ZodType<PortfolioValue>;
 
 /**
- * One cumulative wallet PnL observation. Monetary values are exposed as
- * JavaScript numbers with up to six decimal places.
+ * One cumulative wallet PnL observation. Fractional money and size values
+ * are normalized to decimal strings.
  */
 export type UserPnlPoint = {
   /** Observation time as Unix epoch milliseconds. */
@@ -265,61 +265,60 @@ export type UserPnlPoint = {
   /** Chain block at which the point was observed. */
   sourceBlock: number;
   /** Realized PnL from market positions. */
-  realizedMarketPnl: number;
+  realizedMarketPnl: DecimalString;
   /** Realized PnL from liquidity-provision activity. */
-  realizedLpPnl: number;
+  realizedLpPnl: DecimalString;
   /** Realized PnL from combo positions. */
-  realizedComboPnl: number;
+  realizedComboPnl: DecimalString;
   /** Mark-to-market PnL of open inventory. */
-  unrealizedPnl: number | null;
-  feesRefunded: number | null;
-  makerRebate: number | null;
-  takerRebate: number | null;
-  rewardIncome: number | null;
-  yieldIncome: number | null;
-  referralIncome: number | null;
-  deposits: number | null;
-  withdrawals: number | null;
+  unrealizedPnl: DecimalString | null;
+  feesRefunded: DecimalString | null;
+  makerRebate: DecimalString | null;
+  takerRebate: DecimalString | null;
+  rewardIncome: DecimalString | null;
+  yieldIncome: DecimalString | null;
+  referralIncome: DecimalString | null;
+  deposits: DecimalString | null;
+  withdrawals: DecimalString | null;
   /** Sum of market, liquidity-provision, and combo realized PnL. */
-  realizedPnl: number;
+  realizedPnl: DecimalString;
   /** Rebates plus reward, yield, and referral income. */
-  walletIncome: number | null;
+  walletIncome: DecimalString | null;
   /** Realized plus unrealized position PnL. */
-  positionPnl: number | null;
+  positionPnl: DecimalString | null;
   /** Realized PnL plus wallet income. */
-  settledPnl: number | null;
+  settledPnl: DecimalString | null;
   /** Position PnL plus wallet income. */
-  economicPnl: number | null;
+  economicPnl: DecimalString | null;
   /** Compatibility trading-PnL series. */
-  tradePnl: number | null;
+  tradePnl: DecimalString | null;
   /** Reward, yield, and referral income. */
-  sponsoredIncome: number | null;
+  sponsoredIncome: DecimalString | null;
   /** Cumulative fee charges, represented as a negative amount. */
-  fees: number | null;
+  fees: DecimalString | null;
   /** Fee refunds minus charges. */
-  feesPaid: number | null;
+  feesPaid: DecimalString | null;
   /** Deposits minus withdrawals. */
-  cashflowNet: number | null;
+  cashflowNet: DecimalString | null;
   /** Cumulative maker-attributed fill volume, in shares. */
-  volume: number;
+  volume: DecimalString;
   /** Cumulative maker-attributed fill volume, in USDC. */
-  volumeUsdc: number;
+  volumeUsdc: DecimalString;
   /** Cumulative maker-attributed canonical fill count. */
   tradeCount: number;
 };
 
-const UncoveredAmountSchema = z
-  .number()
-  .nullish()
-  .transform((amount) => amount ?? null);
+const UncoveredAmountSchema = DecimalishSchema.nullish().transform(
+  (amount) => amount ?? null,
+);
 
 export const UserPnlPointSchema = z
   .object({
     timestamp: EpochSecondsToMillisecondsSchema,
     source_block: z.number().int().nonnegative(),
-    realized_market_pnl: z.number(),
-    realized_lp_pnl: z.number(),
-    realized_combo_pnl: z.number(),
+    realized_market_pnl: DecimalishSchema,
+    realized_lp_pnl: DecimalishSchema,
+    realized_combo_pnl: DecimalishSchema,
     unrealized_pnl: UncoveredAmountSchema,
     fees_refunded: UncoveredAmountSchema,
     maker_rebate: UncoveredAmountSchema,
@@ -329,7 +328,7 @@ export const UserPnlPointSchema = z
     referral_income: UncoveredAmountSchema,
     deposits: UncoveredAmountSchema,
     withdrawals: UncoveredAmountSchema,
-    realized_pnl: z.number(),
+    realized_pnl: DecimalishSchema,
     wallet_income: UncoveredAmountSchema,
     position_pnl: UncoveredAmountSchema,
     settled_pnl: UncoveredAmountSchema,
@@ -339,8 +338,8 @@ export const UserPnlPointSchema = z
     fees: UncoveredAmountSchema,
     fees_paid: UncoveredAmountSchema,
     cashflow_net: UncoveredAmountSchema,
-    volume: z.number().nonnegative(),
-    volume_usdc: z.number().nonnegative(),
+    volume: DecimalishSchema,
+    volume_usdc: DecimalishSchema,
     trade_count: z.number().int().nonnegative(),
   })
   .transform(
@@ -400,7 +399,7 @@ export type UserStats = {
   /** Exact number of distinct markets the wallet has traded. */
   trades: number;
   /** Largest resolved position win over $1, in USDC; otherwise zero. */
-  biggestWin: number;
+  biggestWin: DecimalString;
   views: number;
   /** Account join time as Unix epoch milliseconds, when known. */
   joinDate: EpochMilliseconds | null;
@@ -412,7 +411,7 @@ export const UserStatsSchema = z
   .object({
     proxy_wallet: EvmAddressSchema,
     trades: z.number().int().nonnegative(),
-    biggest_win: z.number(),
+    biggest_win: DecimalishSchema,
     views: z.number().int().nonnegative(),
     join_date: EpochSecondsToMillisecondsSchema.nullish(),
     all_time_pnl: UserPnlPointSchema.nullish(),

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -397,7 +397,7 @@ export const UserPnlPointSchema = z
 export type UserStats = {
   wallet: EvmAddress;
   /** Exact number of distinct markets the wallet has traded. */
-  trades: number;
+  tradedMarketCount: number;
   /** Largest resolved position win over $1, in USDC; otherwise zero. */
   biggestWin: DecimalString;
   views: number;
@@ -417,9 +417,17 @@ export const UserStatsSchema = z
     all_time_pnl: UserPnlPointSchema.nullish(),
   })
   .transform(
-    ({ proxy_wallet, biggest_win, join_date, all_time_pnl, ...stats }) => ({
+    ({
+      proxy_wallet,
+      trades,
+      biggest_win,
+      join_date,
+      all_time_pnl,
+      ...stats
+    }) => ({
       ...stats,
       wallet: proxy_wallet,
+      tradedMarketCount: trades,
       biggestWin: biggest_win,
       joinDate: join_date ?? null,
       allTimePnl: all_time_pnl ?? null,

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -17,7 +17,7 @@ import {
   PositionIdSchema,
   type TokenId,
 } from '../shared';
-import { dataPageSchema } from './envelope';
+import { dataEnvelopeSchema, dataPageSchema } from './envelope';
 
 export enum ComboPositionStatus {
   Open = 'OPEN',
@@ -239,10 +239,193 @@ export const PositionSchema = z
     verified: position.verified,
   })) satisfies z.ZodType<Position>;
 
-export const ValueSchema = z.object({
-  user: EvmAddressSchema.nullish(),
-  value: DecimalishSchema.nullish(),
-});
+export type PortfolioValue = {
+  wallet: EvmAddress;
+  /** Total marked portfolio value, in USDC, rounded to four decimals. */
+  value: number;
+};
+
+export const PortfolioValueSchema = z
+  .object({
+    proxy_wallet: EvmAddressSchema,
+    value: z.number(),
+  })
+  .transform(({ proxy_wallet, value }) => ({
+    wallet: proxy_wallet,
+    value,
+  })) satisfies z.ZodType<PortfolioValue>;
+
+/**
+ * One cumulative wallet PnL observation. Monetary values are exposed as
+ * JavaScript numbers with up to six decimal places.
+ */
+export type UserPnlPoint = {
+  /** Observation time as Unix epoch milliseconds. */
+  timestamp: EpochMilliseconds;
+  /** Chain block at which the point was observed. */
+  sourceBlock: number;
+  /** Realized PnL from market positions. */
+  realizedMarketPnl: number;
+  /** Realized PnL from liquidity-provision activity. */
+  realizedLpPnl: number;
+  /** Realized PnL from combo positions. */
+  realizedComboPnl: number;
+  /** Mark-to-market PnL of open inventory. */
+  unrealizedPnl: number | null;
+  feesRefunded: number | null;
+  makerRebate: number | null;
+  takerRebate: number | null;
+  rewardIncome: number | null;
+  yieldIncome: number | null;
+  referralIncome: number | null;
+  deposits: number | null;
+  withdrawals: number | null;
+  /** Sum of market, liquidity-provision, and combo realized PnL. */
+  realizedPnl: number;
+  /** Rebates plus reward, yield, and referral income. */
+  walletIncome: number | null;
+  /** Realized plus unrealized position PnL. */
+  positionPnl: number | null;
+  /** Realized PnL plus wallet income. */
+  settledPnl: number | null;
+  /** Position PnL plus wallet income. */
+  economicPnl: number | null;
+  /** Compatibility trading-PnL series. */
+  tradePnl: number | null;
+  /** Reward, yield, and referral income. */
+  sponsoredIncome: number | null;
+  /** Cumulative fee charges, represented as a negative amount. */
+  fees: number | null;
+  /** Fee refunds minus charges. */
+  feesPaid: number | null;
+  /** Deposits minus withdrawals. */
+  cashflowNet: number | null;
+  /** Cumulative maker-attributed fill volume, in shares. */
+  volume: number;
+  /** Cumulative maker-attributed fill volume, in USDC. */
+  volumeUsdc: number;
+  /** Cumulative maker-attributed canonical fill count. */
+  tradeCount: number;
+};
+
+const UncoveredAmountSchema = z
+  .number()
+  .nullish()
+  .transform((amount) => amount ?? null);
+
+export const UserPnlPointSchema = z
+  .object({
+    timestamp: EpochSecondsToMillisecondsSchema,
+    source_block: z.number().int().nonnegative(),
+    realized_market_pnl: z.number(),
+    realized_lp_pnl: z.number(),
+    realized_combo_pnl: z.number(),
+    unrealized_pnl: UncoveredAmountSchema,
+    fees_refunded: UncoveredAmountSchema,
+    maker_rebate: UncoveredAmountSchema,
+    taker_rebate: UncoveredAmountSchema,
+    reward_income: UncoveredAmountSchema,
+    yield_income: UncoveredAmountSchema,
+    referral_income: UncoveredAmountSchema,
+    deposits: UncoveredAmountSchema,
+    withdrawals: UncoveredAmountSchema,
+    realized_pnl: z.number(),
+    wallet_income: UncoveredAmountSchema,
+    position_pnl: UncoveredAmountSchema,
+    settled_pnl: UncoveredAmountSchema,
+    economic_pnl: UncoveredAmountSchema,
+    trade_pnl: UncoveredAmountSchema,
+    sponsored_income: UncoveredAmountSchema,
+    fees: UncoveredAmountSchema,
+    fees_paid: UncoveredAmountSchema,
+    cashflow_net: UncoveredAmountSchema,
+    volume: z.number().nonnegative(),
+    volume_usdc: z.number().nonnegative(),
+    trade_count: z.number().int().nonnegative(),
+  })
+  .transform(
+    ({
+      source_block,
+      realized_market_pnl,
+      realized_lp_pnl,
+      realized_combo_pnl,
+      unrealized_pnl,
+      fees_refunded,
+      maker_rebate,
+      taker_rebate,
+      reward_income,
+      yield_income,
+      referral_income,
+      realized_pnl,
+      wallet_income,
+      position_pnl,
+      settled_pnl,
+      economic_pnl,
+      trade_pnl,
+      sponsored_income,
+      fees_paid,
+      cashflow_net,
+      volume_usdc,
+      trade_count,
+      ...point
+    }) => ({
+      ...point,
+      sourceBlock: source_block,
+      realizedMarketPnl: realized_market_pnl,
+      realizedLpPnl: realized_lp_pnl,
+      realizedComboPnl: realized_combo_pnl,
+      unrealizedPnl: unrealized_pnl,
+      feesRefunded: fees_refunded,
+      makerRebate: maker_rebate,
+      takerRebate: taker_rebate,
+      rewardIncome: reward_income,
+      yieldIncome: yield_income,
+      referralIncome: referral_income,
+      realizedPnl: realized_pnl,
+      walletIncome: wallet_income,
+      positionPnl: position_pnl,
+      settledPnl: settled_pnl,
+      economicPnl: economic_pnl,
+      tradePnl: trade_pnl,
+      sponsoredIncome: sponsored_income,
+      feesPaid: fees_paid,
+      cashflowNet: cashflow_net,
+      volumeUsdc: volume_usdc,
+      tradeCount: trade_count,
+    }),
+  ) satisfies z.ZodType<UserPnlPoint>;
+
+export type UserStats = {
+  wallet: EvmAddress;
+  /** Exact number of distinct markets the wallet has traded. */
+  trades: number;
+  /** Largest resolved position win over $1, in USDC; otherwise zero. */
+  biggestWin: number;
+  views: number;
+  /** Account join time as Unix epoch milliseconds, when known. */
+  joinDate: EpochMilliseconds | null;
+  /** Latest cumulative all-time PnL observation, when published. */
+  allTimePnl: UserPnlPoint | null;
+};
+
+export const UserStatsSchema = z
+  .object({
+    proxy_wallet: EvmAddressSchema,
+    trades: z.number().int().nonnegative(),
+    biggest_win: z.number(),
+    views: z.number().int().nonnegative(),
+    join_date: EpochSecondsToMillisecondsSchema.nullish(),
+    all_time_pnl: UserPnlPointSchema.nullish(),
+  })
+  .transform(
+    ({ proxy_wallet, biggest_win, join_date, all_time_pnl, ...stats }) => ({
+      ...stats,
+      wallet: proxy_wallet,
+      biggestWin: biggest_win,
+      joinDate: join_date ?? null,
+      allTimePnl: all_time_pnl ?? null,
+    }),
+  ) satisfies z.ZodType<UserStats>;
 
 export const ComboPositionMarketEventSchema = z
   .object({
@@ -385,11 +568,14 @@ export const ComboPositionSchema = z
   );
 
 export const ListPositionsResponseSchema = dataPageSchema(PositionSchema);
-export const FetchPortfolioValueResponseSchema = z.array(ValueSchema);
+export const FetchPortfolioValueResponseSchema =
+  dataEnvelopeSchema(PortfolioValueSchema);
+export const FetchUserStatsResponseSchema = dataEnvelopeSchema(
+  UserStatsSchema.nullable(),
+);
 export const ListComboPositionsResponseSchema =
   dataPageSchema(ComboPositionSchema);
 
-export type Value = z.infer<typeof ValueSchema>;
 export type ComboPositionMarketEvent = z.infer<
   typeof ComboPositionMarketEventSchema
 >;
@@ -399,6 +585,9 @@ export type ComboPosition = z.infer<typeof ComboPositionSchema>;
 export type ListPositionsResponse = z.infer<typeof ListPositionsResponseSchema>;
 export type FetchPortfolioValueResponse = z.infer<
   typeof FetchPortfolioValueResponseSchema
+>;
+export type FetchUserStatsResponse = z.infer<
+  typeof FetchUserStatsResponseSchema
 >;
 export type ListComboPositionsResponse = z.infer<
   typeof ListComboPositionsResponseSchema

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -375,9 +375,7 @@ export function listComboPositions(
 
 const FetchPortfolioValueRequestSchema = z.object({
   user: EvmAddressSchema,
-  conditionId: z
-    .union([ConditionIdSchema, distinctIdList(ConditionIdSchema, 20)])
-    .optional(),
+  conditionIds: distinctIdList(ConditionIdSchema, 20).optional(),
 });
 
 export type FetchPortfolioValueRequest = z.input<
@@ -401,9 +399,9 @@ export const FetchPortfolioValueError = makeErrorGuard(
 /**
  * Fetches the total value for a wallet's positions.
  *
- * When `conditionId` is present, only those single-market positions are
+ * When `conditionIds` is present, only those single-market positions are
  * included; portfolio-level combo positions are excluded. Accepts at most 20
- * distinct condition ids.
+ * distinct condition IDs.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -415,6 +413,7 @@ export const FetchPortfolioValueError = makeErrorGuard(
  * ```ts
  * const value = await fetchPortfolioValue(client, {
  *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+ *   conditionIds: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
  * });
  *
  * // value: PortfolioValue
@@ -424,7 +423,7 @@ export async function fetchPortfolioValue(
   client: BaseClient,
   request: FetchPortfolioValueRequest,
 ): Promise<PortfolioValue> {
-  const { conditionId, ...params } = parseUserInput(
+  const { conditionIds, ...params } = parseUserInput(
     request,
     FetchPortfolioValueRequestSchema,
   );
@@ -434,7 +433,7 @@ export async function fetchPortfolioValue(
       client.data.get('/v2/value', {
         params: toDataSearchParams({
           ...params,
-          condition: conditionId,
+          condition: conditionIds,
         }),
       }),
     ).andThen(validateWith(FetchPortfolioValueResponseSchema)),

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -463,10 +463,10 @@ export const FetchUserStatsError = makeErrorGuard(
 /**
  * Fetches profile and lifetime trading statistics for a wallet.
  *
- * `trades` is the exact number of distinct markets traded. `biggestWin` is
- * the largest resolved position win, and `allTimePnl` is the latest published
- * cumulative PnL observation. Returns `null` when the wallet is not a known
- * user.
+ * `tradedMarketCount` is the exact number of distinct markets traded.
+ * `biggestWin` is the largest resolved position win, and `allTimePnl` is the
+ * latest published cumulative PnL observation. Returns `null` when the wallet
+ * is not a known user.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -11,16 +11,16 @@ import {
   ComboPositionStatus,
   ComboPositionStatusSchema,
   FetchPortfolioValueResponseSchema,
+  FetchUserStatsResponseSchema,
   ListComboPositionsResponseSchema,
   ListPositionsResponseSchema,
+  type PortfolioValue,
   type Position,
   PositionFilterTypeSchema,
   PositionSortBySchema,
   PositionStatusSchema,
   SortDirectionSchema,
-  type Traded,
-  TradedSchema,
-  type Value,
+  type UserStats,
 } from '@polymarket/bindings/data';
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
@@ -374,8 +374,10 @@ export function listComboPositions(
 }
 
 const FetchPortfolioValueRequestSchema = z.object({
-  user: z.string(),
-  market: z.array(z.string()).optional(),
+  user: EvmAddressSchema,
+  conditionId: z
+    .union([ConditionIdSchema, distinctIdList(ConditionIdSchema, 20)])
+    .optional(),
 });
 
 export type FetchPortfolioValueRequest = z.input<
@@ -399,6 +401,10 @@ export const FetchPortfolioValueError = makeErrorGuard(
 /**
  * Fetches the total value for a wallet's positions.
  *
+ * When `conditionId` is present, only those single-market positions are
+ * included; portfolio-level combo positions are excluded. Accepts at most 20
+ * distinct condition ids.
+ *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
@@ -411,39 +417,43 @@ export const FetchPortfolioValueError = makeErrorGuard(
  *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
  * });
  *
- * // value: Value[]
+ * // value: PortfolioValue
  * ```
  */
 export async function fetchPortfolioValue(
   client: BaseClient,
   request: FetchPortfolioValueRequest,
-): Promise<Value[]> {
-  const params = parseUserInput(request, FetchPortfolioValueRequestSchema);
+): Promise<PortfolioValue> {
+  const { conditionId, ...params } = parseUserInput(
+    request,
+    FetchPortfolioValueRequestSchema,
+  );
 
   return unwrap(
-    client.data
-      .get('/value', {
-        params: toLegacyDataSearchParams(params),
-      })
-      .andThen(validateWith(FetchPortfolioValueResponseSchema)),
+    withRateLimitRetry(() =>
+      client.data.get('/v2/value', {
+        params: toDataSearchParams({
+          ...params,
+          condition: conditionId,
+        }),
+      }),
+    ).andThen(validateWith(FetchPortfolioValueResponseSchema)),
   );
 }
 
-const FetchTradedMarketCountRequestSchema = z.object({
-  user: z.string(),
+const FetchUserStatsRequestSchema = z.object({
+  user: EvmAddressSchema,
 });
 
-export type FetchTradedMarketCountRequest = z.input<
-  typeof FetchTradedMarketCountRequestSchema
->;
+export type FetchUserStatsRequest = z.input<typeof FetchUserStatsRequestSchema>;
 
-export type FetchTradedMarketCountError =
+export type FetchUserStatsError =
   | RateLimitError
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
-export const FetchTradedMarketCountError = makeErrorGuard(
+export const FetchUserStatsError = makeErrorGuard(
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -452,35 +462,40 @@ export const FetchTradedMarketCountError = makeErrorGuard(
 );
 
 /**
- * Fetches the total number of markets a wallet has traded.
+ * Fetches profile and lifetime trading statistics for a wallet.
+ *
+ * `trades` is the exact number of distinct markets traded. `biggestWin` is
+ * the largest resolved position win, and `allTimePnl` is the latest published
+ * cumulative PnL observation. Returns `null` when the wallet is not a known
+ * user.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
- * @throws {@link FetchTradedMarketCountError}
+ * @throws {@link FetchUserStatsError}
  * Thrown on failure.
  *
  * @example
  * ```ts
- * const traded = await fetchTradedMarketCount(client, {
+ * const stats = await fetchUserStats(client, {
  *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
  * });
  *
- * // traded === Traded
+ * // stats: UserStats | null
  * ```
  */
-export async function fetchTradedMarketCount(
+export async function fetchUserStats(
   client: BaseClient,
-  request: FetchTradedMarketCountRequest,
-): Promise<Traded> {
-  const params = parseUserInput(request, FetchTradedMarketCountRequestSchema);
+  request: FetchUserStatsRequest,
+): Promise<UserStats | null> {
+  const params = parseUserInput(request, FetchUserStatsRequestSchema);
 
   return unwrap(
-    client.data
-      .get('/traded', {
-        params: toLegacyDataSearchParams(params),
-      })
-      .andThen(validateWith(TradedSchema)),
+    withRateLimitRetry(() =>
+      client.data.get('/v2/user-stats', {
+        params: toDataSearchParams(params),
+      }),
+    ).andThen(validateWith(FetchUserStatsResponseSchema)),
   );
 }
 

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -139,6 +139,10 @@ export type PublicAccountActions = Prettify<{
   /**
    * Fetches the total value for a wallet's positions.
    *
+   * When `conditionId` is present, only those single-market positions are
+   * included; portfolio-level combo positions are excluded. Accepts at most
+   * 20 distinct condition ids.
+   *
    * @throws {@link FetchPortfolioValueError}
    * Thrown on failure.
    *
@@ -290,6 +294,10 @@ export type SecureAccountActions = Prettify<{
   ): Paginated<ComboPosition[]>;
   /**
    * Fetches the total value for a wallet's positions.
+   *
+   * When `conditionId` is present, only those single-market positions are
+   * included; portfolio-level combo positions are excluded. Accepts at most
+   * 20 distinct condition ids.
    *
    * Defaults to the authenticated account's wallet when `user` is omitted.
    *

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -6,9 +6,9 @@ import type {
   Activity,
   ComboActivity,
   ComboPosition,
+  PortfolioValue,
   Position,
-  Traded,
-  Value,
+  UserStats,
 } from '@polymarket/bindings/data';
 import type { Prettify } from '@polymarket/types';
 import {
@@ -17,11 +17,11 @@ import {
   downloadAccountingSnapshot,
   dropNotifications,
   type FetchPortfolioValueRequest,
-  type FetchTradedMarketCountRequest,
+  type FetchUserStatsRequest,
   fetchClosedOnlyMode,
   fetchNotifications,
   fetchPortfolioValue,
-  fetchTradedMarketCount,
+  fetchUserStats,
   type ListAccountTradesRequest,
   type ListActivityRequest,
   type ListComboActivityRequest,
@@ -47,7 +47,7 @@ type DefaultAccountWallet<TRequest extends { user?: string }> = Prettify<
      *
      * @defaultValue `client.account.wallet`
      */
-    user?: TRequest['user'];
+    user?: string;
   }
 >;
 
@@ -57,8 +57,8 @@ export type SecureListComboPositionsRequest =
   DefaultAccountWallet<ListComboPositionsRequest>;
 export type SecureFetchPortfolioValueRequest =
   DefaultAccountWallet<FetchPortfolioValueRequest>;
-export type SecureFetchTradedMarketCountRequest =
-  DefaultAccountWallet<FetchTradedMarketCountRequest>;
+export type SecureFetchUserStatsRequest =
+  DefaultAccountWallet<FetchUserStatsRequest>;
 export type SecureDownloadAccountingSnapshotRequest =
   DefaultAccountWallet<DownloadAccountingSnapshotRequest>;
 export type SecureListActivityRequest =
@@ -149,23 +149,25 @@ export type PublicAccountActions = Prettify<{
    * });
    * ```
    */
-  fetchPortfolioValue(request: FetchPortfolioValueRequest): Promise<Value[]>;
+  fetchPortfolioValue(
+    request: FetchPortfolioValueRequest,
+  ): Promise<PortfolioValue>;
   /**
-   * Fetches the total number of markets a wallet has traded.
+   * Fetches profile and lifetime trading statistics for a wallet.
    *
-   * @throws {@link FetchTradedMarketCountError}
+   * Returns `null` when the wallet is not a known user.
+   *
+   * @throws {@link FetchUserStatsError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const traded = await client.fetchTradedMarketCount({
+   * const stats = await client.fetchUserStats({
    *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
    * });
    * ```
    */
-  fetchTradedMarketCount(
-    request: FetchTradedMarketCountRequest,
-  ): Promise<Traded>;
+  fetchUserStats(request: FetchUserStatsRequest): Promise<UserStats | null>;
   /**
    * Downloads an accounting snapshot archive for a wallet.
    *
@@ -296,18 +298,19 @@ export type SecureAccountActions = Prettify<{
    */
   fetchPortfolioValue(
     request?: SecureFetchPortfolioValueRequest,
-  ): Promise<Value[]>;
+  ): Promise<PortfolioValue>;
   /**
-   * Fetches the total number of markets a wallet has traded.
+   * Fetches profile and lifetime trading statistics for a wallet.
    *
    * Defaults to the authenticated account's wallet when `user` is omitted.
+   * Returns `null` when the wallet is not a known user.
    *
-   * @throws {@link FetchTradedMarketCountError}
+   * @throws {@link FetchUserStatsError}
    * Thrown on failure.
    */
-  fetchTradedMarketCount(
-    request?: SecureFetchTradedMarketCountRequest,
-  ): Promise<Traded>;
+  fetchUserStats(
+    request?: SecureFetchUserStatsRequest,
+  ): Promise<UserStats | null>;
   /**
    * Downloads an accounting snapshot archive for a wallet.
    *
@@ -421,7 +424,7 @@ function publicAccountActions(client: BaseClient): PublicAccountActions {
     listPositions: listPositions.bind(null, client),
     listComboPositions: listComboPositions.bind(null, client),
     fetchPortfolioValue: fetchPortfolioValue.bind(null, client),
-    fetchTradedMarketCount: fetchTradedMarketCount.bind(null, client),
+    fetchUserStats: fetchUserStats.bind(null, client),
     downloadAccountingSnapshot: downloadAccountingSnapshot.bind(null, client),
     listActivity: listActivity.bind(null, client),
     listComboActivity: listComboActivity.bind(null, client),
@@ -457,8 +460,8 @@ export function accountActions(
       listComboPositions(client, withAccountWallet(client, request)),
     fetchPortfolioValue: (request?: SecureFetchPortfolioValueRequest) =>
       fetchPortfolioValue(client, withAccountWallet(client, request)),
-    fetchTradedMarketCount: (request?: SecureFetchTradedMarketCountRequest) =>
-      fetchTradedMarketCount(client, withAccountWallet(client, request)),
+    fetchUserStats: (request?: SecureFetchUserStatsRequest) =>
+      fetchUserStats(client, withAccountWallet(client, request)),
     downloadAccountingSnapshot: (
       request?: SecureDownloadAccountingSnapshotRequest,
     ) => downloadAccountingSnapshot(client, withAccountWallet(client, request)),
@@ -482,7 +485,7 @@ export {
   FetchClosedOnlyModeError,
   FetchNotificationsError,
   FetchPortfolioValueError,
-  FetchTradedMarketCountError,
+  FetchUserStatsError,
   ListAccountTradesError,
   ListActivityError,
   ListComboActivityError,

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -160,6 +160,8 @@ export type PublicAccountActions = Prettify<{
   /**
    * Fetches profile and lifetime trading statistics for a wallet.
    *
+   * `tradedMarketCount` is the exact number of distinct markets traded.
+   *
    * Returns `null` when the wallet is not a known user.
    *
    * @throws {@link FetchUserStatsError}
@@ -310,6 +312,8 @@ export type SecureAccountActions = Prettify<{
   ): Promise<PortfolioValue>;
   /**
    * Fetches profile and lifetime trading statistics for a wallet.
+   *
+   * `tradedMarketCount` is the exact number of distinct markets traded.
    *
    * Defaults to the authenticated account's wallet when `user` is omitted.
    * Returns `null` when the wallet is not a known user.

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -139,9 +139,9 @@ export type PublicAccountActions = Prettify<{
   /**
    * Fetches the total value for a wallet's positions.
    *
-   * When `conditionId` is present, only those single-market positions are
+   * When `conditionIds` is present, only those single-market positions are
    * included; portfolio-level combo positions are excluded. Accepts at most
-   * 20 distinct condition ids.
+   * 20 distinct condition IDs.
    *
    * @throws {@link FetchPortfolioValueError}
    * Thrown on failure.
@@ -150,6 +150,7 @@ export type PublicAccountActions = Prettify<{
    * ```ts
    * const value = await client.fetchPortfolioValue({
    *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+   *   conditionIds: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
    * });
    * ```
    */
@@ -295,9 +296,9 @@ export type SecureAccountActions = Prettify<{
   /**
    * Fetches the total value for a wallet's positions.
    *
-   * When `conditionId` is present, only those single-market positions are
+   * When `conditionIds` is present, only those single-market positions are
    * included; portfolio-level combo positions are excluded. Accepts at most
-   * 20 distinct condition ids.
+   * 20 distinct condition IDs.
    *
    * Defaults to the authenticated account's wallet when `user` is omitted.
    *

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -198,7 +198,7 @@ describe('Portfolio', () => {
       expect(result).toEqual(
         expect.objectContaining({
           wallet: TEST_USER,
-          value: expect.any(Number),
+          value: expect.any(String),
         }),
       );
     });
@@ -246,7 +246,7 @@ describe('Portfolio', () => {
         expect.objectContaining({
           wallet: TEST_USER,
           trades: expect.any(Number),
-          biggestWin: expect.any(Number),
+          biggestWin: expect.any(String),
           views: expect.any(Number),
           joinDate: expect.any(Number),
         }),
@@ -255,9 +255,9 @@ describe('Portfolio', () => {
         expect.objectContaining({
           timestamp: expect.any(Number),
           sourceBlock: expect.any(Number),
-          realizedPnl: expect.any(Number),
-          volume: expect.any(Number),
-          volumeUsdc: expect.any(Number),
+          realizedPnl: expect.any(String),
+          volume: expect.any(String),
+          volumeUsdc: expect.any(String),
           tradeCount: expect.any(Number),
         }),
       );

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -10,6 +10,8 @@ import { describe, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
+const TEST_CONDITION_ID =
+  '0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422';
 
 describe('Portfolio', () => {
   afterEach(() => {
@@ -193,12 +195,28 @@ describe('Portfolio', () => {
         user: TEST_USER,
       });
 
-      expect(result).toEqual([
+      expect(result).toEqual(
         expect.objectContaining({
-          user: TEST_USER,
-          value: expect.any(String),
+          wallet: TEST_USER,
+          value: expect.any(Number),
         }),
-      ]);
+      );
+    });
+
+    it('sends condition filters with the canonical query key', async ({
+      publicClient,
+    }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      await publicClient.fetchPortfolioValue({
+        user: TEST_USER,
+        conditionId: TEST_CONDITION_ID,
+      });
+
+      const [request] = dataRequests(fetchSpy, '/v2/value');
+      expect(request?.get('condition')).toBe(TEST_CONDITION_ID);
+      expect(request?.has('condition_id')).toBe(false);
+      expect(request?.has('market')).toBe(false);
     });
 
     it('defaults secure clients to the authenticated wallet', async ({
@@ -207,24 +225,40 @@ describe('Portfolio', () => {
     }) => {
       const result = await secureClientWithDepositWallet.fetchPortfolioValue();
 
-      expect(result[0]?.user).toSatisfy((user) =>
-        isSameEvmAddress(user, depositWalletAddress),
+      expect(result.wallet).toSatisfy((wallet) =>
+        isSameEvmAddress(wallet, depositWalletAddress),
       );
     });
   });
 
-  describe('fetchTradedMarketCount', () => {
-    it('fetches total traded market count for a wallet', async ({
+  describe('fetchUserStats', () => {
+    it('fetches profile and lifetime trading stats', async ({
       publicClient,
     }) => {
-      const result = await publicClient.fetchTradedMarketCount({
-        user: TEST_USER,
-      });
+      const result = await publicClient
+        .fetchUserStats({
+          user: TEST_USER,
+        })
+        .then(expectPresent);
+      const pnl = expectPresent(result.allTimePnl);
 
       expect(result).toEqual(
         expect.objectContaining({
-          traded: expect.any(Number),
-          user: TEST_USER,
+          wallet: TEST_USER,
+          trades: expect.any(Number),
+          biggestWin: expect.any(Number),
+          views: expect.any(Number),
+          joinDate: expect.any(Number),
+        }),
+      );
+      expect(pnl).toEqual(
+        expect.objectContaining({
+          timestamp: expect.any(Number),
+          sourceBlock: expect.any(Number),
+          realizedPnl: expect.any(Number),
+          volume: expect.any(Number),
+          volumeUsdc: expect.any(Number),
+          tradeCount: expect.any(Number),
         }),
       );
     });
@@ -233,11 +267,13 @@ describe('Portfolio', () => {
       depositWalletAddress,
       secureClientWithDepositWallet,
     }) => {
-      const result =
-        await secureClientWithDepositWallet.fetchTradedMarketCount();
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
-      expect(result.user).toSatisfy((user) =>
-        isSameEvmAddress(user, depositWalletAddress),
+      await secureClientWithDepositWallet.fetchUserStats();
+
+      const [request] = dataRequests(fetchSpy, '/v2/user-stats');
+      expect(request?.get('user')).toSatisfy(
+        (user) => user !== null && isSameEvmAddress(user, depositWalletAddress),
       );
     });
   });
@@ -271,8 +307,15 @@ describe('Portfolio', () => {
 function comboPositionRequests(
   fetchSpy: MockInstance<typeof fetch>,
 ): URLSearchParams[] {
+  return dataRequests(fetchSpy, '/v2/positions/combos');
+}
+
+function dataRequests(
+  fetchSpy: MockInstance<typeof fetch>,
+  pathname: string,
+): URLSearchParams[] {
   return fetchSpy.mock.calls
     .map(([input]) => (input instanceof Request ? input.url : String(input)))
-    .filter((url) => new URL(url).pathname === '/v2/positions/combos')
+    .filter((url) => new URL(url).pathname === pathname)
     .map((url) => new URL(url).searchParams);
 }

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -245,7 +245,7 @@ describe('Portfolio', () => {
       expect(result).toEqual(
         expect.objectContaining({
           wallet: TEST_USER,
-          trades: expect.any(Number),
+          tradedMarketCount: expect.any(Number),
           biggestWin: expect.any(String),
           views: expect.any(Number),
           joinDate: expect.any(Number),

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -210,7 +210,7 @@ describe('Portfolio', () => {
 
       await publicClient.fetchPortfolioValue({
         user: TEST_USER,
-        conditionId: TEST_CONDITION_ID,
+        conditionIds: [TEST_CONDITION_ID],
       });
 
       const [request] = dataRequests(fetchSpy, '/v2/value');


### PR DESCRIPTION
## Summary

- migrate `fetchPortfolioValue` to the V2 object contract and canonical condition filter
- add `fetchUserStats` profile and cumulative PnL models
- normalize fractional money and size fields to `DecimalString`, matching the existing V2 SDK contract
- remove the obsolete `fetchTradedMarketCount` surface while preserving accounting snapshots

Linear: DEV-635

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:types && pnpm test:bindings && pnpm test:client`
- focused live portfolio value and user stats integration tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public SDK surface for portfolio value and traded-market count, with new PnL/stat fields that downstream apps must adopt correctly.
> 
> **Overview**
> **Breaking** portfolio summary APIs move to Data `/v2` with updated shapes and filters.
> 
> `fetchPortfolioValue` now calls `/v2/value` (with rate-limit retry), returns a single `PortfolioValue` (`wallet` + USDC `value` as `DecimalString`) instead of a `Value[]`, and filters via optional `conditionIds` (serialized as `condition`, max 20) rather than legacy `market`. Bindings replace `ValueSchema` with `PortfolioValueSchema` wrapped in `dataEnvelopeSchema`.
> 
> `fetchTradedMarketCount` and `TradedSchema` are removed. **`fetchUserStats`** (`/v2/user-stats`) returns `UserStats | null` with `tradedMarketCount`, profile fields, and optional `allTimePnl` (`UserPnlPoint` with decimal-string money/size fields). Account decorators and error guards are updated accordingly; **`downloadAccountingSnapshot`** is unchanged.
> 
> Unit tests cover schema normalization; integration tests assert v2 query params and response types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3c3f7ff0074a418484ccbb2ba903052fa23ab8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->