### PR TITLE
fix(data): normalize resolution response fields

### DIFF
--- a/.changeset/data-resolution-normalization.md
+++ b/.changeset/data-resolution-normalization.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': patch
+'@polymarket/client': patch
+---
+
+Normalize resolution timestamps, transaction metadata, and payout values into canonical SDK types.

--- a/packages/bindings/src/data/resolutions.test.ts
+++ b/packages/bindings/src/data/resolutions.test.ts
@@ -41,8 +41,8 @@ describe('FetchResolutionsResponseSchema', () => {
         reproposedPrice: '600000',
         price: '1000000',
         transactionHash: `0x${'c'.repeat(64)}`,
-        logIndex: '17',
-        lastUpdatedAt: '1722470400',
+        logIndex: 17,
+        lastUpdatedAt: '2024-08-01T00:00:00.000Z',
       },
     ]);
   });
@@ -63,7 +63,7 @@ describe('FetchResolutionsResponseSchema', () => {
           log_index: '',
           last_update_timestamp: '2026-08-02T03:04:05Z',
           market_type: 'BINARY',
-          payouts: [1_000_000, 0],
+          payouts: [500_000, 500_000],
           resolution_source: 'reported',
           reporter: 'UMA_OO',
           was_arbitrated: false,
@@ -82,7 +82,7 @@ describe('FetchResolutionsResponseSchema', () => {
         questionRulesUpdated: false,
         lastUpdatedAt: '2026-08-02T03:04:05Z',
         marketType: ResolutionMarketType.Binary,
-        payouts: [1_000_000, 0],
+        payouts: ['0.5', '0.5'],
         resolutionSource: ResolutionSource.Reported,
         reporter: ResolutionReporter.UmaOptimisticOracle,
         wasArbitrated: false,
@@ -90,5 +90,24 @@ describe('FetchResolutionsResponseSchema', () => {
         resolvedAt: '2026-08-02T03:04:05Z',
       },
     ]);
+  });
+
+  it('rejects malformed transaction hashes', () => {
+    expect(() =>
+      FetchResolutionsResponseSchema.parse({
+        data: [
+          {
+            question_id: QUESTION_ID,
+            status: 'resolved',
+            extended_review: false,
+            was_disputed: false,
+            new_version_q: false,
+            transaction_hash: 'not-a-transaction-hash',
+            log_index: '17',
+            last_update_timestamp: '1722470400',
+          },
+        ],
+      }),
+    ).toThrow();
   });
 });

--- a/packages/bindings/src/data/resolutions.test.ts
+++ b/packages/bindings/src/data/resolutions.test.ts
@@ -47,7 +47,7 @@ describe('FetchResolutionsResponseSchema', () => {
     ]);
   });
 
