### PR TITLE
feat(data): add user pnl and volume

### DIFF
--- a/.changeset/data-v2-user-metrics.md
+++ b/.changeset/data-v2-user-metrics.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': minor
+'@polymarket/client': minor
+---
+
+Add `fetchUserPnl` and `fetchUserVolume` with normalized decimal-string amounts, cumulative PnL metadata, shared time-window inputs, and authenticated-wallet defaults.

--- a/packages/bindings/src/data/portfolio.test.ts
+++ b/packages/bindings/src/data/portfolio.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   FetchPortfolioValueResponseSchema,
+  FetchUserPnlResponseSchema,
   FetchUserStatsResponseSchema,
+  FetchUserVolumeResponseSchema,
 } from './portfolio';
 
 const WALLET = `0x${'1'.repeat(40)}`;
@@ -87,6 +89,52 @@ describe('FetchUserStatsResponseSchema', () => {
       views: 0,
       joinDate: null,
       allTimePnl: null,
+    });
+  });
+});
+
+describe('FetchUserPnlResponseSchema', () => {
+  it('normalizes the series metadata and points', () => {
+    expect(
+      FetchUserPnlResponseSchema.parse({
+        data: {
+          proxy_wallet: WALLET,
+          interval: '1w',
+          fidelity: '3h',
+          source_fidelity: '1d',
+          points: [userPnlPoint()],
+        },
+      }),
+    ).toMatchObject({
+      wallet: WALLET,
+      interval: '1w',
+      fidelity: '3h',
+      sourceFidelity: '1d',
+      points: [
+        {
+          timestamp: 1_700_000_100_000,
+          realizedPnl: '11.373456',
+          unrealizedPnl: null,
+        },
+      ],
+    });
+  });
+});
+
+describe('FetchUserVolumeResponseSchema', () => {
+  it('normalizes volume amounts to decimal strings', () => {
+    expect(
+      FetchUserVolumeResponseSchema.parse({
+        data: {
+          volume: 1000.123456,
+          volume_usdc: '750.654321',
+          trade_count: 99,
+        },
+      }),
+    ).toEqual({
+      volume: '1000.123456',
+      volumeUsdc: '750.654321',
+      tradeCount: 99,
     });
   });
 });

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -255,6 +255,30 @@ export const PortfolioValueSchema = z
     value,
   })) satisfies z.ZodType<PortfolioValue>;
 
