### PR TITLE
fix(client): re-export OrderPostStatus from the root entry point

### DIFF
--- a/.changeset/dev-640-export-order-post-status.md
+++ b/.changeset/dev-640-export-order-post-status.md
@@ -1,0 +1,5 @@
+---
+"@polymarket/client": patch
+---
+
+Re-export the `OrderPostStatus` enum from `@polymarket/client`, so consumers can compare `AcceptedOrderResponse.status` without importing from `@polymarket/bindings/clob`.

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,6 +3,7 @@ export { OrderSide, OrderType } from '@polymarket/bindings';
 export type * from '@polymarket/bindings/clob';
 export {
   NotificationType,
+  OrderPostStatus,
   OrderResponseErrorCode,
   PriceHistoryInterval,
   SignatureType,

--- a/packages/client/tests/integration/orders.test.ts
+++ b/packages/client/tests/integration/orders.test.ts
@@ -4,11 +4,11 @@ import {
   OrderType,
   toOrderId,
 } from '@polymarket/bindings';
-import { OrderPostStatus } from '@polymarket/bindings/clob';
 import {
   createSecureClient,
   InsufficientLiquidityError,
   type Market,
+  OrderPostStatus,
   type RateLimitUpdate,
   type SecureClient,
   UserInputError,

--- a/packages/client/tests/integration/session-keys.test.ts
+++ b/packages/client/tests/integration/session-keys.test.ts
@@ -1,7 +1,7 @@
 import { OrderSide } from '@polymarket/bindings';
-import { OrderPostStatus } from '@polymarket/bindings/clob';
 import {
   createSecureClient,
+  OrderPostStatus,
   SessionKeyKnownScope,
   SignerType,
 } from '@polymarket/client';

--- a/packages/client/tests/integration/subscriptions.test.ts
+++ b/packages/client/tests/integration/subscriptions.test.ts
@@ -1,7 +1,6 @@
 import { OrderSide } from '@polymarket/bindings';
-import { OrderPostStatus } from '@polymarket/bindings/clob';
 import { UserOrderEventType } from '@polymarket/bindings/subscriptions';
-import type { SecureClient } from '@polymarket/client';
+import { OrderPostStatus, type SecureClient } from '@polymarket/client';
 import { expectPresent } from '@polymarket/types';
 import {
   describe,


### PR DESCRIPTION
## Summary

`AcceptedOrderResponse.status` is typed as `OrderPostStatus`, but the root entry point only re-exported the enum as a type, not as a value. Comparing against a member, `response.status === OrderPostStatus.MATCHED`, forced consumers to import from `@polymarket/bindings/clob`, a package documented as not for direct use. Our own integration tests were doing exactly that.

This adds `OrderPostStatus` to the existing `@polymarket/bindings/clob` value-export block, alongside `OrderResponseErrorCode` from the same file, and switches the three integration tests to import it from `@polymarket/client`.

Changeset: `@polymarket/client` patch.

Fixes #344

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Public re-export only; no runtime behavior changes beyond making an existing enum importable from the supported client entry point.
> 
> **Overview**
> **`OrderPostStatus` is now a value export** from `@polymarket/client`, alongside other CLOB enums like `OrderResponseErrorCode`, so apps can write `response.status === OrderPostStatus.LIVE` without pulling from `@polymarket/bindings/clob`.
> 
> Integration tests in **orders**, **session-keys**, and **subscriptions** were updated to import `OrderPostStatus` from `@polymarket/client` instead of the bindings package. A **patch changeset** documents the release for `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b675c08d4bea696cac5b60d47d926bcd94c504aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->