### PR TITLE
feat(data): migrate market metrics to v2

### DIFF
--- a/.changeset/data-v2-market-metrics.md
+++ b/.changeset/data-v2-market-metrics.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': minor
+'@polymarket/client': minor
+---
+
+**Breaking**: migrate open-interest and live-volume reads to their v2 contracts. Replace `listOpenInterest` with `fetchOpenInterest`, use condition and event identifiers, and expose cumulative taker volume explicitly.

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -69,26 +69,20 @@ export const MetaHolderSchema = z
   })) satisfies z.ZodType<MetaHolder>;
 
 export type OpenInterest = {
-  /** Condition ID of the market, or `GLOBAL` for the global aggregate. */
-  conditionId: ConditionId | 'GLOBAL';
+  /** Condition ID of the market, or `null` for the global aggregate. */
+  conditionId: ConditionId | null;
   /** Priced gross open interest in USDC. */
   value: DecimalString;
 };
 
 export const OpenInterestSchema = z
   .object({
-    condition_id: z.union([
-      ConditionIdSchema.refine(
-        (conditionId) => conditionId.length === 66,
-        'Expected a 32-byte condition ID',
-      ),
-      z.literal('GLOBAL'),
-    ]),
+    condition_id: z.union([ConditionIdSchema, z.literal('GLOBAL')]),
     value: DecimalishSchema,
   })
