### PR TITLE
feat(data): migrate trader boards to v2

### DIFF
--- a/.changeset/data-v2-trader-boards.md
+++ b/.changeset/data-v2-trader-boards.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': minor
+'@polymarket/client': minor
+---
+
+**Breaking**: migrate trader leaderboard reads to the cursor-paginated v2 contract, add a separate by-wallet standing method, and add biggest-winner pagination with explicit market and Combo variants.

--- a/packages/bindings/src/data/common.ts
+++ b/packages/bindings/src/data/common.ts
@@ -43,24 +43,3 @@ export enum TradeFilterType {
 }
 
 export const TradeFilterTypeSchema = z.enum(TradeFilterType);
-
-export const TimePeriodSchema = z.enum(['DAY', 'WEEK', 'MONTH', 'ALL']);
-
-export const LeaderboardCategorySchema = z.enum([
-  'OVERALL',
-  'POLITICS',
-  'SPORTS',
-  'CRYPTO',
-  'CULTURE',
-  'MENTIONS',
-  'WEATHER',
-  'ECONOMICS',
-  'TECH',
-  'FINANCE',
-]);
-
-export const LeaderboardOrderBySchema = z.enum(['PNL', 'VOL']);
-
-export type TimePeriod = z.infer<typeof TimePeriodSchema>;
-export type LeaderboardCategory = z.infer<typeof LeaderboardCategorySchema>;
-export type LeaderboardOrderBy = z.infer<typeof LeaderboardOrderBySchema>;

--- a/packages/bindings/src/data/leaderboard.test.ts
+++ b/packages/bindings/src/data/leaderboard.test.ts
@@ -1,10 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BiggestWinnerKind,
   FetchBuilderVolumeResponseSchema,
+  FetchTraderLeaderboardStandingResponseSchema,
+  ListBiggestWinnersResponseSchema,
   ListBuilderLeaderboardResponseSchema,
+  ListTraderLeaderboardResponseSchema,
 } from './leaderboard';
 
 const BUILDER_CODE = `0x${'ab'.repeat(32)}`;
+const WALLET = '0xa71093cafc0c099b4ccab24c3cb8018d817923c4';
+const MARKET_CONDITION_ID =
+  '0x2ee43c144834af44ab0e677d89807de5608bce1b473d77f7d77cdfe51e4ef9b6';
+const COMBO_CONDITION_ID =
+  '0x03226d7818f083b4498ac54e8945c5e8a90000000000000000000000000000';
+const MARKET_ASSET_ID =
+  '106202820389491271897895061818233650528471052556347030624382465719269419234285';
+const COMBO_POSITION_ID =
+  '1417766874124101375905411871637299379845694748735178839365809761068049760256';
 
 describe('ListBuilderLeaderboardResponseSchema', () => {
   it('normalizes a page and removes an empty profile image sentinel', () => {
@@ -74,5 +87,160 @@ describe('FetchBuilderVolumeResponseSchema', () => {
         activeUsers: 7,
       },
     ]);
+  });
+});
+
+describe('ListTraderLeaderboardResponseSchema', () => {
+  it('normalizes a trader page and missing profile metadata', () => {
+    const page = ListTraderLeaderboardResponseSchema.parse({
+      data: [
+        {
+          rank: 1,
+          user_id: WALLET,
+          pnl: 403832.48803296004,
+          volume: 5149.82,
+          user_name: 'Talvez10',
+          profile_image: '',
+          x_username: '',
+          verified: false,
+        },
+      ],
+      pagination: {
+        limit: 1,
+        offset: 0,
+        has_more: true,
+        next_cursor: 'opaque-cursor',
+      },
+    });
+
+    expect(page).toEqual({
+      items: [
+        {
+          rank: 1,
+          wallet: WALLET,
+          pnl: '403832.48803296004',
+          volume: '5149.82',
+          userName: 'Talvez10',
+          profileImage: null,
+          xUsername: null,
+          verified: false,
+        },
+      ],
+      hasMore: true,
+      nextCursor: 'opaque-cursor',
+    });
+  });
+});
+
+describe('FetchTraderLeaderboardStandingResponseSchema', () => {
+  it('preserves explicit unranked states', () => {
+    const standing = FetchTraderLeaderboardStandingResponseSchema.parse({
+      data: {
+        user_id: WALLET,
+        pnl: 100,
+        volume: 0,
+        rank_pnl: null,
+        rank_volume: null,
+        user_name: '',
+        profile_image: '',
+        x_username: '',
+        verified: false,
+      },
+    });
+
+    expect(standing).toEqual({
+      wallet: WALLET,
+      pnl: '100',
+      volume: '0',
+      pnlRank: null,
+      volumeRank: null,
+      userName: null,
+      profileImage: null,
+      xUsername: null,
+      verified: false,
+    });
+    expect(
+      FetchTraderLeaderboardStandingResponseSchema.parse({ data: null }),
+    ).toBeNull();
+  });
+});
+
+describe('ListBiggestWinnersResponseSchema', () => {
+  it('normalizes market and Combo winners into distinct variants', () => {
+    const page = ListBiggestWinnersResponseSchema.parse({
+      data: [
+        {
+          win_rank: 1,
+          kind: 'market',
+          user_id: WALLET,
+          pnl: 185862.698495,
+          initial_value: 140293.28279536465,
+          final_value: 326155.98129036464,
+          resolved_at: 1788312706,
+          condition_id: MARKET_CONDITION_ID,
+          position_id: MARKET_ASSET_ID,
+          event_id: 924342,
+          event_slug: 'example-event',
+          event_title: 'Example event',
+          user_name: 'Talvez10',
+          profile_image: '',
+        },
+        {
+          win_rank: 2,
+          kind: 'combo',
+          user_id: WALLET,
+          pnl: 128035.305038,
+          initial_value: 98173.46,
+          final_value: 226208.765038,
+          resolved_at: 1785865104,
+          condition_id: COMBO_CONDITION_ID,
+          position_id: COMBO_POSITION_ID,
+          event_id: 0,
+          event_slug: '',
+          event_title: 'First leg / Second leg',
+          user_name: '',
+          profile_image: '',
+        },
+      ],
+      pagination: {
+        limit: 2,
+        offset: 0,
+        has_more: false,
+        next_cursor: null,
+      },
+    });
+
+    expect(page.items[0]).toEqual({
+      rank: 1,
+      kind: BiggestWinnerKind.Market,
+      wallet: WALLET,
+      pnl: '185862.698495',
+      initialValue: '140293.28279536465',
+      finalValue: '326155.98129036464',
+      resolvedAt: 1788312706000,
+      conditionId: MARKET_CONDITION_ID,
+      assetId: MARKET_ASSET_ID,
+      eventId: '924342',
+      eventSlug: 'example-event',
+      eventTitle: 'Example event',
+      userName: 'Talvez10',
+      profileImage: null,
+    });
+    expect(page.items[1]).toEqual({
+      rank: 2,
+      kind: BiggestWinnerKind.Combo,
+      wallet: WALLET,
+      pnl: '128035.305038',
+      initialValue: '98173.46',
+      finalValue: '226208.765038',
+      resolvedAt: 1785865104000,
+      conditionId: COMBO_CONDITION_ID,
+      positionId: COMBO_POSITION_ID,
+      eventId: null,
+      eventSlug: null,
+      eventTitle: 'First leg / Second leg',
+      userName: null,
+      profileImage: null,
+    });
   });
 });

