### PR TITLE
fix(bindings): name yearly builder volume interval

### DIFF
--- a/.changeset/builder-volume-year-interval.md
+++ b/.changeset/builder-volume-year-interval.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': patch
+'@polymarket/client': patch
+---
+
+Expose the yearly builder-volume bucket as `BuilderVolumeInterval.Year` while preserving the wire value `all`.

--- a/packages/bindings/src/data/leaderboard.ts
+++ b/packages/bindings/src/data/leaderboard.ts
@@ -26,7 +26,7 @@ export enum BuilderVolumeInterval {
   Week = 'week',
   Month = 'month',
   /** Groups the series by calendar year. */
-  All = 'all',
+  Year = 'all',
 }
 
 export const BuilderVolumeIntervalSchema = z.enum(BuilderVolumeInterval);

--- a/packages/client/src/actions/leaderboards.ts
+++ b/packages/client/src/actions/leaderboards.ts
@@ -161,11 +161,11 @@ export const FetchBuilderVolumeError = makeErrorGuard(
 /**
  * Fetches the per-builder volume time series.
  *
- * `interval` controls bucket width and defaults to daily; `all` means one
- * bucket per calendar year. `bucketLimit` returns that many complete recent
- * buckets (default 30, max 90), not that many builder rows. Results are newest
- * bucket first, and volume is measured in shares. Transient rate limits are
- * retried automatically.
+ * `interval` controls bucket width and defaults to daily; use
+ * {@link BuilderVolumeInterval.Year} for one bucket per calendar year.
+ * `bucketLimit` returns that many complete recent buckets (default 30, max 90),
+ * not that many builder rows. Results are newest bucket first, and volume is
+ * measured in shares. Transient rate limits are retried automatically.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.

--- a/packages/client/src/decorators/analytics.ts
+++ b/packages/client/src/decorators/analytics.ts
@@ -106,11 +106,11 @@ export type AnalyticsActions = {
   /**
    * Fetches the per-builder volume time series.
    *
-   * `interval` controls bucket width and defaults to daily; `all` means one
-   * bucket per calendar year. `bucketLimit` returns that many complete recent
-   * buckets (default 30, max 90), not that many builder rows. Results are newest
-   * bucket first, and volume is measured in shares. Transient rate limits are
-   * retried automatically.
+   * `interval` controls bucket width and defaults to daily; use
+   * {@link BuilderVolumeInterval.Year} for one bucket per calendar year.
+   * `bucketLimit` returns that many complete recent buckets (default 30, max 90),
+   * not that many builder rows. Results are newest bucket first, and volume is
+   * measured in shares. Transient rate limits are retried automatically.
    *
    * @throws {@link FetchBuilderVolumeError}
    * Thrown on failure.


### PR DESCRIPTION
## Summary

- expose `BuilderVolumeInterval.Year` while preserving the Data API wire value `all`
- align the action and decorator docs with the calendar-year bucket semantics

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:bindings`
- `pnpm test:client`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Wire protocol and runtime behavior are unchanged; only the public enum name and docs differ, though TypeScript callers using `BuilderVolumeInterval.All` must switch to `.Year`.
> 
> **Overview**
> Renames the builder volume time-series bucket enum from **`BuilderVolumeInterval.All`** to **`BuilderVolumeInterval.Year`**, while keeping the Data API wire value **`all`** so requests are unchanged.
> 
> Adds a patch changeset for `@polymarket/bindings` and `@polymarket/client`. Updates JSDoc on **`fetchBuilderVolume`** and the analytics decorator to point callers at **`BuilderVolumeInterval.Year`** for calendar-year buckets instead of describing the raw **`all`** string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bdc10118d582b5c9e94c117d7eed15a679cb02f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->