-  .transform(({ condition_id, ...rest }) => ({
-    ...rest,
-    conditionId: condition_id,
+  .transform(({ condition_id, value }) => ({
+    conditionId: condition_id === 'GLOBAL' ? null : condition_id,
+    value,
   })) satisfies z.ZodType<OpenInterest>;
 
 export type MarketLiveVolume = {
@@ -100,13 +94,7 @@ export type MarketLiveVolume = {
 
 export const MarketLiveVolumeSchema = z
   .object({
-    condition_id: z.preprocess(
-      emptyStringToNull,
-      ConditionIdSchema.refine(
-        (conditionId) => conditionId.length === 66,
-        'Expected a 32-byte condition ID',
-      ).nullable(),
-    ),
+    condition_id: z.preprocess(emptyStringToNull, ConditionIdSchema.nullable()),
     taker_volume: DecimalishSchema,
   })
   .transform(({ condition_id, taker_volume }) => ({

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -11,6 +11,7 @@ import {
   type PositionId,
   type TokenId,
 } from '../shared';
+import { dataEnvelopeSchema } from './envelope';
 
 export type Holder = {
   wallet: EvmAddress | null | undefined;
@@ -68,58 +69,80 @@ export const MetaHolderSchema = z
   })) satisfies z.ZodType<MetaHolder>;
 
 export type OpenInterest = {
-  /** Condition ID of the market whose open interest is reported. */
-  conditionId: ConditionId | null | undefined;
-  /** @deprecated Use `conditionId`. */
-  market: ConditionId | null | undefined;
-  value?: DecimalString | null;
+  /** Condition ID of the market, or `GLOBAL` for the global aggregate. */
+  conditionId: ConditionId | 'GLOBAL';
+  /** Priced gross open interest in USDC. */
+  value: DecimalString;
 };
 
 export const OpenInterestSchema = z
   .object({
-    market: ConditionIdSchema.nullish(),
-    value: DecimalishSchema.nullish(),
+    condition_id: z.union([
+      ConditionIdSchema.refine(
+        (conditionId) => conditionId.length === 66,
+        'Expected a 32-byte condition ID',
+      ),
+      z.literal('GLOBAL'),
+    ]),
+    value: DecimalishSchema,
   })
-  .transform(({ market, ...rest }) => ({
+  .transform(({ condition_id, ...rest }) => ({
     ...rest,
-    conditionId: market,
-    market,
+    conditionId: condition_id,
   })) satisfies z.ZodType<OpenInterest>;
 
-export type MarketVolume = {
-  /** Condition ID of the market whose live volume is reported. */
-  conditionId: ConditionId | null | undefined;
-  /** @deprecated Use `conditionId`. */
-  market: ConditionId | null | undefined;
-  value?: DecimalString | null;
+export type MarketLiveVolume = {
+  /** Condition ID of the market, or `null` when the source row is unidentified. */
+  conditionId: ConditionId | null;
+  /** Cumulative one-side taker volume in shares. */
+  takerVolume: DecimalString;
 };
 
-export const MarketVolumeSchema = z
+export const MarketLiveVolumeSchema = z
   .object({
-    market: z.preprocess(emptyStringToNull, ConditionIdSchema.nullish()),
-    value: DecimalishSchema.nullish(),
+    condition_id: z.preprocess(
+      emptyStringToNull,
+      ConditionIdSchema.refine(
+        (conditionId) => conditionId.length === 66,
+        'Expected a 32-byte condition ID',
+      ).nullable(),
+    ),
+    taker_volume: DecimalishSchema,
   })
-  .transform(({ market, ...rest }) => ({
-    ...rest,
-    conditionId: market,
-    market,
-  })) satisfies z.ZodType<MarketVolume>;
+  .transform(({ condition_id, taker_volume }) => ({
+    conditionId: condition_id,
+    takerVolume: taker_volume,
+  })) satisfies z.ZodType<MarketLiveVolume>;
 
-export const LiveVolumeSchema = z.object({
-  total: DecimalishSchema.nullish(),
-  markets: z.array(MarketVolumeSchema).nullish(),
-});
+export type LiveVolume = {
+  /** Sum of every returned market's taker volume, in shares. */
+  takerVolumeTotal: DecimalString;
+  /** Markets ordered by taker volume descending. */
+  markets: MarketLiveVolume[];
+};
+
+export const LiveVolumeSchema = z
+  .object({
+    taker_volume_total: DecimalishSchema,
+    conditions: z.array(MarketLiveVolumeSchema),
+  })
+  .transform(({ conditions, taker_volume_total }) => ({
+    markets: conditions,
+    takerVolumeTotal: taker_volume_total,
+  })) satisfies z.ZodType<LiveVolume>;
 
 export const ListMarketHoldersResponseSchema = z.array(MetaHolderSchema);
-export const ListOpenInterestResponseSchema = z.array(OpenInterestSchema);
-export const FetchEventLiveVolumeResponseSchema = z.array(LiveVolumeSchema);
+export const FetchOpenInterestResponseSchema = dataEnvelopeSchema(
+  z.array(OpenInterestSchema),
+);
+export const FetchEventLiveVolumeResponseSchema =
+  dataEnvelopeSchema(LiveVolumeSchema);
 
-export type LiveVolume = z.infer<typeof LiveVolumeSchema>;
 export type ListMarketHoldersResponse = z.infer<
   typeof ListMarketHoldersResponseSchema
 >;
-export type ListOpenInterestResponse = z.infer<
-  typeof ListOpenInterestResponseSchema
+export type FetchOpenInterestResponse = z.infer<
+  typeof FetchOpenInterestResponseSchema
 >;
 export type FetchEventLiveVolumeResponse = z.infer<
   typeof FetchEventLiveVolumeResponseSchema

--- a/packages/bindings/src/data/resolutions.ts
+++ b/packages/bindings/src/data/resolutions.ts
@@ -91,10 +91,7 @@ export type Resolution = {
 export const ResolutionSchema = z
   .object({
     question_id: QuestionIdSchema.optional(),
-    condition_id: ConditionIdSchema.refine(
-      (conditionId) => conditionId.length === 66,
-      'Expected a 32-byte condition ID',
-    ).optional(),
+    condition_id: ConditionIdSchema.optional(),
     status: ResolutionStatusSchema,
     extended_review: z.boolean(),
     was_disputed: z.boolean(),

--- a/packages/client/src/actions/events.ts
+++ b/packages/client/src/actions/events.ts
@@ -1,12 +1,8 @@
 import {
-  type ConditionId,
-  ConditionIdSchema,
-  EventIdSchema,
   IsoCalendarDateStringSchema,
   IsoDateTimeStringSchema,
   PaginationCursorSchema,
   QuestionIdSchema,
-  toConditionId,
 } from '@polymarket/bindings';
 import {
   FetchEventLiveVolumeResponseSchema,
@@ -38,9 +34,10 @@ import { parsePolymarketSlugUrl } from '../polymarket-url';
 import { validateWith } from '../response';
 import { withRateLimitRetry } from '../retry';
 import {
+  CanonicalMarketConditionIdSchema,
+  PositiveInt32EventIdSchema,
   snakeCase,
   toDataSearchParams,
-  toLegacyDataSearchParams,
   toSearchParams,
 } from './params';
 
@@ -127,14 +124,6 @@ const FetchEventTagsRequestSchema = z.object({
 });
 
 export type FetchEventTagsRequest = z.input<typeof FetchEventTagsRequestSchema>;
-
-const FetchEventLiveVolumeRequestSchema = z.object({
-  id: z.string(),
-});
-
-export type FetchEventLiveVolumeRequest = z.input<
-  typeof FetchEventLiveVolumeRequestSchema
->;
 
 type ListEventsParams = z.output<typeof ListEventsRequestSchema>;
 
@@ -330,30 +319,8 @@ export async function fetchEventTags(
   );
 }
 
-function toResolutionConditionId(conditionId: ConditionId): ConditionId {
-  const paddedConditionId =
-    conditionId.length === 64 ? `${conditionId}00` : conditionId;
-
-  return toConditionId(paddedConditionId.toLowerCase());
-}
-
-function isSupportedResolutionConditionId(conditionId: ConditionId): boolean {
-  if (conditionId.length === 66) return true;
-
-  const normalizedConditionId = conditionId.toLowerCase();
-  return (
-    normalizedConditionId.startsWith('0x01') ||
-    normalizedConditionId.startsWith('0x02')
-  );
-}
-
-const ResolutionConditionIdSchema = ConditionIdSchema.refine(
-  isSupportedResolutionConditionId,
-  'Expected a 32-byte condition ID or a 31-byte protocol v2 market condition ID',
-).transform(toResolutionConditionId);
-
 const ResolutionConditionIdsSchema = z
-  .array(ResolutionConditionIdSchema)
+  .array(CanonicalMarketConditionIdSchema)
   .min(1)
   .transform((conditionIds) => [...new Set(conditionIds)])
   .refine(
@@ -362,13 +329,7 @@ const ResolutionConditionIdsSchema = z
   );
 
 const ResolutionEventIdsSchema = z
-  .array(
-    EventIdSchema.refine(
-      (eventId) =>
-        /^[1-9]\d*$/.test(eventId) && BigInt(eventId) <= 2_147_483_647n,
-      'Expected a positive 32-bit event ID',
-    ),
-  )
+  .array(PositiveInt32EventIdSchema)
   .min(1)
   .transform((eventIds) => [...new Set(eventIds)])
   .refine((eventIds) => eventIds.length <= 20, 'At most 20 distinct event ids');
@@ -474,6 +435,17 @@ export async function fetchResolutions(
   );
 }
 
+const FetchEventLiveVolumeRequestSchema = z.object({
+  eventIds: z
+    .array(PositiveInt32EventIdSchema)
+    .min(1)
+    .transform((eventIds) => [...new Set(eventIds)]),
+});
+
+export type FetchEventLiveVolumeRequest = z.input<
+  typeof FetchEventLiveVolumeRequestSchema
+>;
+
 export type FetchEventLiveVolumeError =
   | RateLimitError
   | RequestRejectedError
@@ -489,7 +461,12 @@ export const FetchEventLiveVolumeError = makeErrorGuard(
 );
 
 /**
- * Fetches live volume for an event.
+ * Fetches cumulative taker volume for one or more events.
+ *
+ * Results contain one row per market, ordered by taker volume descending, and
+ * a total across all returned markets. Volume is measured in shares. Event IDs
+ * must be positive 32-bit integers. Transient rate limits are retried
+ * automatically.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -500,24 +477,27 @@ export const FetchEventLiveVolumeError = makeErrorGuard(
  * @example
  * ```ts
  * const volume = await fetchEventLiveVolume(client, {
- *   id: '160707',
+ *   eventIds: ['160707'],
  * });
  *
- * // volume: LiveVolume[]
+ * // volume: LiveVolume
  * ```
  */
 export async function fetchEventLiveVolume(
   client: BaseClient,
   request: FetchEventLiveVolumeRequest,
-): Promise<LiveVolume[]> {
-  const params = parseUserInput(request, FetchEventLiveVolumeRequestSchema);
+): Promise<LiveVolume> {
+  const { eventIds } = parseUserInput(
+    request,
+    FetchEventLiveVolumeRequestSchema,
+  );
 
   return unwrap(
-    client.data
-      .get('/live-volume', {
-        params: toLegacyDataSearchParams(params),
-      })
-      .andThen(validateWith(FetchEventLiveVolumeResponseSchema)),
+    withRateLimitRetry(() =>
+      client.data.get('/v2/live-volume', {
+        params: toDataSearchParams({ eventId: eventIds }),
+      }),
+    ).andThen(validateWith(FetchEventLiveVolumeResponseSchema)),
   );
 }
 

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -449,12 +449,7 @@ export async function listMarketHolders(
 }
 
 const FetchOpenInterestRequestSchema = z.object({
-  conditionId: z
-    .union([
-      CanonicalMarketConditionIdSchema,
-      distinctIdList(CanonicalMarketConditionIdSchema, 20),
-    ])
-    .optional(),
+  conditionIds: distinctIdList(CanonicalMarketConditionIdSchema, 20).optional(),
 });
 
 export type FetchOpenInterestRequest = z.input<
@@ -478,10 +473,11 @@ export const FetchOpenInterestError = makeErrorGuard(
 /**
  * Fetches priced gross open interest for selected markets or globally.
  *
- * `conditionId` accepts one or up to 20 distinct market condition IDs. Omit it
- * for the global aggregate. A requested servable market with no holdings has a
- * zero value; an absent row means the market is not servable. Values are in
- * USDC. Transient rate limits are retried automatically.
+ * `conditionIds` accepts up to 20 distinct market condition IDs. Omit it for
+ * the global aggregate, whose `conditionId` is `null`. A requested servable
+ * market with no holdings has a zero value; an absent row means the market is
+ * not servable. Values are in USDC. Transient rate limits are retried
+ * automatically.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -492,7 +488,7 @@ export const FetchOpenInterestError = makeErrorGuard(
  * @example
  * ```ts
  * const openInterest = await fetchOpenInterest(client, {
- *   conditionId: '0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093',
+ *   conditionIds: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
  * });
  *
  * // openInterest: OpenInterest[]
@@ -502,7 +498,7 @@ export async function fetchOpenInterest(
   client: BaseClient,
   request: FetchOpenInterestRequest = {},
 ): Promise<OpenInterest[]> {
-  const { conditionId } = parseUserInput(
+  const { conditionIds } = parseUserInput(
     request,
     FetchOpenInterestRequestSchema,
   );
@@ -510,7 +506,7 @@ export async function fetchOpenInterest(
   return unwrap(
     withRateLimitRetry(() =>
       client.data.get('/v2/oi', {
-        params: toDataSearchParams({ condition: conditionId }),
+        params: toDataSearchParams({ condition: conditionIds }),
       }),
     ).andThen(validateWith(FetchOpenInterestResponseSchema)),
   );

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -9,8 +9,8 @@ import {
   ListComboMarketsResponseSchema,
 } from '@polymarket/bindings/combos';
 import {
+  FetchOpenInterestResponseSchema,
   ListMarketHoldersResponseSchema,
-  ListOpenInterestResponseSchema,
   type MetaHolder,
   type OpenInterest,
 } from '@polymarket/bindings/data';
@@ -36,7 +36,15 @@ import { parseUserInput } from '../input';
 import { PageSizeSchema, type Paginated, paginate } from '../pagination';
 import { parsePolymarketSlugUrl } from '../polymarket-url';
 import { validateWith } from '../response';
-import { snakeCase, toLegacyDataSearchParams, toSearchParams } from './params';
+import { withRateLimitRetry } from '../retry';
+import {
+  CanonicalMarketConditionIdSchema,
+  distinctIdList,
+  snakeCase,
+  toDataSearchParams,
+  toLegacyDataSearchParams,
+  toSearchParams,
+} from './params';
 
 // The public markets endpoint forces active=true and archived=false server-side.
 const ListMarketsRequestSchema = z.object({
@@ -115,15 +123,8 @@ const ListMarketHoldersRequestSchema = z.object({
   minBalance: z.number().int().optional(),
 });
 
-const ListOpenInterestRequestSchema = z.object({
-  market: z.array(z.string()).optional(),
-});
-
 export type ListMarketHoldersRequest = z.input<
   typeof ListMarketHoldersRequestSchema
->;
-export type ListOpenInterestRequest = z.input<
-  typeof ListOpenInterestRequestSchema
 >;
 type ListMarketsParams = z.output<typeof ListMarketsRequestSchema>;
 
@@ -447,13 +448,26 @@ export async function listMarketHolders(
   );
 }
 
-export type ListOpenInterestError =
+const FetchOpenInterestRequestSchema = z.object({
+  conditionId: z
+    .union([
+      CanonicalMarketConditionIdSchema,
+      distinctIdList(CanonicalMarketConditionIdSchema, 20),
+    ])
+    .optional(),
+});
+
+export type FetchOpenInterestRequest = z.input<
+  typeof FetchOpenInterestRequestSchema
+>;
+
+export type FetchOpenInterestError =
   | RateLimitError
   | RequestRejectedError
   | TransportError
   | UnexpectedResponseError
   | UserInputError;
-export const ListOpenInterestError = makeErrorGuard(
+export const FetchOpenInterestError = makeErrorGuard(
   RateLimitError,
   RequestRejectedError,
   TransportError,
@@ -462,35 +476,43 @@ export const ListOpenInterestError = makeErrorGuard(
 );
 
 /**
- * Lists open interest for one or more markets.
+ * Fetches priced gross open interest for selected markets or globally.
+ *
+ * `conditionId` accepts one or up to 20 distinct market condition IDs. Omit it
+ * for the global aggregate. A requested servable market with no holdings has a
+ * zero value; an absent row means the market is not servable. Values are in
+ * USDC. Transient rate limits are retried automatically.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
- * @throws {@link ListOpenInterestError}
+ * @throws {@link FetchOpenInterestError}
  * Thrown on failure.
  *
  * @example
  * ```ts
- * const openInterest = await listOpenInterest(client, {
- *   market: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
+ * const openInterest = await fetchOpenInterest(client, {
+ *   conditionId: '0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093',
  * });
  *
  * // openInterest: OpenInterest[]
  * ```
  */
-export async function listOpenInterest(
+export async function fetchOpenInterest(
   client: BaseClient,
-  request: ListOpenInterestRequest = {},
+  request: FetchOpenInterestRequest = {},
 ): Promise<OpenInterest[]> {
-  const params = parseUserInput(request, ListOpenInterestRequestSchema);
+  const { conditionId } = parseUserInput(
+    request,
+    FetchOpenInterestRequestSchema,
+  );
 
   return unwrap(
-    client.data
-      .get('/oi', {
-        params: toLegacyDataSearchParams(params),
-      })
-      .andThen(validateWith(ListOpenInterestResponseSchema)),
+    withRateLimitRetry(() =>
+      client.data.get('/v2/oi', {
+        params: toDataSearchParams({ condition: conditionId }),
+      }),
+    ).andThen(validateWith(FetchOpenInterestResponseSchema)),
   );
 }
 

--- a/packages/client/src/actions/params.ts
+++ b/packages/client/src/actions/params.ts
@@ -1,3 +1,9 @@
+import {
+  type ConditionId,
+  ConditionIdSchema,
+  EventIdSchema,
+  toConditionId,
+} from '@polymarket/bindings';
 import { z } from 'zod';
 
 export type SearchParamPrimitive = boolean | number | string;
@@ -121,6 +127,39 @@ export const TimeWindowSchema = z
   .transform((value) => (value === 'full' ? { start: 1 } : value));
 
 export type TimeWindow = z.input<typeof TimeWindowSchema>;
+
+function toCanonicalMarketConditionId(conditionId: ConditionId): ConditionId {
+  const paddedConditionId =
+    conditionId.length === 64 ? `${conditionId}00` : conditionId;
+
+  return toConditionId(paddedConditionId.toLowerCase());
+}
+
+function isSupportedMarketConditionId(conditionId: ConditionId): boolean {
+  if (conditionId.length === 66) return true;
+
+  const normalizedConditionId = conditionId.toLowerCase();
+  return (
+    normalizedConditionId.startsWith('0x01') ||
+    normalizedConditionId.startsWith('0x02')
+  );
+}
+
+/**
+ * A canonical 32-byte market condition ID. A 31-byte protocol v2 market ID is
+ * right-padded to its canonical representation; combo condition IDs are
+ * rejected.
+ */
+export const CanonicalMarketConditionIdSchema = ConditionIdSchema.refine(
+  isSupportedMarketConditionId,
+  'Expected a 32-byte condition ID or a 31-byte protocol v2 market condition ID',
+).transform(toCanonicalMarketConditionId);
+
+/** A positive event ID that fits the platform's signed 32-bit identifier. */
+export const PositiveInt32EventIdSchema = EventIdSchema.refine(
+  (eventId) => /^[1-9]\d*$/.test(eventId) && BigInt(eventId) <= 2_147_483_647n,
+  'Expected a positive 32-bit event ID',
+);
 
 /**
  * A list of ids deduplicated case-insensitively (first-seen casing kept) and

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -23,6 +23,7 @@ import {
   type FetchLastTradePricesRequest,
   type FetchMidpointRequest,
   type FetchMidpointsRequest,
+  type FetchOpenInterestRequest,
   type FetchOrderBookRequest,
   type FetchOrderBooksRequest,
   type FetchPriceHistoryRequest,
@@ -36,6 +37,7 @@ import {
   fetchLastTradePrices,
   fetchMidpoint,
   fetchMidpoints,
+  fetchOpenInterest,
   fetchOrderBook,
   fetchOrderBooks,
   fetchPrice,
@@ -45,10 +47,8 @@ import {
   fetchSpread,
   fetchSpreads,
   type ListMarketHoldersRequest,
-  type ListOpenInterestRequest,
   type ListTradesRequest,
   listMarketHolders,
-  listOpenInterest,
   listTrades,
 } from '../actions';
 import type {
@@ -60,19 +60,26 @@ import type { Paginated } from '../pagination';
 
 export type DataActions = {
   /**
-   * Fetches live volume for an event.
+   * Fetches cumulative taker volume for one or more events.
+   *
+   * Results contain one row per market, ordered by taker volume descending, and
+   * a total across all returned markets. Volume is measured in shares. Event
+   * IDs must be positive 32-bit integers. Transient rate limits are retried
+   * automatically.
    *
    * @throws {@link FetchEventLiveVolumeError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const volume = await client.fetchEventLiveVolume({ id: '123' });
+   * const volume = await client.fetchEventLiveVolume({
+   *   eventIds: ['160707'],
+   * });
    * ```
    */
   fetchEventLiveVolume(
     request: FetchEventLiveVolumeRequest,
-  ): Promise<LiveVolume[]>;
+  ): Promise<LiveVolume>;
   /**
    * Fetches resolution lifecycle rows by question, condition, or event.
    *
@@ -259,19 +266,26 @@ export type DataActions = {
    */
   estimateMarketPrice(request: EstimateMarketPriceRequest): Promise<number>;
   /**
-   * Lists open interest for one or more markets.
+   * Fetches priced gross open interest for selected markets or globally.
    *
-   * @throws {@link ListOpenInterestError}
+   * `conditionId` accepts one or up to 20 distinct market condition IDs. Omit
+   * it for the global aggregate. A requested servable market with no holdings
+   * has a zero value; an absent row means the market is not servable. Values
+   * are in USDC. Transient rate limits are retried automatically.
+   *
+   * @throws {@link FetchOpenInterestError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const openInterest = await client.listOpenInterest({
-   *   market: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
+   * const openInterest = await client.fetchOpenInterest({
+   *   conditionId: '0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093',
    * });
    * ```
    */
-  listOpenInterest(request?: ListOpenInterestRequest): Promise<OpenInterest[]>;
+  fetchOpenInterest(
+    request?: FetchOpenInterestRequest,
+  ): Promise<OpenInterest[]>;
   /**
    * Lists the top holders for one or more markets.
    *
@@ -351,7 +365,7 @@ export function dataActions(client: BaseClient): DataActions {
     fetchLastTradePrices: fetchLastTradePrices.bind(null, client),
     fetchPriceHistory: fetchPriceHistory.bind(null, client),
     estimateMarketPrice: estimateMarketPrice.bind(null, client),
-    listOpenInterest: listOpenInterest.bind(null, client),
+    fetchOpenInterest: fetchOpenInterest.bind(null, client),
     listMarketHolders: listMarketHolders.bind(null, client),
     listTrades: listTrades.bind(null, client),
   };
@@ -367,6 +381,7 @@ export {
   FetchLastTradePricesError,
   FetchMidpointError,
   FetchMidpointsError,
+  FetchOpenInterestError,
   FetchOrderBookError,
   FetchOrderBooksError,
   FetchPriceError,
@@ -376,7 +391,6 @@ export {
   FetchSpreadError,
   FetchSpreadsError,
   ListMarketHoldersError,
-  ListOpenInterestError,
   ListTradesError,
   ResolutionMarketType,
   ResolutionReporter,

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -268,10 +268,11 @@ export type DataActions = {
   /**
    * Fetches priced gross open interest for selected markets or globally.
    *
-   * `conditionId` accepts one or up to 20 distinct market condition IDs. Omit
-   * it for the global aggregate. A requested servable market with no holdings
-   * has a zero value; an absent row means the market is not servable. Values
-   * are in USDC. Transient rate limits are retried automatically.
+   * `conditionIds` accepts up to 20 distinct market condition IDs. Omit it for
+   * the global aggregate, whose `conditionId` is `null`. A requested servable
+   * market with no holdings has a zero value; an absent row means the market
+   * is not servable. Values are in USDC. Transient rate limits are retried
+   * automatically.
    *
    * @throws {@link FetchOpenInterestError}
    * Thrown on failure.
@@ -279,7 +280,7 @@ export type DataActions = {
    * @example
    * ```ts
    * const openInterest = await client.fetchOpenInterest({
-   *   conditionId: '0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093',
+   *   conditionIds: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
    * });
    * ```
    */

--- a/packages/client/tests/integration/events.test.ts
+++ b/packages/client/tests/integration/events.test.ts
@@ -99,18 +99,49 @@ describe('Events', () => {
   });
 
   describe('fetchEventLiveVolume', () => {
-    it('fetches live volume for an event', async ({ publicClient }) => {
+    it('fetches taker volume from the v2 route', async ({ publicClient }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
       const result = await publicClient.fetchEventLiveVolume({
-        id: event.id,
+        eventIds: [event.id],
       });
 
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0]).toEqual(
+      expect(result).toEqual(
         expect.objectContaining({
           markets: expect.any(Array),
-          total: expect.any(String),
+          takerVolumeTotal: expect.any(String),
         }),
       );
+
+      for (const market of result.markets) {
+        expect(market).toEqual(
+          expect.objectContaining({
+            takerVolume: expect.any(String),
+          }),
+        );
+        expect(
+          market.conditionId === null || typeof market.conditionId === 'string',
+        ).toBe(true);
+      }
+
+      const requestUrl = fetchSpy.mock.calls
+        .map(([input]) =>
+          input instanceof Request ? input.url : String(input),
+        )
+        .find((url) => new URL(url).pathname === '/v2/live-volume');
+
+      expect(
+        new URL(expectPresent(requestUrl)).searchParams.get('event_id'),
+      ).toBe(event.id);
+    });
+
+    it('rejects a partially invalid event selection', async ({
+      publicClient,
+    }) => {
+      await expect(
+        publicClient.fetchEventLiveVolume({
+          eventIds: [event.id, 'not-an-event'],
+        }),
+      ).rejects.toThrow(UserInputError);
     });
   });
 

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -4,6 +4,7 @@ import {
   UserInputError,
 } from '@polymarket/client';
 import { expectPresent } from '@polymarket/types';
+import { afterEach, vi } from 'vitest';
 import { describe, environment, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
@@ -33,6 +34,10 @@ const {
 const positionConditionId = expectPresent(position.conditionId);
 
 describe('Markets', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe('listMarkets', () => {
     it('fetches markets', async ({ publicClient }) => {
       const paginator = publicClient.listMarkets({
@@ -193,18 +198,35 @@ describe('Markets', () => {
     });
   });
 
-  describe('listOpenInterest', () => {
-    it('lists open interest for a market', async ({ publicClient }) => {
-      const result = await publicClient.listOpenInterest({
-        market: [positionConditionId],
+  describe('fetchOpenInterest', () => {
+    it('fetches open interest from the v2 route', async ({ publicClient }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const result = await publicClient.fetchOpenInterest({
+        conditionId: positionConditionId,
       });
 
       expect(result).toEqual([
         expect.objectContaining({
-          market: positionConditionId,
+          conditionId: positionConditionId,
           value: expect.any(String),
         }),
       ]);
+
+      const requestUrl = fetchSpy.mock.calls
+        .map(([input]) =>
+          input instanceof Request ? input.url : String(input),
+        )
+        .find((url) => new URL(url).pathname === '/v2/oi');
+
+      expect(
+        new URL(expectPresent(requestUrl)).searchParams.get('condition'),
+      ).toBe(positionConditionId);
+    });
+
+    it('rejects an invalid condition ID', async ({ publicClient }) => {
+      await expect(
+        publicClient.fetchOpenInterest({ conditionId: 'not-a-condition' }),
+      ).rejects.toThrow(UserInputError);
     });
   });
 });

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -202,7 +202,7 @@ describe('Markets', () => {
     it('fetches open interest from the v2 route', async ({ publicClient }) => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch');
       const result = await publicClient.fetchOpenInterest({
-        conditionId: positionConditionId,
+        conditionIds: [positionConditionId],
       });
 
       expect(result).toEqual([
@@ -225,8 +225,19 @@ describe('Markets', () => {
 
     it('rejects an invalid condition ID', async ({ publicClient }) => {
       await expect(
-        publicClient.fetchOpenInterest({ conditionId: 'not-a-condition' }),
+        publicClient.fetchOpenInterest({ conditionIds: ['not-a-condition'] }),
       ).rejects.toThrow(UserInputError);
+    });
+
+    it('normalizes the global aggregate', async ({ publicClient }) => {
+      const result = await publicClient.fetchOpenInterest();
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          conditionId: null,
+          value: expect.any(String),
+        }),
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- migrate open-interest and live-volume reads to their v2 contracts
- replace `listOpenInterest` with direct `fetchOpenInterest` and validate canonical selectors
- expose taker-volume fields and normalize unidentified condition buckets to `null`

Linear: DEV-636

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test:bindings` and `pnpm test:client`
- focused live market and event integration tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public breaking API renames and response shape changes for analytics consumers; behavior is scoped to data reads with stricter input validation rather than auth or funds flow.
> 
> **Overview**
> **Breaking SDK change** for market analytics: open interest and event live volume now call the data service **v2** routes and use updated request/response shapes.
> 
> `listOpenInterest` is removed in favor of **`fetchOpenInterest`**, which hits `/v2/oi` with optional **`conditionIds`** (up to 20 canonical market IDs) and returns **USDC gross OI** rows keyed by `conditionId` (`null` for the global aggregate). Live volume moves to **`/v2/live-volume`** with **`eventIds`** instead of a single `id`; the client now returns one **`LiveVolume`** object with **`takerVolumeTotal`** and per-market **`takerVolume`** (shares), not an array with `total`.
> 
> Bindings parse the v2 wire format (`condition_id`, `GLOBAL`, `dataEnvelopeSchema`) and drop deprecated `market`/`value` live-volume fields. Shared **`CanonicalMarketConditionIdSchema`** and **`PositiveInt32EventIdSchema`** centralize selector validation (also used for resolutions). Both actions use **`toDataSearchParams`**, **`withRateLimitRetry`**, and updated integration tests assert the v2 paths and query params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0612a64c5f29257bdae8d8afc3b1b50791ede01f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->