### PR TITLE
feat(bindings): expose market protocol versions

### DIFF
--- a/.changeset/expose-market-protocol-version.md
+++ b/.changeset/expose-market-protocol-version.md
@@ -3,4 +3,4 @@
 "@polymarket/client": minor
 ---
 
-Expose forward-compatible market protocol versions.
+Expose protocol versions on markets and events.

--- a/.changeset/expose-market-protocol-version.md
+++ b/.changeset/expose-market-protocol-version.md
@@ -1,0 +1,6 @@
+---
+"@polymarket/bindings": minor
+"@polymarket/client": minor
+---
+
+Expose forward-compatible market protocol versions.

--- a/packages/bindings/src/gamma/event.test.ts
+++ b/packages/bindings/src/gamma/event.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import { EventSchema, TeamOrdering } from './event';
+import { ProtocolVersion } from './market';
 
 describe('EventSchema', () => {
+  it('exposes the protocol version shared by its markets', () => {
+    const event = EventSchema.parse({
+      id: '570555',
+      version: ProtocolVersion.V2,
+    });
+
+    expect(event.version).toBe(ProtocolVersion.V2);
+  });
+
   it('exposes parentEventId as a string event id', () => {
     const event = EventSchema.parse({
       id: '570555',

--- a/packages/bindings/src/gamma/event.ts
+++ b/packages/bindings/src/gamma/event.ts
@@ -39,6 +39,7 @@ import {
   hasBinaryOutcomes,
   type Market,
   normalizeMarket,
+  ProtocolVersion,
 } from './market';
 
 const BestLineIdSchema = z.string().transform(toBestLineId);
@@ -63,6 +64,7 @@ export const SeriesIdSchema = z
 const SportIdSchema = z.number().int().transform(toSportId);
 const TeamIdSchema = z.number().int().transform(toTeamId);
 const TemplateIdSchema = z.string().transform(toTemplateId);
+const ProtocolVersionSchema = z.enum(ProtocolVersion);
 
 export const CollectionReferenceSchema = z.object({
   id: CollectionIdSchema,
@@ -379,6 +381,8 @@ export type EventPartner = {
 
 export type Event = {
   id: EventId;
+  /** Protocol version shared by every market in this event. */
+  version?: ProtocolVersion | null;
   parentEventId?: EventId | null;
   ticker?: string | null;
   slug?: string | null;
@@ -411,6 +415,7 @@ export type Event = {
 
 export const GammaEventSchema = z.object({
   id: EventIdSchema,
+  version: ProtocolVersionSchema.nullish(),
   ticker: z.string().nullish(),
   slug: z.string().nullish(),
   title: z.string().nullish(),
@@ -569,6 +574,7 @@ export type SportsMetadata = z.infer<typeof SportsMetadataSchema>;
 function normalizeEvent(event: GammaEvent): Event {
   return {
     id: event.id,
+    version: event.version,
     parentEventId: event.parentEventId,
     ticker: event.ticker,
     slug: event.slug,

--- a/packages/bindings/src/gamma/market.test.ts
+++ b/packages/bindings/src/gamma/market.test.ts
@@ -4,6 +4,7 @@ import {
   ListMarketsKeysetResponseSchema,
   ListMarketsResponseSchema,
   MarketSchema,
+  ProtocolVersion,
 } from './market';
 
 const rawBinaryMarket = {
@@ -62,38 +63,49 @@ describe('MarketSchema', () => {
   it.each([
     {
       name: 'legacy market',
-      identifiers: { clobTokenIds: '["11", "12"]' },
+      identifiers: {
+        clobTokenIds: '["11", "12"]',
+        version: ProtocolVersion.V1,
+      },
       expected: {
         yes: { tokenId: '11', positionId: null },
         no: { tokenId: '12', positionId: null },
       },
       marketPositionIds: [],
+      protocolVersion: ProtocolVersion.V1,
     },
     {
       name: 'PolyV2 market',
-      identifiers: { positionIds: '["21", "22"]' },
+      identifiers: {
+        positionIds: '["21", "22"]',
+        version: ProtocolVersion.V2,
+      },
       expected: {
         yes: { tokenId: null, positionId: '21' },
         no: { tokenId: null, positionId: '22' },
       },
       marketPositionIds: ['21', '22'],
+      protocolVersion: ProtocolVersion.V2,
     },
     {
       name: 'CTF market with Combos',
       identifiers: {
         clobTokenIds: '["11", "12"]',
         positionIds: '["21", "22"]',
+        version: ProtocolVersion.V1,
       },
       expected: {
         yes: { tokenId: '11', positionId: '21' },
         no: { tokenId: '12', positionId: '22' },
       },
       marketPositionIds: ['21', '22'],
+      protocolVersion: ProtocolVersion.V1,
     },
   ])('normalizes outcome identifiers for a $name', ({
     identifiers,
     expected,
     marketPositionIds,
+    protocolVersion,
   }) => {
     const market = MarketSchema.parse({
       ...rawBinaryMarket,
@@ -103,6 +115,16 @@ describe('MarketSchema', () => {
     expect(market.outcomes.yes).toEqual(expect.objectContaining(expected.yes));
     expect(market.outcomes.no).toEqual(expect.objectContaining(expected.no));
     expect(market.positionIds).toEqual(marketPositionIds);
+    expect(market.version).toBe(protocolVersion);
+  });
+
+  it('passes unknown protocol versions through as strings', () => {
+    const market = MarketSchema.parse({
+      ...rawBinaryMarket,
+      version: 'v3',
+    });
+
+    expect(market.version).toBe('v3');
   });
 
   it.each([

--- a/packages/bindings/src/gamma/market.test.ts
+++ b/packages/bindings/src/gamma/market.test.ts
@@ -62,7 +62,7 @@ describe('MarketSchema', () => {
 
   it.each([
     {
-      name: 'legacy market',
+      name: 'CTF market',
       identifiers: {
         clobTokenIds: '["11", "12"]',
         version: ProtocolVersion.V1,
@@ -118,13 +118,13 @@ describe('MarketSchema', () => {
     expect(market.version).toBe(protocolVersion);
   });
 
-  it('passes unknown protocol versions through as strings', () => {
-    const market = MarketSchema.parse({
+  it('rejects unknown protocol versions', () => {
+    const result = MarketSchema.safeParse({
       ...rawBinaryMarket,
       version: 'v3',
     });
 
-    expect(market.version).toBe('v3');
+    expect(result.success).toBe(false);
   });
 
   it('accepts a null protocol version', () => {

--- a/packages/bindings/src/gamma/market.test.ts
+++ b/packages/bindings/src/gamma/market.test.ts
@@ -127,6 +127,15 @@ describe('MarketSchema', () => {
     expect(market.version).toBe('v3');
   });
 
+  it('accepts a null protocol version', () => {
+    const market = MarketSchema.parse({
+      ...rawBinaryMarket,
+      version: null,
+    });
+
+    expect(market.version).toBeNull();
+  });
+
   it.each([
     CTF_CONDITION_ID,
     POLYV2_CONDITION_ID,

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -209,7 +209,7 @@ export type MarketTag = {
 export type Market = {
   id: MarketId;
   /** Protocol version used to trade this market. */
-  version?: MarketProtocolVersion;
+  version?: MarketProtocolVersion | null;
   slug?: string | null;
   conditionId: ConditionId | null;
   question?: string | null;
@@ -234,7 +234,7 @@ export type Market = {
 
 export const GammaMarketSchema = z.object({
   id: MarketIdSchema,
-  version: ProtocolVersionSchema.optional(),
+  version: ProtocolVersionSchema.nullish(),
   question: z.string().nullish(),
   conditionId: z
     .preprocess(emptyStringToNull, ConditionIdResponseSchema.nullish())

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -83,6 +83,17 @@ export type ComboStatus = ComboKnownStatus | (string & {});
 
 const ComboStatusSchema = z.string().transform((value): ComboStatus => value);
 
+export enum ProtocolVersion {
+  V1 = 'v1',
+  V2 = 'v2',
+}
+
+export type MarketProtocolVersion = ProtocolVersion | (string & {});
+
+export const ProtocolVersionSchema = z
+  .string()
+  .transform((value): MarketProtocolVersion => value);
+
 export enum UmaResolutionStatus {
   Disputed = 'disputed',
   Proposed = 'proposed',
@@ -197,6 +208,8 @@ export type MarketTag = {
 
 export type Market = {
   id: MarketId;
+  /** Protocol version used to trade this market. */
+  version?: MarketProtocolVersion;
   slug?: string | null;
   conditionId: ConditionId | null;
   question?: string | null;
@@ -221,6 +234,7 @@ export type Market = {
 
 export const GammaMarketSchema = z.object({
   id: MarketIdSchema,
+  version: ProtocolVersionSchema.optional(),
   question: z.string().nullish(),
   conditionId: z
     .preprocess(emptyStringToNull, ConditionIdResponseSchema.nullish())
@@ -440,6 +454,7 @@ export type FetchMarketTagsResponse = z.infer<
 export function normalizeMarket(market: GammaMarket): Market {
   return {
     id: market.id,
+    version: market.version,
     slug: market.slug,
     conditionId: market.conditionId,
     question: market.question,

--- a/packages/bindings/src/gamma/market.ts
+++ b/packages/bindings/src/gamma/market.ts
@@ -88,11 +88,7 @@ export enum ProtocolVersion {
   V2 = 'v2',
 }
 
-export type MarketProtocolVersion = ProtocolVersion | (string & {});
-
-export const ProtocolVersionSchema = z
-  .string()
-  .transform((value): MarketProtocolVersion => value);
+const ProtocolVersionSchema = z.enum(ProtocolVersion);
 
 export enum UmaResolutionStatus {
   Disputed = 'disputed',
@@ -209,7 +205,7 @@ export type MarketTag = {
 export type Market = {
   id: MarketId;
   /** Protocol version used to trade this market. */
-  version?: MarketProtocolVersion | null;
+  version?: ProtocolVersion | null;
   slug?: string | null;
   conditionId: ConditionId | null;
   question?: string | null;

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -12,6 +12,7 @@ export { ActivityType } from '@polymarket/bindings/data';
 export type * from '@polymarket/bindings/gamma';
 export {
   ComboKnownStatus,
+  ProtocolVersion,
   TeamOrdering,
   WalletType,
 } from '@polymarket/bindings/gamma';


### PR DESCRIPTION
Expose known market protocol versions while preserving unknown future values as strings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive bindings/schema fields with minor package bumps; stricter parsing only affects responses that include unsupported protocol version strings.
> 
> **Overview**
> Adds a **`ProtocolVersion`** enum (`v1` / `v2`) and optional **`version`** on normalized **markets** and **events**, parsed from Gamma responses and passed through normalization.
> 
> Validation only accepts known enum values or **`null`**; unknown strings (e.g. `v3`) fail schema parsing. **`@polymarket/client`** re-exports **`ProtocolVersion`** for app use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53a5caa5c700a5cd8c35fb5747405d7055dcd861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->