-  it('normalizes condition lifecycle fields and removes unset sentinels', () => {
+  it('normalizes condition lifecycle fields and absent transaction metadata', () => {
     const resolutions = FetchResolutionsResponseSchema.parse({
       data: [
         {
@@ -80,6 +80,8 @@ describe('FetchResolutionsResponseSchema', () => {
         extendedReview: false,
         wasDisputed: false,
         questionRulesUpdated: false,
+        transactionHash: null,
+        logIndex: null,
         lastUpdatedAt: '2026-08-02T03:04:05Z',
         marketType: ResolutionMarketType.Binary,
         payouts: ['0.5', '0.5'],

--- a/packages/bindings/src/data/resolutions.ts
+++ b/packages/bindings/src/data/resolutions.ts
@@ -100,10 +100,7 @@ const PayoutSchema = z
 export const ResolutionSchema = z
   .object({
     question_id: QuestionIdSchema.optional(),
-    condition_id: ConditionIdSchema.refine(
-      (conditionId) => conditionId.length === 66,
-      'Expected a 32-byte condition ID',
-    ).optional(),
+    condition_id: ConditionIdSchema.optional(),
     status: ResolutionStatusSchema,
     extended_review: z.boolean(),
     was_disputed: z.boolean(),

--- a/packages/bindings/src/data/resolutions.ts
+++ b/packages/bindings/src/data/resolutions.ts
@@ -4,12 +4,14 @@ import {
   ConditionIdSchema,
   type DecimalString,
   DecimalStringSchema,
+  E6BigIntStringToDecimalStringSchema,
+  EpochLikeToIsoDateTimeStringSchema,
   type IsoDateTimeString,
   IsoDateTimeStringSchema,
-  type MixedDateTimeString,
-  MixedDateTimeStringSchema,
   type QuestionId,
   QuestionIdSchema,
+  type TxHash,
+  TxHashSchema,
 } from '../shared';
 import { dataEnvelopeSchema } from './envelope';
 
@@ -73,20 +75,27 @@ export type Resolution = {
   /** Final oracle settlement price, omitted until set. */
   price?: DecimalString;
   /** Transaction for the latest lifecycle event, when available. */
-  transactionHash?: string;
+  transactionHash?: TxHash;
   /** Log index for `transactionHash`, when available. */
-  logIndex?: string;
-  /** Latest lifecycle change, represented as epoch seconds or RFC3339 UTC. */
-  lastUpdatedAt: MixedDateTimeString;
+  logIndex?: number;
+  /** Latest lifecycle change as an ISO 8601 datetime. */
+  lastUpdatedAt: IsoDateTimeString;
   marketType?: ResolutionMarketType;
-  /** Per-outcome payout in micro collateral units per share. */
-  payouts?: number[];
+  /** Per-outcome payout in collateral units per share. */
+  payouts?: [outcome0: DecimalString, outcome1: DecimalString];
   resolutionSource?: ResolutionSource;
   reporter?: ResolutionReporter;
   wasArbitrated?: boolean;
   resolvedBlock?: number;
   resolvedAt?: IsoDateTimeString;
 };
+
+const PayoutSchema = z
+  .number()
+  .int()
+  .min(0)
+  .transform(String)
+  .pipe(E6BigIntStringToDecimalStringSchema);
 
 export const ResolutionSchema = z
   .object({
@@ -102,11 +111,14 @@ export const ResolutionSchema = z
     proposed_price: DecimalStringSchema.optional(),
     reproposed_price: DecimalStringSchema.optional(),
     price: DecimalStringSchema.optional(),
-    transaction_hash: z.string(),
-    log_index: z.string(),
-    last_update_timestamp: MixedDateTimeStringSchema,
+    transaction_hash: z.union([z.literal(''), TxHashSchema]),
+    log_index: z.union([
+      z.literal(''),
+      z.string().regex(/^\d+$/).transform(Number),
+    ]),
+    last_update_timestamp: EpochLikeToIsoDateTimeStringSchema,
     market_type: ResolutionMarketTypeSchema.optional(),
-    payouts: z.array(z.number().int()).optional(),
+    payouts: z.tuple([PayoutSchema, PayoutSchema]).optional(),
     resolution_source: ResolutionSourceSchema.optional(),
     reporter: ResolutionReporterSchema.optional(),
     was_arbitrated: z.boolean().optional(),

--- a/packages/bindings/src/data/resolutions.ts
+++ b/packages/bindings/src/data/resolutions.ts
@@ -6,6 +6,7 @@ import {
   DecimalStringSchema,
   E6BigIntStringToDecimalStringSchema,
   EpochLikeToIsoDateTimeStringSchema,
+  emptyStringToNull,
   type IsoDateTimeString,
   IsoDateTimeStringSchema,
   type QuestionId,
@@ -74,10 +75,10 @@ export type Resolution = {
   reproposedPrice?: DecimalString;
   /** Final oracle settlement price, omitted until set. */
   price?: DecimalString;
-  /** Transaction for the latest lifecycle event, when available. */
-  transactionHash?: TxHash;
-  /** Log index for `transactionHash`, when available. */
-  logIndex?: number;
+  /** Transaction for the latest lifecycle event, or `null` when unavailable. */
+  transactionHash: TxHash | null;
+  /** Log index for `transactionHash`, or `null` when unavailable. */
+  logIndex: number | null;
   /** Latest lifecycle change as an ISO 8601 datetime. */
   lastUpdatedAt: IsoDateTimeString;
   marketType?: ResolutionMarketType;
@@ -108,11 +109,11 @@ export const ResolutionSchema = z
     proposed_price: DecimalStringSchema.optional(),
     reproposed_price: DecimalStringSchema.optional(),
     price: DecimalStringSchema.optional(),
-    transaction_hash: z.union([z.literal(''), TxHashSchema]),
-    log_index: z.union([
-      z.literal(''),
-      z.string().regex(/^\d+$/).transform(Number),
-    ]),
+    transaction_hash: z.preprocess(emptyStringToNull, TxHashSchema.nullable()),
+    log_index: z.preprocess(
+      emptyStringToNull,
+      z.string().regex(/^\d+$/).transform(Number).nullable(),
+    ),
     last_update_timestamp: EpochLikeToIsoDateTimeStringSchema,
     market_type: ResolutionMarketTypeSchema.optional(),
     payouts: z.tuple([PayoutSchema, PayoutSchema]).optional(),
@@ -128,6 +129,8 @@ export const ResolutionSchema = z
       extendedReview: wire.extended_review,
       wasDisputed: wire.was_disputed,
       questionRulesUpdated: wire.new_version_q,
+      transactionHash: wire.transaction_hash,
+      logIndex: wire.log_index,
       lastUpdatedAt: wire.last_update_timestamp,
     };
 
@@ -144,10 +147,6 @@ export const ResolutionSchema = z
     if (wire.price !== undefined && wire.price !== '69') {
       resolution.price = wire.price;
     }
-    if (wire.transaction_hash !== '') {
-      resolution.transactionHash = wire.transaction_hash;
-    }
-    if (wire.log_index !== '') resolution.logIndex = wire.log_index;
     if (wire.market_type !== undefined)
       resolution.marketType = wire.market_type;
     if (wire.payouts !== undefined) resolution.payouts = wire.payouts;


### PR DESCRIPTION
## Summary
- follow up on Cesare’s post-merge review of #333
- normalize resolution timestamps, transaction metadata, and e6 payouts at the binding boundary
- expose TxHash, numeric log indexes, ISO timestamps, and a two-item decimal payout tuple

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test
- built @polymarket/types and @polymarket/bindings; live events integration test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking TypeScript contract changes for `fetchResolutions` consumers (`logIndex`, payouts, timestamps, and always-present nullable tx fields), though behavior is confined to parse-time normalization at the API boundary.
> 
> **Overview**
> Tightens **`Resolution`** parsing in `@polymarket/bindings` so wire data lands in canonical SDK shapes instead of mixed string/number forms.
> 
> **`lastUpdatedAt`** is always an ISO 8601 string (epoch seconds from the API are converted). **`transactionHash`** and **`logIndex`** are required on the type as **`TxHash | null`** and **`number | null`**, with empty wire strings mapped to `null` and invalid hashes rejected at parse time. **`payouts`** become a fixed two-outcome tuple of decimal collateral strings (e6 micro-units on the wire are scaled down). The extra **`condition_id`** length refine is removed so validation matches the shared **`ConditionId`** schema.
> 
> Tests are updated for the new shapes and add coverage for malformed transaction hashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 615a8fa99e6d54c6e7d18f4cd70a93b665b20120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->