+/** Window served by a user PnL series. */
+export enum UserPnlInterval {
+  Max = 'max',
+  All = 'all',
+  OneMonth = '1m',
+  OneWeek = '1w',
+  OneDay = '1d',
+  TwelveHours = '12h',
+  SixHours = '6h',
+}
+
+export const UserPnlIntervalSchema = z.enum(UserPnlInterval);
+
+/** Time step between points in a user PnL series. */
+export enum UserPnlFidelity {
+  OneDay = '1d',
+  EighteenHours = '18h',
+  TwelveHours = '12h',
+  ThreeHours = '3h',
+  OneHour = '1h',
+}
+
+export const UserPnlFidelitySchema = z.enum(UserPnlFidelity);
+
 /**
  * One cumulative wallet PnL observation. Fractional money and size values
  * are normalized to decimal strings.
@@ -393,6 +417,51 @@ export const UserPnlPointSchema = z
       tradeCount: trade_count,
     }),
   ) satisfies z.ZodType<UserPnlPoint>;
+
+export type UserPnlSeries = {
+  wallet: EvmAddress;
+  interval: UserPnlInterval;
+  fidelity: UserPnlFidelity;
+  /** Fidelity of the underlying observations before grid synthesis. */
+  sourceFidelity: UserPnlFidelity;
+  /** Dense cumulative points, oldest first. */
+  points: UserPnlPoint[];
+};
+
+export const UserPnlSeriesSchema = z
+  .object({
+    proxy_wallet: EvmAddressSchema,
+    interval: UserPnlIntervalSchema,
+    fidelity: UserPnlFidelitySchema,
+    source_fidelity: UserPnlFidelitySchema,
+    points: z.array(UserPnlPointSchema),
+  })
+  .transform(({ proxy_wallet, source_fidelity, ...series }) => ({
+    ...series,
+    wallet: proxy_wallet,
+    sourceFidelity: source_fidelity,
+  })) satisfies z.ZodType<UserPnlSeries>;
+
+export type UserVolume = {
+  /** Both-sides traded volume in shares. */
+  volume: DecimalString;
+  /** Both-sides traded volume in USD. */
+  volumeUsdc: DecimalString;
+  /** Number of fills in the served window. */
+  tradeCount: number;
+};
+
+export const UserVolumeSchema = z
+  .object({
+    volume: DecimalishSchema,
+    volume_usdc: DecimalishSchema,
+    trade_count: z.number().int().nonnegative(),
+  })
+  .transform(({ volume_usdc, trade_count, ...volume }) => ({
+    ...volume,
+    volumeUsdc: volume_usdc,
+    tradeCount: trade_count,
+  })) satisfies z.ZodType<UserVolume>;
 
 export type UserStats = {
   wallet: EvmAddress;
@@ -572,6 +641,10 @@ export const FetchPortfolioValueResponseSchema =
 export const FetchUserStatsResponseSchema = dataEnvelopeSchema(
   UserStatsSchema.nullable(),
 );
+export const FetchUserPnlResponseSchema =
+  dataEnvelopeSchema(UserPnlSeriesSchema);
+export const FetchUserVolumeResponseSchema =
+  dataEnvelopeSchema(UserVolumeSchema);
 export const ListComboPositionsResponseSchema =
   dataPageSchema(ComboPositionSchema);
 
@@ -587,6 +660,10 @@ export type FetchPortfolioValueResponse = z.infer<
 >;
 export type FetchUserStatsResponse = z.infer<
   typeof FetchUserStatsResponseSchema
+>;
+export type FetchUserPnlResponse = z.infer<typeof FetchUserPnlResponseSchema>;
+export type FetchUserVolumeResponse = z.infer<
+  typeof FetchUserVolumeResponseSchema
 >;
 export type ListComboPositionsResponse = z.infer<
   typeof ListComboPositionsResponseSchema

--- a/packages/bindings/src/data/portfolio.ts
+++ b/packages/bindings/src/data/portfolio.ts
@@ -258,7 +258,6 @@ export const PortfolioValueSchema = z
 /** Window served by a user PnL series. */
 export enum UserPnlInterval {
   Max = 'max',
-  All = 'all',
   OneMonth = '1m',
   OneWeek = '1w',
   OneDay = '1d',

--- a/packages/client/src/actions/portfolio.ts
+++ b/packages/client/src/actions/portfolio.ts
@@ -11,7 +11,9 @@ import {
   ComboPositionStatus,
   ComboPositionStatusSchema,
   FetchPortfolioValueResponseSchema,
+  FetchUserPnlResponseSchema,
   FetchUserStatsResponseSchema,
+  FetchUserVolumeResponseSchema,
   ListComboPositionsResponseSchema,
   ListPositionsResponseSchema,
   type PortfolioValue,
@@ -20,7 +22,11 @@ import {
   PositionSortBySchema,
   PositionStatusSchema,
   SortDirectionSchema,
+  UserPnlFidelitySchema,
+  UserPnlIntervalSchema,
+  type UserPnlSeries,
   type UserStats,
+  type UserVolume,
 } from '@polymarket/bindings/data';
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
@@ -51,6 +57,8 @@ export {
   PositionFilterType,
   PositionSortBy,
   PositionStatus,
+  UserPnlFidelity,
+  UserPnlInterval,
 } from '@polymarket/bindings/data';
 
 const ListPositionsRequestSchema = z
@@ -496,6 +504,126 @@ export async function fetchUserStats(
         params: toDataSearchParams(params),
       }),
     ).andThen(validateWith(FetchUserStatsResponseSchema)),
+  );
+}
+
+const FetchUserPnlRequestSchema = z.object({
+  user: EvmAddressSchema,
+  interval: UserPnlIntervalSchema.optional(),
+  fidelity: UserPnlFidelitySchema.optional(),
+});
+
+export type FetchUserPnlRequest = z.input<typeof FetchUserPnlRequestSchema>;
+
+export type FetchUserPnlError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const FetchUserPnlError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Fetches a wallet's cumulative PnL series.
+ *
+ * `interval` defaults to one day and `fidelity` defaults to one hour. Each
+ * point is cumulative through its timestamp; nullable amounts mean the source
+ * was unavailable and are never coerced to zero.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
+ * @throws {@link FetchUserPnlError}
+ * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const pnl = await fetchUserPnl(client, {
+ *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+ *   interval: UserPnlInterval.OneWeek,
+ *   fidelity: UserPnlFidelity.ThreeHours,
+ * });
+ * ```
+ */
+export async function fetchUserPnl(
+  client: BaseClient,
+  request: FetchUserPnlRequest,
+): Promise<UserPnlSeries> {
+  const params = parseUserInput(request, FetchUserPnlRequestSchema);
+
+  return unwrap(
+    withRateLimitRetry(() =>
+      client.data.get('/v2/user-pnl', {
+        params: toDataSearchParams(params),
+      }),
+    ).andThen(validateWith(FetchUserPnlResponseSchema)),
+  );
+}
+
+const FetchUserVolumeRequestSchema = z.object({
+  user: EvmAddressSchema,
+  window: TimeWindowSchema.optional(),
+});
+
+export type FetchUserVolumeRequest = z.input<
+  typeof FetchUserVolumeRequestSchema
+>;
+
+export type FetchUserVolumeError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const FetchUserVolumeError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Fetches a wallet's trading volume for a time window.
+ *
+ * Volume is returned in shares and USD. Window bounds accept epoch seconds or
+ * `Date` values and are widened to whole UTC days.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
+ * @throws {@link FetchUserVolumeError}
+ * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const volume = await fetchUserVolume(client, {
+ *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+ *   window: { start: new Date('2026-08-01T00:00:00Z') },
+ * });
+ * ```
+ */
+export async function fetchUserVolume(
+  client: BaseClient,
+  request: FetchUserVolumeRequest,
+): Promise<UserVolume> {
+  const { window, ...params } = parseUserInput(
+    request,
+    FetchUserVolumeRequestSchema,
+  );
+
+  return unwrap(
+    withRateLimitRetry(() =>
+      client.data.get('/v2/user-volume', {
+        params: toDataSearchParams({ ...params, ...window }),
+      }),
+    ).andThen(validateWith(FetchUserVolumeResponseSchema)),
   );
 }
 

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -8,7 +8,9 @@ import type {
   ComboPosition,
   PortfolioValue,
   Position,
+  UserPnlSeries,
   UserStats,
+  UserVolume,
 } from '@polymarket/bindings/data';
 import type { Prettify } from '@polymarket/types';
 import {
@@ -17,11 +19,15 @@ import {
   downloadAccountingSnapshot,
   dropNotifications,
   type FetchPortfolioValueRequest,
+  type FetchUserPnlRequest,
   type FetchUserStatsRequest,
+  type FetchUserVolumeRequest,
   fetchClosedOnlyMode,
   fetchNotifications,
   fetchPortfolioValue,
+  fetchUserPnl,
   fetchUserStats,
+  fetchUserVolume,
   type ListAccountTradesRequest,
   type ListActivityRequest,
   type ListComboActivityRequest,
@@ -57,8 +63,12 @@ export type SecureListComboPositionsRequest =
   DefaultAccountWallet<ListComboPositionsRequest>;
 export type SecureFetchPortfolioValueRequest =
   DefaultAccountWallet<FetchPortfolioValueRequest>;
+export type SecureFetchUserPnlRequest =
+  DefaultAccountWallet<FetchUserPnlRequest>;
 export type SecureFetchUserStatsRequest =
   DefaultAccountWallet<FetchUserStatsRequest>;
+export type SecureFetchUserVolumeRequest =
+  DefaultAccountWallet<FetchUserVolumeRequest>;
 export type SecureDownloadAccountingSnapshotRequest =
   DefaultAccountWallet<DownloadAccountingSnapshotRequest>;
 export type SecureListActivityRequest =
@@ -172,6 +182,44 @@ export type PublicAccountActions = Prettify<{
    * ```
    */
   fetchUserStats(request: FetchUserStatsRequest): Promise<UserStats | null>;
+  /**
+   * Fetches a wallet's cumulative PnL series.
+   *
+   * `interval` defaults to one day and `fidelity` defaults to one hour. Each
+   * point is cumulative through its timestamp; nullable amounts mean the
+   * source was unavailable and are never coerced to zero.
+   *
+   * @throws {@link FetchUserPnlError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const pnl = await client.fetchUserPnl({
+   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+   *   interval: UserPnlInterval.OneWeek,
+   *   fidelity: UserPnlFidelity.ThreeHours,
+   * });
+   * ```
+   */
+  fetchUserPnl(request: FetchUserPnlRequest): Promise<UserPnlSeries>;
+  /**
+   * Fetches a wallet's trading volume for a time window.
+   *
+   * Volume is returned in shares and USD. Window bounds accept epoch seconds
+   * or `Date` values and are widened to whole UTC days.
+   *
+   * @throws {@link FetchUserVolumeError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const volume = await client.fetchUserVolume({
+   *   user: '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b',
+   *   window: { start: new Date('2026-08-01T00:00:00Z') },
+   * });
+   * ```
+   */
+  fetchUserVolume(request: FetchUserVolumeRequest): Promise<UserVolume>;
   /**
    * Downloads an accounting snapshot archive for a wallet.
    *
@@ -320,6 +368,27 @@ export type SecureAccountActions = Prettify<{
     request?: SecureFetchUserStatsRequest,
   ): Promise<UserStats | null>;
   /**
+   * Fetches the cumulative PnL series for a wallet.
+   *
+   * Defaults to the authenticated account's wallet when `user` is omitted.
+   * `interval` defaults to one day and `fidelity` defaults to one hour.
+   *
+   * @throws {@link FetchUserPnlError}
+   * Thrown on failure.
+   */
+  fetchUserPnl(request?: SecureFetchUserPnlRequest): Promise<UserPnlSeries>;
+  /**
+   * Fetches trading volume for a wallet over a time window.
+   *
+   * Defaults to the authenticated account's wallet when `user` is omitted.
+   * Window bounds accept epoch seconds or `Date` values and are widened to
+   * whole UTC days.
+   *
+   * @throws {@link FetchUserVolumeError}
+   * Thrown on failure.
+   */
+  fetchUserVolume(request?: SecureFetchUserVolumeRequest): Promise<UserVolume>;
+  /**
    * Downloads an accounting snapshot archive for a wallet.
    *
    * Defaults to the authenticated account's wallet when `user` is omitted.
@@ -433,6 +502,8 @@ function publicAccountActions(client: BaseClient): PublicAccountActions {
     listComboPositions: listComboPositions.bind(null, client),
     fetchPortfolioValue: fetchPortfolioValue.bind(null, client),
     fetchUserStats: fetchUserStats.bind(null, client),
+    fetchUserPnl: fetchUserPnl.bind(null, client),
+    fetchUserVolume: fetchUserVolume.bind(null, client),
     downloadAccountingSnapshot: downloadAccountingSnapshot.bind(null, client),
     listActivity: listActivity.bind(null, client),
     listComboActivity: listComboActivity.bind(null, client),
@@ -470,6 +541,10 @@ export function accountActions(
       fetchPortfolioValue(client, withAccountWallet(client, request)),
     fetchUserStats: (request?: SecureFetchUserStatsRequest) =>
       fetchUserStats(client, withAccountWallet(client, request)),
+    fetchUserPnl: (request?: SecureFetchUserPnlRequest) =>
+      fetchUserPnl(client, withAccountWallet(client, request)),
+    fetchUserVolume: (request?: SecureFetchUserVolumeRequest) =>
+      fetchUserVolume(client, withAccountWallet(client, request)),
     downloadAccountingSnapshot: (
       request?: SecureDownloadAccountingSnapshotRequest,
     ) => downloadAccountingSnapshot(client, withAccountWallet(client, request)),
@@ -493,7 +568,9 @@ export {
   FetchClosedOnlyModeError,
   FetchNotificationsError,
   FetchPortfolioValueError,
+  FetchUserPnlError,
   FetchUserStatsError,
+  FetchUserVolumeError,
   ListAccountTradesError,
   ListActivityError,
   ListComboActivityError,
@@ -513,4 +590,6 @@ export {
   PositionFilterType,
   PositionSortBy,
   PositionStatus,
+  UserPnlFidelity,
+  UserPnlInterval,
 } from '../actions/portfolio';

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -3,6 +3,8 @@ import {
   ComboPositionStatus,
   PositionStatus,
   UserInputError,
+  UserPnlFidelity,
+  UserPnlInterval,
 } from '@polymarket/client';
 import { expectPresent, isSameEvmAddress } from '@polymarket/types';
 import { afterEach, type MockInstance, vi } from 'vitest';
@@ -87,7 +89,7 @@ describe('Portfolio', () => {
           outcomeLabel: expect.any(String),
           redeemable: expect.any(Boolean),
           wallet: TEST_USER,
-          realizedPayoutUsdc: expect.any(Number),
+          realizedPayoutUsdc: expect.any(String),
           grossEntryCostUsdc: expect.any(String),
           entryFeesUsdc: expect.any(String),
         }),
@@ -272,6 +274,87 @@ describe('Portfolio', () => {
       await secureClientWithDepositWallet.fetchUserStats();
 
       const [request] = dataRequests(fetchSpy, '/v2/user-stats');
+      expect(request?.get('user')).toSatisfy(
+        (user) => user !== null && isSameEvmAddress(user, depositWalletAddress),
+      );
+    });
+  });
+
+  describe('fetchUserPnl', () => {
+    it('fetches a cumulative PnL series', async ({ publicClient }) => {
+      const result = await publicClient.fetchUserPnl({
+        user: TEST_USER,
+        interval: UserPnlInterval.OneWeek,
+        fidelity: UserPnlFidelity.ThreeHours,
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          wallet: TEST_USER,
+          interval: UserPnlInterval.OneWeek,
+          fidelity: UserPnlFidelity.ThreeHours,
+          sourceFidelity: expect.any(String),
+          points: expect.any(Array),
+        }),
+      );
+      expect(result.points.length).toBeGreaterThan(0);
+      expect(result.points[0]).toEqual(
+        expect.objectContaining({
+          timestamp: expect.any(Number),
+          realizedPnl: expect.any(String),
+          volume: expect.any(String),
+          tradeCount: expect.any(Number),
+        }),
+      );
+    });
+
+    it('defaults secure clients to the authenticated wallet', async ({
+      depositWalletAddress,
+      secureClientWithDepositWallet,
+    }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      await secureClientWithDepositWallet.fetchUserPnl({
+        interval: UserPnlInterval.OneDay,
+      });
+
+      const [request] = dataRequests(fetchSpy, '/v2/user-pnl');
+      expect(request?.get('user')).toSatisfy(
+        (user) => user !== null && isSameEvmAddress(user, depositWalletAddress),
+      );
+    });
+  });
+
+  describe('fetchUserVolume', () => {
+    it('fetches volume for a window using canonical query keys', async ({
+      publicClient,
+    }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const result = await publicClient.fetchUserVolume({
+        user: TEST_USER,
+        window: { start: 1_788_134_400, end: 1_788_220_800 },
+      });
+
+      expect(result).toEqual({
+        volume: expect.any(String),
+        volumeUsdc: expect.any(String),
+        tradeCount: expect.any(Number),
+      });
+
+      const [request] = dataRequests(fetchSpy, '/v2/user-volume');
+      expect(request?.get('start')).toBe('1788134400');
+      expect(request?.get('end')).toBe('1788220800');
+    });
+
+    it('defaults secure clients to the authenticated wallet', async ({
+      depositWalletAddress,
+      secureClientWithDepositWallet,
+    }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      await secureClientWithDepositWallet.fetchUserVolume();
+
+      const [request] = dataRequests(fetchSpy, '/v2/user-volume');
       expect(request?.get('user')).toSatisfy(
         (user) => user !== null && isSameEvmAddress(user, depositWalletAddress),
       );


### PR DESCRIPTION
## Summary

- Add `fetchUserPnl` and `fetchUserVolume` with v2 binding schemas, public/secure account methods, and decimal-string normalization.
- Reuse shared rate-limit/window handling and fix the inherited combo payout integration assertion. Stacked on #339.

## Validation

- `pnpm lint` and `pnpm typecheck`
- `pnpm build` and `pnpm test`
- Live portfolio integration: 12 passed, 6 credential-gated skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK and schema surface with tests; no auth or payment logic changes beyond new read-only data endpoints.
> 
> **Overview**
> Adds **`fetchUserPnl`** and **`fetchUserVolume`** to the data client, wired through v2 **`/v2/user-pnl`** and **`/v2/user-volume`** with the same rate-limit/retry and response validation patterns as other portfolio actions.
> 
> **Bindings** gain `UserPnlInterval` / `UserPnlFidelity`, full **`UserPnlSeries`** and **`UserVolume`** types (snake_case → camelCase, money as decimal strings, nullable PnL fields left null), plus **`FetchUserPnlResponseSchema`** and **`FetchUserVolumeResponseSchema`** with unit tests.
> 
> **Client surface**: low-level actions and **public** / **secure** account methods (secure paths default `user` to the authenticated wallet). PnL accepts optional interval/fidelity; volume accepts the shared optional **`window`** (merged into query params as `start`/`end`). **`UserPnlInterval`** and **`UserPnlFidelity`** are re-exported from the account decorator.
> 
> Integration coverage exercises live responses, canonical volume query keys, and secure wallet defaults. Combo position integration now expects **`realizedPayoutUsdc`** as a string, matching decimal-string normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0586ebdafdcf98bfff5fd0940ff9fde2a6b2ecc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->