--- a/packages/bindings/src/data/leaderboard.ts
+++ b/packages/bindings/src/data/leaderboard.ts
@@ -2,15 +2,29 @@ import { z } from 'zod';
 import {
   type BuilderCode,
   BuilderCodeSchema,
+  type ClobAssetId,
+  ClobAssetIdSchema,
+  type ComboConditionId,
+  ComboConditionIdSchema,
+  type ConditionId,
+  ConditionIdSchema,
   DecimalishSchema,
   type DecimalString,
+  type EpochMilliseconds,
+  EpochSecondsToMillisecondsSchema,
+  type EventId,
+  EventIdSchema,
+  type EvmAddress,
   EvmAddressSchema,
+  emptyStringToNull,
   type IsoCalendarDateString,
   IsoCalendarDateStringSchema,
+  type PositionId,
+  PositionIdSchema,
 } from '../shared';
 import { dataEnvelopeSchema, dataPageSchema } from './envelope';
 
-/** Window used to rank builders on the builder leaderboard. */
+/** Window used to rank a leaderboard. */
 export enum LeaderboardWindow {
   Day = 'day',
   Week = 'week',
@@ -31,6 +45,22 @@ export enum BuilderVolumeInterval {
 
 export const BuilderVolumeIntervalSchema = z.enum(BuilderVolumeInterval);
 
+/** Metric used to rank traders on the leaderboard. */
+export enum TraderLeaderboardSort {
+  Pnl = 'PNL',
+  Volume = 'VOLUME',
+}
+
+export const TraderLeaderboardSortSchema = z.enum(TraderLeaderboardSort);
+
+/** Source of a winning position. */
+export enum BiggestWinnerKind {
+  Market = 'market',
+  Combo = 'combo',
+}
+
+export const BiggestWinnerKindSchema = z.enum(BiggestWinnerKind);
+
 export type BuilderStanding = {
   /** Rank in the selected leaderboard window. */
   rank: number;
@@ -48,7 +78,7 @@ export type BuilderStanding = {
 
 export const BuilderStandingSchema = z
   .object({
-    rank: z.number().int().min(0),
+    rank: z.number().int().positive(),
     builder_name: z.string(),
     builder_code: BuilderCodeSchema,
     profile_image: z.string(),
@@ -112,21 +142,217 @@ export const BuilderVolumePointSchema = z
     }),
   ) satisfies z.ZodType<BuilderVolumePoint>;
 
+const NullableTextSchema = z.preprocess(
+  emptyStringToNull,
+  z.string().nullable(),
+);
+
+export type TraderLeaderboardEntry = {
+  /** Competition rank on the selected board; ties share a rank and the next rank skips. */
+  rank: number;
+  /** Ranked wallet. */
+  wallet: EvmAddress;
+  /** PnL in USD for the selected window. */
+  pnl: DecimalString;
+  /** Both-sides traded volume in shares. */
+  volume: DecimalString;
+  userName: string | null;
+  profileImage: string | null;
+  xUsername: string | null;
+  verified: boolean;
+};
+
 export const TraderLeaderboardEntrySchema = z
   .object({
-    rank: z.string().nullish(),
-    proxyWallet: EvmAddressSchema.nullish(),
-    userName: z.string().nullish(),
-    vol: DecimalishSchema.nullish(),
-    pnl: DecimalishSchema.nullish(),
-    profileImage: z.string().nullish(),
-    xUsername: z.string().nullish(),
-    verifiedBadge: z.boolean().nullish(),
+    rank: z.number().int().min(0),
+    user_id: EvmAddressSchema,
+    pnl: DecimalishSchema,
+    volume: DecimalishSchema,
+    user_name: NullableTextSchema,
+    profile_image: NullableTextSchema,
+    x_username: NullableTextSchema,
+    verified: z.boolean(),
   })
-  .transform(({ proxyWallet, ...rest }) => ({
-    ...rest,
-    wallet: proxyWallet,
-  }));
+  .transform(({ profile_image, user_id, user_name, x_username, ...entry }) => ({
+    ...entry,
+    wallet: user_id,
+    userName: user_name,
+    profileImage: profile_image,
+    xUsername: x_username,
+  })) satisfies z.ZodType<TraderLeaderboardEntry>;
+
+export type TraderLeaderboardStanding = {
+  /** Looked-up wallet. */
+  wallet: EvmAddress;
+  /** PnL in USD for the selected window. */
+  pnl: DecimalString;
+  /** Both-sides traded volume in shares. */
+  volume: DecimalString;
+  /** Competition rank on the PnL board, or `null` when unranked. */
+  pnlRank: number | null;
+  /** Competition rank on the volume board, or `null` when unranked. */
+  volumeRank: number | null;
+  userName: string | null;
+  profileImage: string | null;
+  xUsername: string | null;
+  verified: boolean;
+};
+
+export const TraderLeaderboardStandingSchema = z
+  .object({
+    user_id: EvmAddressSchema,
+    pnl: DecimalishSchema,
+    volume: DecimalishSchema,
+    rank_pnl: z.number().int().positive().nullable(),
+    rank_volume: z.number().int().positive().nullable(),
+    user_name: NullableTextSchema,
+    profile_image: NullableTextSchema,
+    x_username: NullableTextSchema,
+    verified: z.boolean(),
+  })
+  .transform(
+    ({
+      profile_image,
+      rank_pnl,
+      rank_volume,
+      user_id,
+      user_name,
+      x_username,
+      ...standing
+    }) => ({
+      ...standing,
+      wallet: user_id,
+      pnlRank: rank_pnl,
+      volumeRank: rank_volume,
+      userName: user_name,
+      profileImage: profile_image,
+      xUsername: x_username,
+    }),
+  ) satisfies z.ZodType<TraderLeaderboardStanding>;
+
+export type MarketBiggestWinner = {
+  /** Unique one-based row ordinal on the selected board. */
+  rank: number;
+  kind: BiggestWinnerKind.Market;
+  wallet: EvmAddress;
+  /** Profit from this winning position, in USD. */
+  pnl: DecimalString;
+  /** Cost basis of this winning position, in USD. */
+  initialValue: DecimalString;
+  /** Value of this winning position at resolution, in USD. */
+  finalValue: DecimalString;
+  /** Resolution time as Unix epoch milliseconds. */
+  resolvedAt: EpochMilliseconds;
+  conditionId: ConditionId;
+  assetId: ClobAssetId;
+  eventId: EventId;
+  eventSlug: string;
+  eventTitle: string;
+  userName: string | null;
+  profileImage: string | null;
+};
+
+export type ComboBiggestWinner = {
+  /** Unique one-based row ordinal on the selected board. */
+  rank: number;
+  kind: BiggestWinnerKind.Combo;
+  wallet: EvmAddress;
+  /** Profit from this winning position, in USD. */
+  pnl: DecimalString;
+  /** Cost basis of this winning position, in USD. */
+  initialValue: DecimalString;
+  /** Value of this winning position at resolution, in USD. */
+  finalValue: DecimalString;
+  /** Resolution time as Unix epoch milliseconds. */
+  resolvedAt: EpochMilliseconds;
+  conditionId: ComboConditionId;
+  positionId: PositionId;
+  eventId: null;
+  eventSlug: null;
+  /** Questions of the Combo's legs joined with ` / `. */
+  eventTitle: string;
+  userName: string | null;
+  profileImage: string | null;
+};
+
+export type BiggestWinner = MarketBiggestWinner | ComboBiggestWinner;
+
+const MarketBiggestWinnerSchema = z.object({
+  win_rank: z.number().int().positive(),
+  kind: z.literal(BiggestWinnerKind.Market),
+  user_id: EvmAddressSchema,
+  pnl: DecimalishSchema,
+  initial_value: DecimalishSchema,
+  final_value: DecimalishSchema,
+  resolved_at: EpochSecondsToMillisecondsSchema,
+  condition_id: ConditionIdSchema,
+  position_id: ClobAssetIdSchema,
+  event_id: EventIdSchema,
+  event_slug: z.string(),
+  event_title: z.string(),
+  user_name: NullableTextSchema,
+  profile_image: NullableTextSchema,
+});
+
+const ComboBiggestWinnerSchema = z.object({
+  win_rank: z.number().int().positive(),
+  kind: z.literal(BiggestWinnerKind.Combo),
+  user_id: EvmAddressSchema,
+  pnl: DecimalishSchema,
+  initial_value: DecimalishSchema,
+  final_value: DecimalishSchema,
+  resolved_at: EpochSecondsToMillisecondsSchema,
+  condition_id: ComboConditionIdSchema,
+  position_id: PositionIdSchema,
+  event_id: z.literal(0),
+  event_slug: z.literal(''),
+  event_title: z.string(),
+  user_name: NullableTextSchema,
+  profile_image: NullableTextSchema,
+});
+
+export const BiggestWinnerSchema = z
+  .discriminatedUnion('kind', [
+    MarketBiggestWinnerSchema,
+    ComboBiggestWinnerSchema,
+  ])
+  .transform((winner): BiggestWinner => {
+    if (winner.kind === BiggestWinnerKind.Combo) {
+      return {
+        rank: winner.win_rank,
+        kind: winner.kind,
+        wallet: winner.user_id,
+        pnl: winner.pnl,
+        initialValue: winner.initial_value,
+        finalValue: winner.final_value,
+        resolvedAt: winner.resolved_at,
+        conditionId: winner.condition_id,
+        positionId: winner.position_id,
+        eventId: null,
+        eventSlug: null,
+        eventTitle: winner.event_title,
+        userName: winner.user_name,
+        profileImage: winner.profile_image,
+      };
+    }
+
+    return {
+      rank: winner.win_rank,
+      kind: winner.kind,
+      wallet: winner.user_id,
+      pnl: winner.pnl,
+      initialValue: winner.initial_value,
+      finalValue: winner.final_value,
+      resolvedAt: winner.resolved_at,
+      conditionId: winner.condition_id,
+      assetId: winner.position_id,
+      eventId: winner.event_id,
+      eventSlug: winner.event_slug,
+      eventTitle: winner.event_title,
+      userName: winner.user_name,
+      profileImage: winner.profile_image,
+    };
+  }) satisfies z.ZodType<BiggestWinner>;
 
 export const ListBuilderLeaderboardResponseSchema = dataPageSchema(
   BuilderStandingSchema,
@@ -134,13 +360,15 @@ export const ListBuilderLeaderboardResponseSchema = dataPageSchema(
 export const FetchBuilderVolumeResponseSchema = dataEnvelopeSchema(
   z.array(BuilderVolumePointSchema),
 );
-export const ListTraderLeaderboardResponseSchema = z.array(
+export const ListTraderLeaderboardResponseSchema = dataPageSchema(
   TraderLeaderboardEntrySchema,
 );
+export const FetchTraderLeaderboardStandingResponseSchema = dataEnvelopeSchema(
+  TraderLeaderboardStandingSchema.nullable(),
+);
+export const ListBiggestWinnersResponseSchema =
+  dataPageSchema(BiggestWinnerSchema);
 
-export type TraderLeaderboardEntry = z.infer<
-  typeof TraderLeaderboardEntrySchema
->;
 export type ListBuilderLeaderboardResponse = z.infer<
   typeof ListBuilderLeaderboardResponseSchema
 >;
@@ -149,4 +377,10 @@ export type FetchBuilderVolumeResponse = z.infer<
 >;
 export type ListTraderLeaderboardResponse = z.infer<
   typeof ListTraderLeaderboardResponseSchema
+>;
+export type FetchTraderLeaderboardStandingResponse = z.infer<
+  typeof FetchTraderLeaderboardStandingResponseSchema
+>;
+export type ListBiggestWinnersResponse = z.infer<
+  typeof ListBiggestWinnersResponseSchema
 >;

--- a/packages/client/src/actions/leaderboards.ts
+++ b/packages/client/src/actions/leaderboards.ts
@@ -1,16 +1,18 @@
-import { PaginationCursorSchema } from '@polymarket/bindings';
+import { EvmAddressSchema, PaginationCursorSchema } from '@polymarket/bindings';
 import {
+  type BiggestWinner,
   type BuilderStanding,
   BuilderVolumeIntervalSchema,
   type BuilderVolumePoint,
   FetchBuilderVolumeResponseSchema,
-  LeaderboardCategorySchema,
-  LeaderboardOrderBySchema,
+  FetchTraderLeaderboardStandingResponseSchema,
   LeaderboardWindowSchema,
+  ListBiggestWinnersResponseSchema,
   ListBuilderLeaderboardResponseSchema,
   ListTraderLeaderboardResponseSchema,
-  TimePeriodSchema,
   type TraderLeaderboardEntry,
+  TraderLeaderboardSortSchema,
+  type TraderLeaderboardStanding,
 } from '@polymarket/bindings/data';
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
@@ -24,20 +26,16 @@ import {
   UserInputError,
 } from '../errors';
 import { parseUserInput } from '../input';
-import {
-  decodeOffsetCursor,
-  encodeOffsetCursor,
-  PageSizeSchema,
-  type Paginated,
-  paginate,
-} from '../pagination';
+import { PageSizeSchema, type Paginated, paginate } from '../pagination';
 import { validateWith } from '../response';
 import { withRateLimitRetry } from '../retry';
-import { toDataSearchParams, toLegacyDataSearchParams } from './params';
+import { toDataSearchParams } from './params';
 
 export {
+  BiggestWinnerKind,
   BuilderVolumeInterval,
   LeaderboardWindow,
+  TraderLeaderboardSort,
 } from '@polymarket/bindings/data';
 
 const ListBuilderLeaderboardRequestSchema = z.object({
@@ -201,15 +199,15 @@ export async function fetchBuilderVolume(
   );
 }
 
+const BoardCategorySchema = z.string().min(1);
+
 const ListTraderLeaderboardRequestSchema = z.object({
-  category: LeaderboardCategorySchema.optional(),
+  category: BoardCategorySchema.optional(),
   cursor: PaginationCursorSchema.optional(),
-  // Matches the upstream per-request limit cap.
-  pageSize: PageSizeSchema.max(50).default(20),
-  timePeriod: TimePeriodSchema.optional(),
-  orderBy: LeaderboardOrderBySchema.optional(),
-  user: z.string().optional(),
-  userName: z.string().optional(),
+  // The first-page default and cap; continuation cursors retain their page size.
+  pageSize: PageSizeSchema.max(1000).default(100),
+  sortBy: TraderLeaderboardSortSchema.optional(),
+  window: LeaderboardWindowSchema.optional(),
 });
 
 export type ListTraderLeaderboardRequest = z.input<
@@ -233,6 +231,11 @@ export const ListTraderLeaderboardError = makeErrorGuard(
 /**
  * Lists trader leaderboard rankings.
  *
+ * `window` defaults to one day, `category` to overall, and `sortBy` to PnL.
+ * Finite-window PnL is marked equity change net of flows, while all-time PnL
+ * is realized only. Volume is measured in shares. Tied traders share a rank
+ * and the next rank skips. `pageSize` defaults to 100 (max 1000).
+ *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
  *
@@ -243,9 +246,9 @@ export const ListTraderLeaderboardError = makeErrorGuard(
  * Fetch the first page of results:
  * ```ts
  * const result = listTraderLeaderboard(client, {
- *   orderBy: 'PNL',
  *   pageSize: 10,
- *   timePeriod: 'DAY',
+ *   sortBy: TraderLeaderboardSort.Pnl,
+ *   window: LeaderboardWindow.Week,
  * });
  *
  * const firstPage = await result.firstPage();
@@ -260,9 +263,9 @@ export const ListTraderLeaderboardError = makeErrorGuard(
  * Loop through all pages with `for await`:
  * ```ts
  * const result = listTraderLeaderboard(client, {
- *   orderBy: 'PNL',
  *   pageSize: 10,
- *   timePeriod: 'DAY',
+ *   sortBy: TraderLeaderboardSort.Pnl,
+ *   window: LeaderboardWindow.Week,
  * });
  *
  * for await (const page of result) {
@@ -274,36 +277,173 @@ export function listTraderLeaderboard(
   client: BaseClient,
   request: ListTraderLeaderboardRequest = {},
 ): Paginated<TraderLeaderboardEntry[]> {
-  const { cursor, pageSize, ...params } = parseUserInput(
+  const { category, cursor, pageSize, sortBy, window } = parseUserInput(
     request,
     ListTraderLeaderboardRequestSchema,
   );
 
-  return paginate((cursor) => {
-    const decoded = decodeOffsetCursor(cursor, pageSize);
-
-    return client.data
-      .get('/v1/leaderboard', {
-        params: toLegacyDataSearchParams({
-          ...params,
-          limit: decoded.pageSize,
-          offset: decoded.offset,
+  return paginate(
+    (cursor) =>
+      withRateLimitRetry(() =>
+        client.data.get('/v2/leaderboard', {
+          // Retain the selected board across the cursor walk. The cursor pins
+          // these values and the server rejects contradictory restatements.
+          params: toDataSearchParams({
+            category,
+            cursor,
+            limit: pageSize,
+            sortBy,
+            timePeriod: window,
+          }),
         }),
-      })
-      .andThen(validateWith(ListTraderLeaderboardResponseSchema))
-      .map((traders) => {
-        const hasMore = traders.length >= decoded.pageSize;
+      ).andThen(validateWith(ListTraderLeaderboardResponseSchema)),
+    cursor,
+  );
+}
 
-        return {
-          items: traders,
-          hasMore,
-          nextCursor: hasMore
-            ? encodeOffsetCursor({
-                offset: decoded.offset + decoded.pageSize,
-                pageSize: decoded.pageSize,
-              })
-            : undefined,
-        };
-      });
-  }, cursor);
+const FetchTraderLeaderboardStandingRequestSchema = z.object({
+  category: BoardCategorySchema.optional(),
+  user: EvmAddressSchema,
+  window: LeaderboardWindowSchema.optional(),
+});
+
+export type FetchTraderLeaderboardStandingRequest = z.input<
+  typeof FetchTraderLeaderboardStandingRequestSchema
+>;
+
+export type FetchTraderLeaderboardStandingError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const FetchTraderLeaderboardStandingError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Fetches one trader's standing on both the PnL and volume boards.
+ *
+ * `window` defaults to one day and `category` to overall. A `null` rank means
+ * the trader is unranked on that board. Returns `null` for an unknown wallet.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
+ * @throws {@link FetchTraderLeaderboardStandingError}
+ * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const standing = await fetchTraderLeaderboardStanding(client, {
+ *   user: '0xa71093cafc0c099b4ccab24c3cb8018d817923c4',
+ *   window: LeaderboardWindow.All,
+ * });
+ *
+ * // standing: TraderLeaderboardStanding | null
+ * ```
+ */
+export async function fetchTraderLeaderboardStanding(
+  client: BaseClient,
+  request: FetchTraderLeaderboardStandingRequest,
+): Promise<TraderLeaderboardStanding | null> {
+  const { category, user, window } = parseUserInput(
+    request,
+    FetchTraderLeaderboardStandingRequestSchema,
+  );
+
+  return unwrap(
+    withRateLimitRetry(() =>
+      client.data.get('/v2/leaderboard', {
+        params: toDataSearchParams({
+          category,
+          timePeriod: window,
+          user,
+        }),
+      }),
+    ).andThen(validateWith(FetchTraderLeaderboardStandingResponseSchema)),
+  );
+}
+
+const ListBiggestWinnersRequestSchema = z.object({
+  category: BoardCategorySchema.optional(),
+  cursor: PaginationCursorSchema.optional(),
+  // The first-page default and cap; continuation cursors retain their page size.
+  pageSize: PageSizeSchema.max(1000).default(100),
+  window: LeaderboardWindowSchema.optional(),
+});
+
+export type ListBiggestWinnersRequest = z.input<
+  typeof ListBiggestWinnersRequestSchema
+>;
+
+export type ListBiggestWinnersError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const ListBiggestWinnersError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Lists the largest individual winning positions.
+ *
+ * The board has one row per position, ranked by its resolution profit.
+ * `window` applies to resolution time and defaults to one day; `category`
+ * defaults to overall. Equal profits retain distinct row ordinals. Combo rows
+ * have no parent event, so branch on `kind` before using event metadata.
+ * `pageSize` defaults to 100 (max 1000).
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
+ * @throws {@link ListBiggestWinnersError}
+ * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const result = listBiggestWinners(client, {
+ *   category: 'sports',
+ *   pageSize: 10,
+ *   window: LeaderboardWindow.Week,
+ * });
+ *
+ * for await (const page of result) {
+ *   // page.items: BiggestWinner[]
+ * }
+ * ```
+ */
+export function listBiggestWinners(
+  client: BaseClient,
+  request: ListBiggestWinnersRequest = {},
+): Paginated<BiggestWinner[]> {
+  const { category, cursor, pageSize, window } = parseUserInput(
+    request,
+    ListBiggestWinnersRequestSchema,
+  );
+
+  return paginate(
+    (cursor) =>
+      withRateLimitRetry(() =>
+        client.data.get('/v2/biggest-winners', {
+          params: toDataSearchParams({
+            category,
+            cursor,
+            limit: pageSize,
+            timePeriod: window,
+          }),
+        }),
+      ).andThen(validateWith(ListBiggestWinnersResponseSchema)),
+    cursor,
+  );
 }

--- a/packages/client/src/decorators/account.ts
+++ b/packages/client/src/decorators/account.ts
@@ -8,6 +8,7 @@ import type {
   ComboPosition,
   PortfolioValue,
   Position,
+  TraderLeaderboardStanding,
   UserPnlSeries,
   UserStats,
   UserVolume,
@@ -19,12 +20,14 @@ import {
   downloadAccountingSnapshot,
   dropNotifications,
   type FetchPortfolioValueRequest,
+  type FetchTraderLeaderboardStandingRequest,
   type FetchUserPnlRequest,
   type FetchUserStatsRequest,
   type FetchUserVolumeRequest,
   fetchClosedOnlyMode,
   fetchNotifications,
   fetchPortfolioValue,
+  fetchTraderLeaderboardStanding,
   fetchUserPnl,
   fetchUserStats,
   fetchUserVolume,
@@ -63,6 +66,8 @@ export type SecureListComboPositionsRequest =
   DefaultAccountWallet<ListComboPositionsRequest>;
 export type SecureFetchPortfolioValueRequest =
   DefaultAccountWallet<FetchPortfolioValueRequest>;
+export type SecureFetchTraderLeaderboardStandingRequest =
+  DefaultAccountWallet<FetchTraderLeaderboardStandingRequest>;
 export type SecureFetchUserPnlRequest =
   DefaultAccountWallet<FetchUserPnlRequest>;
 export type SecureFetchUserStatsRequest =
@@ -167,6 +172,26 @@ export type PublicAccountActions = Prettify<{
   fetchPortfolioValue(
     request: FetchPortfolioValueRequest,
   ): Promise<PortfolioValue>;
+  /**
+   * Fetches one trader's standing on both the PnL and volume boards.
+   *
+   * `window` defaults to one day and `category` to overall. A `null` rank means
+   * the trader is unranked on that board. Returns `null` for an unknown wallet.
+   *
+   * @throws {@link FetchTraderLeaderboardStandingError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const standing = await client.fetchTraderLeaderboardStanding({
+   *   user: '0xa71093cafc0c099b4ccab24c3cb8018d817923c4',
+   *   window: LeaderboardWindow.All,
+   * });
+   * ```
+   */
+  fetchTraderLeaderboardStanding(
+    request: FetchTraderLeaderboardStandingRequest,
+  ): Promise<TraderLeaderboardStanding | null>;
   /**
    * Fetches profile and lifetime trading statistics for a wallet.
    *
@@ -359,6 +384,26 @@ export type SecureAccountActions = Prettify<{
     request?: SecureFetchPortfolioValueRequest,
   ): Promise<PortfolioValue>;
   /**
+   * Fetches one trader's standing on both the PnL and volume boards.
+   *
+   * Defaults to the authenticated account's wallet when `user` is omitted.
+   * `window` defaults to one day and `category` to overall. A `null` rank means
+   * the trader is unranked on that board. Returns `null` for an unknown wallet.
+   *
+   * @throws {@link FetchTraderLeaderboardStandingError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const standing = await client.fetchTraderLeaderboardStanding({
+   *   window: LeaderboardWindow.All,
+   * });
+   * ```
+   */
+  fetchTraderLeaderboardStanding(
+    request?: SecureFetchTraderLeaderboardStandingRequest,
+  ): Promise<TraderLeaderboardStanding | null>;
+  /**
    * Fetches profile and lifetime trading statistics for a wallet.
    *
    * `tradedMarketCount` is the exact number of distinct markets traded.
@@ -506,6 +551,10 @@ function publicAccountActions(client: BaseClient): PublicAccountActions {
     listPositions: listPositions.bind(null, client),
     listComboPositions: listComboPositions.bind(null, client),
     fetchPortfolioValue: fetchPortfolioValue.bind(null, client),
+    fetchTraderLeaderboardStanding: fetchTraderLeaderboardStanding.bind(
+      null,
+      client,
+    ),
     fetchUserStats: fetchUserStats.bind(null, client),
     fetchUserPnl: fetchUserPnl.bind(null, client),
     fetchUserVolume: fetchUserVolume.bind(null, client),
@@ -544,6 +593,13 @@ export function accountActions(
       listComboPositions(client, withAccountWallet(client, request)),
     fetchPortfolioValue: (request?: SecureFetchPortfolioValueRequest) =>
       fetchPortfolioValue(client, withAccountWallet(client, request)),
+    fetchTraderLeaderboardStanding: (
+      request?: SecureFetchTraderLeaderboardStandingRequest,
+    ) =>
+      fetchTraderLeaderboardStanding(
+        client,
+        withAccountWallet(client, request),
+      ),
     fetchUserStats: (request?: SecureFetchUserStatsRequest) =>
       fetchUserStats(client, withAccountWallet(client, request)),
     fetchUserPnl: (request?: SecureFetchUserPnlRequest) =>
@@ -573,6 +629,7 @@ export {
   FetchClosedOnlyModeError,
   FetchNotificationsError,
   FetchPortfolioValueError,
+  FetchTraderLeaderboardStandingError,
   FetchUserPnlError,
   FetchUserStatsError,
   FetchUserVolumeError,

--- a/packages/client/src/decorators/analytics.ts
+++ b/packages/client/src/decorators/analytics.ts
@@ -6,6 +6,7 @@ import type {
   TraderLeaderboardEntry,
   TraderLeaderboardStanding,
 } from '@polymarket/bindings/data';
+import type { Prettify } from '@polymarket/types';
 import {
   type FetchBuilderVolumeRequest,
   type FetchTraderLeaderboardStandingRequest,
@@ -230,10 +231,51 @@ export type AnalyticsActions = {
   ): Paginated<BiggestWinner[]>;
 };
 
+export type SecureFetchTraderLeaderboardStandingRequest = Prettify<
+  Omit<FetchTraderLeaderboardStandingRequest, 'user'> & {
+    /**
+     * Wallet address to use.
+     *
+     * @defaultValue `client.account.wallet`
+     */
+    user?: string;
+  }
+>;
+
+export type SecureAnalyticsActions = Prettify<
+  Omit<AnalyticsActions, 'fetchTraderLeaderboardStanding'> & {
+    /**
+     * Fetches one trader's standing on both the PnL and volume boards.
+     *
+     * Defaults to the authenticated account's wallet when `user` is omitted.
+     * `window` defaults to one day and `category` to overall. A `null` rank
+     * means the trader is unranked on that board. Returns `null` for an unknown
+     * wallet.
+     *
+     * @throws {@link FetchTraderLeaderboardStandingError}
+     * Thrown on failure.
+     *
+     * @example
+     * ```ts
+     * const standing = await client.fetchTraderLeaderboardStanding({
+     *   window: LeaderboardWindow.All,
+     * });
+     * ```
+     */
+    fetchTraderLeaderboardStanding(
+      request?: SecureFetchTraderLeaderboardStandingRequest,
+    ): Promise<TraderLeaderboardStanding | null>;
+  }
+>;
+
 export function analyticsActions(client: BasePublicClient): AnalyticsActions;
-export function analyticsActions(client: BaseSecureClient): AnalyticsActions;
-export function analyticsActions(client: BaseClient): AnalyticsActions {
-  return {
+export function analyticsActions(
+  client: BaseSecureClient,
+): SecureAnalyticsActions;
+export function analyticsActions(
+  client: BaseClient,
+): AnalyticsActions | SecureAnalyticsActions {
+  const actions: AnalyticsActions = {
     listBuilderTrades: listBuilderTrades.bind(null, client),
     listBuilderLeaderboard: listBuilderLeaderboard.bind(null, client),
     fetchBuilderVolume: fetchBuilderVolume.bind(null, client),
@@ -244,11 +286,26 @@ export function analyticsActions(client: BaseClient): AnalyticsActions {
     ),
     listBiggestWinners: listBiggestWinners.bind(null, client),
   };
+
+  if (client.isPublicClient()) {
+    return actions;
+  }
+
+  return {
+    ...actions,
+    fetchTraderLeaderboardStanding: (
+      request: SecureFetchTraderLeaderboardStandingRequest = {},
+    ) =>
+      fetchTraderLeaderboardStanding(client, {
+        ...request,
+        user: request.user ?? client.account.wallet,
+      }),
+  };
 }
 
 // Error unions and runtime `isError` guards for every action bound above.
 // Surfaced at the root entry point through `export * from './decorators'`.
-// Keep this list in sync with the methods on AnalyticsActions.
+// Keep this list in sync with the methods on AnalyticsActions / SecureAnalyticsActions.
 export {
   BiggestWinnerKind,
   BuilderVolumeInterval,

--- a/packages/client/src/decorators/analytics.ts
+++ b/packages/client/src/decorators/analytics.ts
@@ -4,14 +4,10 @@ import type {
   BuilderStanding,
   BuilderVolumePoint,
   TraderLeaderboardEntry,
-  TraderLeaderboardStanding,
 } from '@polymarket/bindings/data';
-import type { Prettify } from '@polymarket/types';
 import {
   type FetchBuilderVolumeRequest,
-  type FetchTraderLeaderboardStandingRequest,
   fetchBuilderVolume,
-  fetchTraderLeaderboardStanding,
   type ListBiggestWinnersRequest,
   type ListBuilderLeaderboardRequest,
   type ListBuilderTradesRequest,
@@ -181,27 +177,6 @@ export type AnalyticsActions = {
   ): Paginated<TraderLeaderboardEntry[]>;
 
   /**
-   * Fetches one trader's standing on both the PnL and volume boards.
-   *
-   * `window` defaults to one day and `category` to overall. A `null` rank means
-   * the trader is unranked on that board. Returns `null` for an unknown wallet.
-   *
-   * @throws {@link FetchTraderLeaderboardStandingError}
-   * Thrown on failure.
-   *
-   * @example
-   * ```ts
-   * const standing = await client.fetchTraderLeaderboardStanding({
-   *   user: '0xa71093cafc0c099b4ccab24c3cb8018d817923c4',
-   *   window: LeaderboardWindow.All,
-   * });
-   * ```
-   */
-  fetchTraderLeaderboardStanding(
-    request: FetchTraderLeaderboardStandingRequest,
-  ): Promise<TraderLeaderboardStanding | null>;
-
-  /**
    * Lists the largest individual winning positions.
    *
    * The board has one row per position, ranked by its resolution profit.
@@ -231,86 +206,25 @@ export type AnalyticsActions = {
   ): Paginated<BiggestWinner[]>;
 };
 
-export type SecureFetchTraderLeaderboardStandingRequest = Prettify<
-  Omit<FetchTraderLeaderboardStandingRequest, 'user'> & {
-    /**
-     * Wallet address to use.
-     *
-     * @defaultValue `client.account.wallet`
-     */
-    user?: string;
-  }
->;
-
-export type SecureAnalyticsActions = Prettify<
-  Omit<AnalyticsActions, 'fetchTraderLeaderboardStanding'> & {
-    /**
-     * Fetches one trader's standing on both the PnL and volume boards.
-     *
-     * Defaults to the authenticated account's wallet when `user` is omitted.
-     * `window` defaults to one day and `category` to overall. A `null` rank
-     * means the trader is unranked on that board. Returns `null` for an unknown
-     * wallet.
-     *
-     * @throws {@link FetchTraderLeaderboardStandingError}
-     * Thrown on failure.
-     *
-     * @example
-     * ```ts
-     * const standing = await client.fetchTraderLeaderboardStanding({
-     *   window: LeaderboardWindow.All,
-     * });
-     * ```
-     */
-    fetchTraderLeaderboardStanding(
-      request?: SecureFetchTraderLeaderboardStandingRequest,
-    ): Promise<TraderLeaderboardStanding | null>;
-  }
->;
-
 export function analyticsActions(client: BasePublicClient): AnalyticsActions;
-export function analyticsActions(
-  client: BaseSecureClient,
-): SecureAnalyticsActions;
-export function analyticsActions(
-  client: BaseClient,
-): AnalyticsActions | SecureAnalyticsActions {
-  const actions: AnalyticsActions = {
+export function analyticsActions(client: BaseSecureClient): AnalyticsActions;
+export function analyticsActions(client: BaseClient): AnalyticsActions {
+  return {
     listBuilderTrades: listBuilderTrades.bind(null, client),
     listBuilderLeaderboard: listBuilderLeaderboard.bind(null, client),
     fetchBuilderVolume: fetchBuilderVolume.bind(null, client),
     listTraderLeaderboard: listTraderLeaderboard.bind(null, client),
-    fetchTraderLeaderboardStanding: fetchTraderLeaderboardStanding.bind(
-      null,
-      client,
-    ),
     listBiggestWinners: listBiggestWinners.bind(null, client),
-  };
-
-  if (client.isPublicClient()) {
-    return actions;
-  }
-
-  return {
-    ...actions,
-    fetchTraderLeaderboardStanding: (
-      request: SecureFetchTraderLeaderboardStandingRequest = {},
-    ) =>
-      fetchTraderLeaderboardStanding(client, {
-        ...request,
-        user: request.user ?? client.account.wallet,
-      }),
   };
 }
 
 // Error unions and runtime `isError` guards for every action bound above.
 // Surfaced at the root entry point through `export * from './decorators'`.
-// Keep this list in sync with the methods on AnalyticsActions / SecureAnalyticsActions.
+// Keep this list in sync with the methods on AnalyticsActions.
 export {
   BiggestWinnerKind,
   BuilderVolumeInterval,
   FetchBuilderVolumeError,
-  FetchTraderLeaderboardStandingError,
   LeaderboardWindow,
   ListBiggestWinnersError,
   ListBuilderLeaderboardError,

--- a/packages/client/src/decorators/analytics.ts
+++ b/packages/client/src/decorators/analytics.ts
@@ -1,15 +1,21 @@
 import type { BuilderTrade } from '@polymarket/bindings/clob';
 import type {
+  BiggestWinner,
   BuilderStanding,
   BuilderVolumePoint,
   TraderLeaderboardEntry,
+  TraderLeaderboardStanding,
 } from '@polymarket/bindings/data';
 import {
   type FetchBuilderVolumeRequest,
+  type FetchTraderLeaderboardStandingRequest,
   fetchBuilderVolume,
+  fetchTraderLeaderboardStanding,
+  type ListBiggestWinnersRequest,
   type ListBuilderLeaderboardRequest,
   type ListBuilderTradesRequest,
   type ListTraderLeaderboardRequest,
+  listBiggestWinners,
   listBuilderLeaderboard,
   listBuilderTrades,
   listTraderLeaderboard,
@@ -130,6 +136,11 @@ export type AnalyticsActions = {
   /**
    * Lists trader leaderboard rankings.
    *
+   * `window` defaults to one day, `category` to overall, and `sortBy` to PnL.
+   * Finite-window PnL is marked equity change net of flows, while all-time PnL
+   * is realized only. Volume is measured in shares. Tied traders share a rank
+   * and the next rank skips. `pageSize` defaults to 100 (max 1000).
+   *
    * @throws {@link ListTraderLeaderboardError}
    * Thrown on failure.
    *
@@ -137,9 +148,9 @@ export type AnalyticsActions = {
    * Fetch the first page of results:
    * ```ts
    * const paginator = client.listTraderLeaderboard({
-   *   orderBy: 'PNL',
    *   pageSize: 10,
-   *   timePeriod: 'DAY',
+   *   sortBy: TraderLeaderboardSort.Pnl,
+   *   window: LeaderboardWindow.Week,
    * });
    *
    * const firstPage = await paginator.firstPage();
@@ -154,9 +165,9 @@ export type AnalyticsActions = {
    * Loop through all pages with `for await`:
    * ```ts
    * const paginator = client.listTraderLeaderboard({
-   *   orderBy: 'PNL',
    *   pageSize: 10,
-   *   timePeriod: 'DAY',
+   *   sortBy: TraderLeaderboardSort.Pnl,
+   *   window: LeaderboardWindow.Week,
    * });
    *
    * for await (const page of paginator) {
@@ -167,6 +178,56 @@ export type AnalyticsActions = {
   listTraderLeaderboard(
     request?: ListTraderLeaderboardRequest,
   ): Paginated<TraderLeaderboardEntry[]>;
+
+  /**
+   * Fetches one trader's standing on both the PnL and volume boards.
+   *
+   * `window` defaults to one day and `category` to overall. A `null` rank means
+   * the trader is unranked on that board. Returns `null` for an unknown wallet.
+   *
+   * @throws {@link FetchTraderLeaderboardStandingError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const standing = await client.fetchTraderLeaderboardStanding({
+   *   user: '0xa71093cafc0c099b4ccab24c3cb8018d817923c4',
+   *   window: LeaderboardWindow.All,
+   * });
+   * ```
+   */
+  fetchTraderLeaderboardStanding(
+    request: FetchTraderLeaderboardStandingRequest,
+  ): Promise<TraderLeaderboardStanding | null>;
+
+  /**
+   * Lists the largest individual winning positions.
+   *
+   * The board has one row per position, ranked by its resolution profit.
+   * `window` applies to resolution time and defaults to one day; `category`
+   * defaults to overall. Equal profits retain distinct row ordinals. Combo rows
+   * have no parent event, so branch on `kind` before using event metadata.
+   * `pageSize` defaults to 100 (max 1000).
+   *
+   * @throws {@link ListBiggestWinnersError}
+   * Thrown on failure.
+   *
+   * @example
+   * ```ts
+   * const paginator = client.listBiggestWinners({
+   *   category: 'sports',
+   *   pageSize: 10,
+   *   window: LeaderboardWindow.Week,
+   * });
+   *
+   * for await (const page of paginator) {
+   *   // page.items: BiggestWinner[]
+   * }
+   * ```
+   */
+  listBiggestWinners(
+    request?: ListBiggestWinnersRequest,
+  ): Paginated<BiggestWinner[]>;
 };
 
 export function analyticsActions(client: BasePublicClient): AnalyticsActions;
@@ -177,6 +238,11 @@ export function analyticsActions(client: BaseClient): AnalyticsActions {
     listBuilderLeaderboard: listBuilderLeaderboard.bind(null, client),
     fetchBuilderVolume: fetchBuilderVolume.bind(null, client),
     listTraderLeaderboard: listTraderLeaderboard.bind(null, client),
+    fetchTraderLeaderboardStanding: fetchTraderLeaderboardStanding.bind(
+      null,
+      client,
+    ),
+    listBiggestWinners: listBiggestWinners.bind(null, client),
   };
 }
 
@@ -184,10 +250,14 @@ export function analyticsActions(client: BaseClient): AnalyticsActions {
 // Surfaced at the root entry point through `export * from './decorators'`.
 // Keep this list in sync with the methods on AnalyticsActions.
 export {
+  BiggestWinnerKind,
   BuilderVolumeInterval,
   FetchBuilderVolumeError,
+  FetchTraderLeaderboardStandingError,
   LeaderboardWindow,
+  ListBiggestWinnersError,
   ListBuilderLeaderboardError,
   ListBuilderTradesError,
   ListTraderLeaderboardError,
+  TraderLeaderboardSort,
 } from '../actions';

--- a/packages/client/src/decorators/index.ts
+++ b/packages/client/src/decorators/index.ts
@@ -9,11 +9,7 @@ import {
   type PublicAccountActions,
   type SecureAccountActions,
 } from './account';
-import {
-  type AnalyticsActions,
-  analyticsActions,
-  type SecureAnalyticsActions,
-} from './analytics';
+import { type AnalyticsActions, analyticsActions } from './analytics';
 import { type DataActions, dataActions } from './data';
 import { type DiscoveryActions, discoveryActions } from './discovery';
 import {
@@ -49,7 +45,7 @@ export type PublicActions = Prettify<
 export type SecureActions = Prettify<
   DiscoveryActions &
     DataActions &
-    SecureAnalyticsActions &
+    AnalyticsActions &
     SecurePerpsActions &
     SecureAccountActions &
     SecureRewardsActions &

--- a/packages/client/src/decorators/index.ts
+++ b/packages/client/src/decorators/index.ts
@@ -9,7 +9,11 @@ import {
   type PublicAccountActions,
   type SecureAccountActions,
 } from './account';
-import { type AnalyticsActions, analyticsActions } from './analytics';
+import {
+  type AnalyticsActions,
+  analyticsActions,
+  type SecureAnalyticsActions,
+} from './analytics';
 import { type DataActions, dataActions } from './data';
 import { type DiscoveryActions, discoveryActions } from './discovery';
 import {
@@ -45,7 +49,7 @@ export type PublicActions = Prettify<
 export type SecureActions = Prettify<
   DiscoveryActions &
     DataActions &
-    AnalyticsActions &
+    SecureAnalyticsActions &
     SecurePerpsActions &
     SecureAccountActions &
     SecureRewardsActions &

--- a/packages/client/tests/integration/data-pagination.test.ts
+++ b/packages/client/tests/integration/data-pagination.test.ts
@@ -1,5 +1,5 @@
 import { OrderSide } from '@polymarket/bindings';
-import { dataEnvelopeSchema, dataPageSchema } from '@polymarket/bindings/data';
+import { dataEnvelopeSchema } from '@polymarket/bindings/data';
 import { unwrap } from '@polymarket/types';
 import { z } from 'zod';
 import { describe, expect, it } from './fixtures';
@@ -73,32 +73,6 @@ describe('Data pagination', () => {
  * corresponding endpoint lands in the SDK.
  */
 describe('Data envelope', () => {
-  it('parses a paginated list envelope into the page shape', async ({
-    publicClient,
-  }) => {
-    const response = await unwrap(
-      publicClient.data.get('v2/leaderboard', {
-        params: new URLSearchParams({ limit: '2', time_period: 'all' }),
-      }),
-    );
-
-    const page = dataPageSchema(
-      z
-        .object({
-          rank: z.number().int(),
-          user_id: z.string(),
-          pnl: z.number(),
-          volume: z.number(),
-          verified: z.boolean(),
-        })
-        .loose(),
-    ).parse(await response.json());
-
-    expect(page.items.length).toBeGreaterThan(0);
-    expect(page.hasMore).toBe(true);
-    expect(page.nextCursor).toEqual(expect.any(String));
-  });
-
   it('unwraps a single-object envelope to the payload', async ({
     publicClient,
   }) => {

--- a/packages/client/tests/integration/leaderboards.test.ts
+++ b/packages/client/tests/integration/leaderboards.test.ts
@@ -1,4 +1,10 @@
-import { BuilderVolumeInterval, LeaderboardWindow } from '@polymarket/client';
+import {
+  BiggestWinnerKind,
+  BuilderVolumeInterval,
+  LeaderboardWindow,
+  TraderLeaderboardSort,
+} from '@polymarket/client';
+import { expectPresent } from '@polymarket/types';
 import { afterEach, type MockInstance, vi } from 'vitest';
 import { describe, expect, it } from './fixtures';
 import { expectNonEmptyPage } from './helpers';
@@ -9,19 +15,114 @@ describe('Leaderboards', () => {
   });
 
   describe('listTraderLeaderboard', () => {
-    it('lists trader rankings', async ({ publicClient }) => {
-      const result = await publicClient
+    it('lists normalized trader rankings across cursor pages', async ({
+      publicClient,
+    }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const paginator = publicClient.listTraderLeaderboard({
+        category: 'sports',
+        pageSize: 1,
+        sortBy: TraderLeaderboardSort.Volume,
+        window: LeaderboardWindow.Week,
+      });
+      const firstPage = await paginator.firstPage().then(expectNonEmptyPage);
+      const secondPage = await paginator
+        .from(firstPage.nextCursor)
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      expect(firstPage.items).toHaveLength(1);
+      expect(secondPage.items).toHaveLength(1);
+      expect(firstPage.items[0]).toEqual(
+        expect.objectContaining({
+          pnl: expect.any(String),
+          rank: expect.any(Number),
+          volume: expect.any(String),
+          wallet: expect.stringMatching(/^0x[0-9a-f]{40}$/i),
+        }),
+      );
+
+      const requests = traderLeaderboardRequests(fetchSpy);
+      expect(requests).toHaveLength(2);
+
+      for (const request of requests) {
+        expect(request.get('category')).toBe('sports');
+        expect(request.get('limit')).toBe('1');
+        expect(request.get('sort_by')).toBe(TraderLeaderboardSort.Volume);
+        expect(request.get('time_period')).toBe(LeaderboardWindow.Week);
+      }
+
+      expect(requests[0]?.get('cursor')).toBeNull();
+      expect(requests[1]?.get('cursor')).toBe(firstPage.nextCursor);
+    });
+  });
+
+  describe('fetchTraderLeaderboardStanding', () => {
+    it('composes a ranked wallet into its normalized standing', async ({
+      publicClient,
+    }) => {
+      const leaderboard = await publicClient
         .listTraderLeaderboard({
+          category: 'combos',
           pageSize: 1,
+          sortBy: TraderLeaderboardSort.Pnl,
+          window: LeaderboardWindow.All,
         })
         .firstPage()
         .then(expectNonEmptyPage);
 
-      expect(result.items).toHaveLength(1);
-      expect(result.items[0]).toEqual(
+      const standing = expectPresent(
+        await publicClient.fetchTraderLeaderboardStanding({
+          category: 'combos',
+          user: leaderboard.items[0].wallet,
+          window: LeaderboardWindow.All,
+        }),
+      );
+
+      expect(standing).toEqual(
         expect.objectContaining({
-          rank: expect.any(String),
-          wallet: expect.any(String),
+          pnl: expect.any(String),
+          pnlRank: expect.any(Number),
+          volume: expect.any(String),
+          volumeRank: null,
+          wallet: leaderboard.items[0].wallet,
+        }),
+      );
+    });
+  });
+
+  describe('listBiggestWinners', () => {
+    it('lists Combo winners without fake event metadata', async ({
+      publicClient,
+    }) => {
+      const page = await publicClient
+        .listBiggestWinners({
+          category: 'combos',
+          pageSize: 1,
+          window: LeaderboardWindow.All,
+        })
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      const winner = page.items[0];
+      expect(winner.kind).toBe(BiggestWinnerKind.Combo);
+
+      if (winner.kind !== BiggestWinnerKind.Combo) {
+        throw new Error('Expected a Combo winner');
+      }
+
+      expect(winner).toEqual(
+        expect.objectContaining({
+          conditionId: expect.any(String),
+          eventId: null,
+          eventSlug: null,
+          finalValue: expect.any(String),
+          initialValue: expect.any(String),
+          pnl: expect.any(String),
+          positionId: expect.any(String),
+          rank: expect.any(Number),
+          resolvedAt: expect.any(Number),
+          wallet: expect.stringMatching(/^0x[0-9a-f]{40}$/i),
         }),
       );
     });
@@ -117,6 +218,12 @@ function builderLeaderboardRequests(
   fetchSpy: MockInstance<typeof fetch>,
 ): URLSearchParams[] {
   return dataRequests(fetchSpy, '/v2/builders/leaderboard');
+}
+
+function traderLeaderboardRequests(
+  fetchSpy: MockInstance<typeof fetch>,
+): URLSearchParams[] {
+  return dataRequests(fetchSpy, '/v2/leaderboard');
 }
 
 function builderVolumeRequests(

--- a/packages/client/tests/integration/leaderboards.test.ts
+++ b/packages/client/tests/integration/leaderboards.test.ts
@@ -89,6 +89,22 @@ describe('Leaderboards', () => {
         }),
       );
     });
+
+    it('defaults to the authenticated wallet for secure clients', async ({
+      secureClientWithDepositWallet,
+    }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      await secureClientWithDepositWallet.fetchTraderLeaderboardStanding({
+        window: LeaderboardWindow.All,
+      });
+
+      const requests = traderLeaderboardRequests(fetchSpy);
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.get('user')).toBe(
+        secureClientWithDepositWallet.account.wallet,
+      );
+    });
   });
 
   describe('listBiggestWinners', () => {


### PR DESCRIPTION
## Summary
- migrate trader leaderboard reads to cursor-paginated v2 and split by-wallet standing into `fetchTraderLeaderboardStanding`
- add `listBiggestWinners` with explicit market and Combo result variants
- normalize identifiers, amounts, timestamps, profile sentinels, and rank absence at the bindings boundary

## Validation
- `pnpm -r --sort --if-present run build`
- `pnpm test:types`, `pnpm test:bindings`, and `pnpm test:client`
- live `client-integration` leaderboard suite (6 tests)
- `pnpm lint`
- `pnpm -r --sort --if-present run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public SDK types and request parameters for `listTraderLeaderboard` will break downstream callers until they adopt v2 fields and pagination; new data normalization (ranks, amounts, standing nulls) can surface subtle UI bugs if not handled.
> 
> **Overview**
> **Breaking** migration of trader leaderboard reads from legacy `/v1/leaderboard` (offset pagination, `orderBy` / `timePeriod` / fixed category enums) to **`/v2/leaderboard`** with server cursors, `sortBy` (`TraderLeaderboardSort`), `window` (`LeaderboardWindow`), and free-form `category` strings. Response shapes are normalized in bindings: numeric ranks, `wallet` + decimal-string `pnl`/`volume`, nullable profile fields, and paginated `{ items, hasMore, nextCursor }` instead of a bare array.
> 
> Adds **`fetchTraderLeaderboardStanding`** (same v2 route with `user`) for per-wallet PnL/volume and separate `pnlRank` / `volumeRank` (nullable when unranked), exposed on both analytics-style listing and **account** decorators (secure clients default `user` to the authenticated wallet).
> 
> Adds **`listBiggestWinners`** on `/v2/biggest-winners` with cursor pagination and a discriminated **`BiggestWinner`** model (`market` vs `combo`: different IDs, combo rows use `null` event metadata). Removes the old `TimePeriod` / `LeaderboardCategory` / `LeaderboardOrderBy` exports from data common; page defaults rise to 100 (max 1000). Unit and integration tests cover parsing, cursor walks, and combo winner shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d65e0e23c0b487aadd72d1a5c94b2b02e0035864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->