### PR TITLE
feat(data): migrate price history to v2

### DIFF
--- a/.changeset/data-v2-price-history.md
+++ b/.changeset/data-v2-price-history.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': minor
+'@polymarket/client': minor
+---
+
+**Breaking**: replace `fetchPriceHistory` with cursor-paginated `listPriceHistory`, using token IDs, strict time selections, second-based bucket widths, and normalized price points.

--- a/docs/sdk-direction.md
+++ b/docs/sdk-direction.md
@@ -20,7 +20,7 @@ The SDK should hide internal service boundaries where possible while staying clo
 - Prefer workflow-first APIs over service-shaped APIs.
 - Keep public models pragmatic, typed, and consistent.
 - Standardize SDK identifier naming on JS/TS-style `...Id` forms such as `orderId`, `tradeId`, `tokenId`, and `marketId`.
-- Normalize the CTF position identifier to `tokenId` in the SDK public model, even when upstream services call the same value `assetId`.
+- Use `assetId` for exchange assets in the SDK public model, whether they identify a CTF token or a Polymarket V2 position.
 - Translate legacy `...ID` and wire-format variants at the service boundary.
 - Add lower-level controls only when they support a concrete SDK workflow.
 

--- a/packages/bindings/src/clob/market-data.ts
+++ b/packages/bindings/src/clob/market-data.ts
@@ -12,16 +12,6 @@ import {
   type TokenId,
 } from '../shared';
 
-export enum PriceHistoryInterval {
-  MAX = 'max',
-  ONE_WEEK = '1w',
-  ONE_DAY = '1d',
-  SIX_HOURS = '6h',
-  ONE_HOUR = '1h',
-}
-
-export const PriceHistoryIntervalSchema = z.enum(PriceHistoryInterval);
-
 export const MidpointSchema = z.object({
   mid: DecimalStringSchema,
 });
@@ -104,18 +94,6 @@ export const LastTradePricesSchema = z.array(
   LastTradePriceForTokenResponseSchema,
 );
 export type LastTradePrices = z.infer<typeof LastTradePricesSchema>;
-
-const PriceHistoryPointSchema = z.object({
-  t: z.number().int(),
-  // CLOB price history is intentionally approximate and emitted as JSON numbers.
-  p: z.number(),
-});
-export type PriceHistoryPoint = z.infer<typeof PriceHistoryPointSchema>;
-
-export const PriceHistorySchema = z.object({
-  history: z.array(PriceHistoryPointSchema),
-});
-export type PriceHistory = z.infer<typeof PriceHistorySchema>;
 
 export const ConditionByTokenSchema = z
   .object({

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -6,12 +6,54 @@ import {
   ConditionIdSchema,
   DecimalishSchema,
   type DecimalString,
+  type EpochMilliseconds,
+  EpochSecondsToMillisecondsSchema,
   EvmAddressSchema,
   emptyStringToNull,
   type PositionId,
   type TokenId,
 } from '../shared';
-import { dataEnvelopeSchema } from './envelope';
+import { dataEnvelopeSchema, dataPageSchema } from './envelope';
+
+/** Relative window for a token's price history. */
+export enum PriceHistoryInterval {
+  Max = 'max',
+  OneMonth = '1m',
+  OneWeek = '1w',
+  OneDay = '1d',
+  SixHours = '6h',
+  OneHour = '1h',
+}
+
+export const PriceHistoryIntervalSchema = z.enum(PriceHistoryInterval);
+
+export type PriceHistoryPoint = {
+  /** Observation time as Unix epoch milliseconds. */
+  timestamp: EpochMilliseconds;
+  /** Observed price, normalized to a decimal string. */
+  price: DecimalString;
+  /** Width of the observation window in seconds; zero identifies an exact tick. */
+  resolutionSeconds: number;
+};
+
+export const PriceHistoryPointSchema = z
+  .object({
+    timestamp: EpochSecondsToMillisecondsSchema,
+    price: DecimalishSchema,
+    resolution_seconds: z.number().int().nonnegative(),
+  })
+  .transform(({ price, resolution_seconds, timestamp }) => ({
+    timestamp,
+    price,
+    resolutionSeconds: resolution_seconds,
+  })) satisfies z.ZodType<PriceHistoryPoint>;
+
+export const ListPriceHistoryResponseSchema = dataPageSchema(
+  PriceHistoryPointSchema,
+);
+export type ListPriceHistoryResponse = z.infer<
+  typeof ListPriceHistoryResponseSchema
+>;
 
 export type Holder = {
   wallet: EvmAddress | null | undefined;

--- a/packages/client/src/actions/clob.ts
+++ b/packages/client/src/actions/clob.ts
@@ -33,10 +33,6 @@ import {
   OrderBooksSchema,
   PaginatedCurrentRewardsSchema,
   PaginatedMarketRewardsSchema,
-  type PriceHistoryInterval,
-  PriceHistoryIntervalSchema,
-  type PriceHistoryPoint,
-  PriceHistorySchema,
   PriceSchema,
   type Prices,
   PricesSchema,
@@ -987,99 +983,6 @@ export async function fetchLastTradePrices(
       })
       .andThen(validateWith(LastTradePricesSchema)),
   );
-}
-
-const ListPriceHistoryRequestSchema = exchangeAssetRequestSchema({
-  startTs: z.number().int().optional(),
-  endTs: z.number().int().optional(),
-  fidelity: z.number().int().positive().optional(),
-  interval: PriceHistoryIntervalSchema.optional(),
-});
-
-export type FetchPriceHistoryRequest =
-  | {
-      /** Identifier for a CTF token or Polymarket V2 position. */
-      assetId: string;
-      tokenId?: never;
-      startTs?: number;
-      endTs?: number;
-      fidelity?: number;
-      interval?: PriceHistoryInterval;
-    }
-  | {
-      assetId?: never;
-      /** @deprecated Use `assetId`. */
-      tokenId: string;
-      startTs?: number;
-      endTs?: number;
-      fidelity?: number;
-      interval?: PriceHistoryInterval;
-    };
-
-export type FetchPriceHistoryError =
-  | RateLimitError
-  | RequestRejectedError
-  | TransportError
-  | UnexpectedResponseError
-  | UserInputError;
-export const FetchPriceHistoryError = makeErrorGuard(
-  RateLimitError,
-  RequestRejectedError,
-  TransportError,
-  UnexpectedResponseError,
-  UserInputError,
-);
-
-/**
- * Fetches historical price points for an exchange asset.
- *
- * @remarks
- * This is a low-level function. Most SDK consumers should prefer the client instance API.
- *
- * @throws {@link FetchPriceHistoryError}
- * Thrown on failure.
- *
- * @example
- * ```ts
- * const history = await fetchPriceHistory(client, {
- *   assetId: '0x0122…0000',
- *   interval: PriceHistoryInterval.ONE_DAY,
- *   fidelity: 60,
- * });
- *
- * // history === PriceHistoryPoint[]
- * ```
- *
- */
-export async function fetchPriceHistory(
-  client: BaseClient,
-  request: FetchPriceHistoryRequest,
-): Promise<PriceHistoryPoint[]> {
-  const params = parseUserInput(request, ListPriceHistoryRequestSchema);
-  const response = await unwrap(
-    client.clob
-      .get('/prices-history', {
-        params: toSearchParams(
-          {
-            market: params.assetId ?? params.tokenId,
-            startTs: params.startTs,
-            endTs: params.endTs,
-            fidelity: params.fidelity,
-            interval: params.interval,
-          },
-          {
-            market: 'market',
-            startTs: 'startTs',
-            endTs: 'endTs',
-            fidelity: 'fidelity',
-            interval: 'interval',
-          },
-        ),
-      })
-      .andThen(validateWith(PriceHistorySchema)),
-  );
-
-  return response.history;
 }
 
 const ListCurrentRewardsRequestSchema = z

--- a/packages/client/src/actions/markets.test-d.ts
+++ b/packages/client/src/actions/markets.test-d.ts
@@ -49,26 +49,17 @@ describe('price history request types', () => {
   });
 });
 
-function checkDataActionsReturnType(actions: DataActions) {
-  expectTypeOf(
-    actions.listPriceHistory({
-      tokenId: '123',
-      interval: PriceHistoryInterval.OneDay,
-    }),
-  ).toEqualTypeOf<Paginated<PriceHistoryPoint[]>>();
-}
-
-void checkDataActionsReturnType;
-
 function listMarketPriceHistory(actions: DataActions, market: Market) {
   const tokenId = market.outcomes.yes.tokenId;
 
   if (tokenId === null) return;
 
-  actions.listPriceHistory({
-    tokenId,
-    interval: PriceHistoryInterval.OneDay,
-  });
+  expectTypeOf(
+    actions.listPriceHistory({
+      tokenId,
+      interval: PriceHistoryInterval.OneDay,
+    }),
+  ).toEqualTypeOf<Paginated<PriceHistoryPoint[]>>();
 }
 
 void listMarketPriceHistory;

--- a/packages/client/src/actions/markets.test-d.ts
+++ b/packages/client/src/actions/markets.test-d.ts
@@ -1,0 +1,74 @@
+import {
+  PriceHistoryInterval,
+  type PriceHistoryPoint,
+} from '@polymarket/bindings/data';
+import type { Market } from '@polymarket/bindings/gamma';
+import { describe, expectTypeOf, it } from 'vitest';
+import type { DataActions } from '../decorators';
+import type { Paginated } from '../pagination';
+import type { ListPriceHistoryRequest, listPriceHistory } from './markets';
+
+describe('price history request types', () => {
+  it('accepts exactly one time selection', () => {
+    const intervalRequest = {
+      tokenId: '123',
+      interval: PriceHistoryInterval.OneDay,
+    } satisfies ListPriceHistoryRequest;
+    const rangeRequest = {
+      tokenId: '123',
+      start: new Date(),
+      end: new Date(),
+    } satisfies ListPriceHistoryRequest;
+    const asOfRequest = {
+      tokenId: '123',
+      asOf: 1_700_000_000,
+    } satisfies ListPriceHistoryRequest;
+
+    // @ts-expect-error Interval and explicit ranges are mutually exclusive.
+    const conflictingRequest: ListPriceHistoryRequest = {
+      tokenId: '123',
+      interval: PriceHistoryInterval.OneDay,
+      start: 1_700_000_000,
+    };
+    // @ts-expect-error A time selection is required.
+    const missingWindowRequest: ListPriceHistoryRequest = {
+      tokenId: '123',
+    };
+
+    void intervalRequest;
+    void rangeRequest;
+    void asOfRequest;
+    void conflictingRequest;
+    void missingWindowRequest;
+  });
+
+  it('exposes the same paginated model on actions and decorators', () => {
+    expectTypeOf<ReturnType<typeof listPriceHistory>>().toEqualTypeOf<
+      Paginated<PriceHistoryPoint[]>
+    >();
+  });
+});
+
+function checkDataActionsReturnType(actions: DataActions) {
+  expectTypeOf(
+    actions.listPriceHistory({
+      tokenId: '123',
+      interval: PriceHistoryInterval.OneDay,
+    }),
+  ).toEqualTypeOf<Paginated<PriceHistoryPoint[]>>();
+}
+
+void checkDataActionsReturnType;
+
+function listMarketPriceHistory(actions: DataActions, market: Market) {
+  const tokenId = market.outcomes.yes.tokenId;
+
+  if (tokenId === null) return;
+
+  actions.listPriceHistory({
+    tokenId,
+    interval: PriceHistoryInterval.OneDay,
+  });
+}
+
+void listMarketPriceHistory;

--- a/packages/client/src/actions/markets.test-d.ts
+++ b/packages/client/src/actions/markets.test-d.ts
@@ -11,28 +11,28 @@ import type { ListPriceHistoryRequest, listPriceHistory } from './markets';
 describe('price history request types', () => {
   it('accepts exactly one time selection', () => {
     const intervalRequest = {
-      tokenId: '123',
+      assetId: '123',
       interval: PriceHistoryInterval.OneDay,
     } satisfies ListPriceHistoryRequest;
     const rangeRequest = {
-      tokenId: '123',
+      assetId: '123',
       start: new Date(),
       end: new Date(),
     } satisfies ListPriceHistoryRequest;
     const asOfRequest = {
-      tokenId: '123',
+      assetId: '123',
       asOf: 1_700_000_000,
     } satisfies ListPriceHistoryRequest;
 
     // @ts-expect-error Interval and explicit ranges are mutually exclusive.
     const conflictingRequest: ListPriceHistoryRequest = {
-      tokenId: '123',
+      assetId: '123',
       interval: PriceHistoryInterval.OneDay,
       start: 1_700_000_000,
     };
     // @ts-expect-error A time selection is required.
     const missingWindowRequest: ListPriceHistoryRequest = {
-      tokenId: '123',
+      assetId: '123',
     };
 
     void intervalRequest;
@@ -50,13 +50,13 @@ describe('price history request types', () => {
 });
 
 function listMarketPriceHistory(actions: DataActions, market: Market) {
-  const tokenId = market.outcomes.yes.tokenId;
+  const assetId = market.outcomes.yes.tokenId;
 
-  if (tokenId === null) return;
+  if (assetId === null) return;
 
   expectTypeOf(
     actions.listPriceHistory({
-      tokenId,
+      assetId,
       interval: PriceHistoryInterval.OneDay,
     }),
   ).toEqualTypeOf<Paginated<PriceHistoryPoint[]>>();

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -1,8 +1,10 @@
 import {
   ConditionIdSchema,
   IsoDateTimeStringSchema,
+  type PaginationCursor,
   PaginationCursorSchema,
   PositionIdSchema,
+  TokenIdSchema,
 } from '@polymarket/bindings';
 import {
   type ComboMarket,
@@ -11,8 +13,12 @@ import {
 import {
   FetchOpenInterestResponseSchema,
   ListMarketHoldersResponseSchema,
+  ListPriceHistoryResponseSchema,
   type MetaHolder,
   type OpenInterest,
+  PriceHistoryInterval,
+  PriceHistoryIntervalSchema,
+  type PriceHistoryPoint,
 } from '@polymarket/bindings/data';
 import {
   FetchMarketTagsResponseSchema,
@@ -40,11 +46,14 @@ import { withRateLimitRetry } from '../retry';
 import {
   CanonicalMarketConditionIdSchema,
   distinctIdList,
+  EpochSecondsLikeSchema,
   snakeCase,
   toDataSearchParams,
   toLegacyDataSearchParams,
   toSearchParams,
 } from './params';
+
+export { PriceHistoryInterval };
 
 // The public markets endpoint forces active=true and archived=false server-side.
 const ListMarketsRequestSchema = z.object({
@@ -445,6 +454,195 @@ export async function listMarketHolders(
         params: toLegacyDataSearchParams(params),
       })
       .andThen(validateWith(ListMarketHoldersResponseSchema)),
+  );
+}
+
+export type ListPriceHistoryRequest =
+  | {
+      tokenId: string;
+      interval: PriceHistoryInterval;
+      bucketSeconds?: number;
+      cursor?: PaginationCursor;
+      pageSize?: number;
+      start?: never;
+      end?: never;
+      asOf?: never;
+    }
+  | {
+      tokenId: string;
+      start: number | Date;
+      end?: number | Date;
+      bucketSeconds?: number;
+      cursor?: PaginationCursor;
+      pageSize?: number;
+      interval?: never;
+      asOf?: never;
+    }
+  | {
+      tokenId: string;
+      asOf: number | Date;
+      interval?: never;
+      start?: never;
+      end?: never;
+      bucketSeconds?: never;
+      cursor?: never;
+      pageSize?: never;
+    };
+
+const MAX_PRICE_HISTORY_WINDOW_SECONDS = 15 * 24 * 60 * 60;
+
+const PriceHistoryTimestampSchema = EpochSecondsLikeSchema.pipe(
+  z.number().int().positive(),
+);
+
+const PriceHistoryTokenIdSchema = z.string().min(1).pipe(TokenIdSchema);
+
+const PriceHistorySeriesRequestFields = {
+  tokenId: PriceHistoryTokenIdSchema,
+  bucketSeconds: z.number().int().min(60).max(86_400).optional(),
+  cursor: PaginationCursorSchema.optional(),
+  pageSize: PageSizeSchema.max(10_000).default(10_000),
+};
+
+const PriceHistoryIntervalRequestSchema = z
+  .object({
+    ...PriceHistorySeriesRequestFields,
+    interval: PriceHistoryIntervalSchema,
+    start: z.never().optional(),
+    end: z.never().optional(),
+    asOf: z.never().optional(),
+  })
+  .superRefine(({ bucketSeconds, interval }, context) => {
+    const minimumBucketSeconds =
+      interval === PriceHistoryInterval.Max ||
+      interval === PriceHistoryInterval.OneMonth
+        ? 600
+        : interval === PriceHistoryInterval.OneWeek
+          ? 300
+          : 60;
+
+    if (bucketSeconds !== undefined && bucketSeconds < minimumBucketSeconds) {
+      context.addIssue({
+        code: 'custom',
+        message: `bucketSeconds must be at least ${minimumBucketSeconds} for this interval`,
+        path: ['bucketSeconds'],
+      });
+    }
+  });
+
+const PriceHistoryRangeRequestSchema = z
+  .object({
+    ...PriceHistorySeriesRequestFields,
+    start: PriceHistoryTimestampSchema,
+    end: PriceHistoryTimestampSchema.optional(),
+    interval: z.never().optional(),
+    asOf: z.never().optional(),
+  })
+  .superRefine(({ end, start }, context) => {
+    if (end !== undefined && end < start) {
+      context.addIssue({
+        code: 'custom',
+        message: 'end must not precede start',
+        path: ['end'],
+      });
+      return;
+    }
+
+    const upperBound = end ?? Math.floor(Date.now() / 1_000);
+    if (
+      upperBound >= start &&
+      upperBound - start > MAX_PRICE_HISTORY_WINDOW_SECONDS
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'start to end must span at most 15 days',
+        path: ['end'],
+      });
+    }
+  });
+
+const PriceHistoryAsOfRequestSchema = z.object({
+  tokenId: PriceHistoryTokenIdSchema,
+  asOf: PriceHistoryTimestampSchema,
+  interval: z.never().optional(),
+  start: z.never().optional(),
+  end: z.never().optional(),
+  bucketSeconds: z.never().optional(),
+  cursor: z.never().optional(),
+  pageSize: z.never().optional(),
+});
+
+const ListPriceHistoryRequestSchema = z.union([
+  PriceHistoryIntervalRequestSchema,
+  PriceHistoryRangeRequestSchema,
+  PriceHistoryAsOfRequestSchema,
+]) satisfies z.ZodType<ListPriceHistoryRequest, ListPriceHistoryRequest>;
+
+export type ListPriceHistoryError =
+  | RateLimitError
+  | RequestRejectedError
+  | TransportError
+  | UnexpectedResponseError
+  | UserInputError;
+export const ListPriceHistoryError = makeErrorGuard(
+  RateLimitError,
+  RequestRejectedError,
+  TransportError,
+  UnexpectedResponseError,
+  UserInputError,
+);
+
+/**
+ * Lists historical price observations for an outcome token.
+ *
+ * Select exactly one time form: a relative `interval`, an explicit `start`
+ * with optional `end`, or the latest observation at or before an `asOf`
+ * instant. Time inputs accept Unix epoch seconds or `Date` values. Prices are
+ * decimal strings and returned timestamps are Unix epoch milliseconds. Series
+ * pages are ordered oldest first; an `asOf` request returns at most one item.
+ * Series page sizes default to and are capped at 10,000 points. Transient rate
+ * limits are retried automatically.
+ *
+ * @remarks
+ * This is a low-level function. Most SDK consumers should prefer the client instance API.
+ *
+ * @throws {@link ListPriceHistoryError}
+ * Thrown on failure.
+ *
+ * @example
+ * ```ts
+ * const history = listPriceHistory(client, {
+ *   tokenId: '17023124228269928849020611259015948850061676830917875073785033885105715180702',
+ *   interval: PriceHistoryInterval.OneDay,
+ *   bucketSeconds: 3600,
+ * });
+ *
+ * for await (const page of history) {
+ *   // page.items: PriceHistoryPoint[]
+ * }
+ * ```
+ */
+export function listPriceHistory(
+  client: BaseClient,
+  request: ListPriceHistoryRequest,
+): Paginated<PriceHistoryPoint[]> {
+  const { cursor, pageSize, ...params } = parseUserInput(
+    request,
+    ListPriceHistoryRequestSchema,
+  );
+
+  return paginate(
+    (cursor) =>
+      withRateLimitRetry(() =>
+        client.data.get('/v2/prices-history', {
+          params: toDataSearchParams({
+            ...params,
+            limit: pageSize,
+            cursor,
+          }),
+        }),
+      ).andThen(validateWith(ListPriceHistoryResponseSchema)),
+    cursor,
   );
 }
 

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -1,10 +1,10 @@
 import {
+  ClobAssetIdSchema,
   ConditionIdSchema,
   IsoDateTimeStringSchema,
   type PaginationCursor,
   PaginationCursorSchema,
   PositionIdSchema,
-  TokenIdSchema,
 } from '@polymarket/bindings';
 import {
   type ComboMarket,
@@ -459,7 +459,7 @@ export async function listMarketHolders(
 
 export type ListPriceHistoryRequest =
   | {
-      tokenId: string;
+      assetId: string;
       interval: PriceHistoryInterval;
       bucketSeconds?: number;
       cursor?: PaginationCursor;
@@ -469,7 +469,7 @@ export type ListPriceHistoryRequest =
       asOf?: never;
     }
   | {
-      tokenId: string;
+      assetId: string;
       start: number | Date;
       end?: number | Date;
       bucketSeconds?: number;
@@ -479,7 +479,7 @@ export type ListPriceHistoryRequest =
       asOf?: never;
     }
   | {
-      tokenId: string;
+      assetId: string;
       asOf: number | Date;
       interval?: never;
       start?: never;
@@ -495,10 +495,10 @@ const PriceHistoryTimestampSchema = EpochSecondsLikeSchema.pipe(
   z.number().int().positive(),
 );
 
-const PriceHistoryTokenIdSchema = z.string().min(1).pipe(TokenIdSchema);
+const PriceHistoryAssetIdSchema = z.string().min(1).pipe(ClobAssetIdSchema);
 
 const PriceHistorySeriesRequestFields = {
-  tokenId: PriceHistoryTokenIdSchema,
+  assetId: PriceHistoryAssetIdSchema,
   bucketSeconds: z.number().int().min(60).max(86_400).optional(),
   cursor: PaginationCursorSchema.optional(),
   pageSize: PageSizeSchema.max(10_000).default(10_000),
@@ -559,7 +559,7 @@ const PriceHistoryRangeRequestSchema = z
   });
 
 const PriceHistoryAsOfRequestSchema = z.object({
-  tokenId: PriceHistoryTokenIdSchema,
+  assetId: PriceHistoryAssetIdSchema,
   asOf: PriceHistoryTimestampSchema,
   interval: z.never().optional(),
   start: z.never().optional(),
@@ -590,7 +590,7 @@ export const ListPriceHistoryError = makeErrorGuard(
 );
 
 /**
- * Lists historical price observations for an outcome token.
+ * Lists historical price observations for an exchange asset.
  *
  * Select exactly one time form: a relative `interval`, an explicit `start`
  * with optional `end`, or the latest observation at or before an `asOf`
@@ -609,7 +609,7 @@ export const ListPriceHistoryError = makeErrorGuard(
  * @example
  * ```ts
  * const history = listPriceHistory(client, {
- *   tokenId: '17023124228269928849020611259015948850061676830917875073785033885105715180702',
+ *   assetId: '17023124228269928849020611259015948850061676830917875073785033885105715180702',
  *   interval: PriceHistoryInterval.OneDay,
  *   bucketSeconds: 3600,
  * });
@@ -623,7 +623,7 @@ export function listPriceHistory(
   client: BaseClient,
   request: ListPriceHistoryRequest,
 ): Paginated<PriceHistoryPoint[]> {
-  const { cursor, pageSize, ...params } = parseUserInput(
+  const { assetId, cursor, pageSize, ...params } = parseUserInput(
     request,
     ListPriceHistoryRequestSchema,
   );
@@ -634,6 +634,7 @@ export function listPriceHistory(
         client.data.get('/v2/prices-history', {
           params: toDataSearchParams({
             ...params,
+            tokenId: assetId,
             limit: pageSize,
             cursor,
           }),

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -490,9 +490,11 @@ export type ListPriceHistoryRequest =
     };
 
 const MAX_PRICE_HISTORY_WINDOW_SECONDS = 15 * 24 * 60 * 60;
+/** Latest supported instant: 9999-12-31T23:59:59Z. */
+const MAX_PRICE_HISTORY_TIMESTAMP_SECONDS = 253_402_300_799;
 
 const PriceHistoryTimestampSchema = EpochSecondsLikeSchema.pipe(
-  z.number().int().positive(),
+  z.number().int().positive().max(MAX_PRICE_HISTORY_TIMESTAMP_SECONDS),
 );
 
 const PriceHistoryAssetIdSchema = z.string().min(1).pipe(ClobAssetIdSchema);
@@ -594,11 +596,15 @@ export const ListPriceHistoryError = makeErrorGuard(
  *
  * Select exactly one time form: a relative `interval`, an explicit `start`
  * with optional `end`, or the latest observation at or before an `asOf`
- * instant. Time inputs accept Unix epoch seconds or `Date` values. Prices are
- * decimal strings and returned timestamps are Unix epoch milliseconds. Series
- * pages are ordered oldest first; an `asOf` request returns at most one item.
- * Series page sizes default to and are capped at 10,000 points. Transient rate
- * limits are retried automatically.
+ * instant. Time inputs accept Unix epoch seconds or `Date` values. When
+ * `bucketSeconds` is omitted, resolution is selected automatically for the
+ * requested window and reported on each point as `resolutionSeconds`. An
+ * explicit bucket is used exactly as requested and may produce an empty series
+ * when that resolution is unavailable for the window. Prices are decimal
+ * strings and returned timestamps are Unix epoch milliseconds. Series pages
+ * are ordered oldest first; an `asOf` request returns at most one item. Series
+ * page sizes default to and are capped at 10,000 points. Transient rate limits
+ * are retried automatically.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -549,10 +549,7 @@ const PriceHistoryRangeRequestSchema = z
     }
 
     const upperBound = end ?? Math.floor(Date.now() / 1_000);
-    if (
-      upperBound >= start &&
-      upperBound - start > MAX_PRICE_HISTORY_WINDOW_SECONDS
-    ) {
+    if (upperBound - start > MAX_PRICE_HISTORY_WINDOW_SECONDS) {
       context.addIssue({
         code: 'custom',
         message: 'start to end must span at most 15 days',

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -237,11 +237,15 @@ export type DataActions = {
    *
    * Select exactly one time form: a relative `interval`, an explicit `start`
    * with optional `end`, or the latest observation at or before an `asOf`
-   * instant. Time inputs accept Unix epoch seconds or `Date` values. Prices are
-   * decimal strings and returned timestamps are Unix epoch milliseconds. Series
-   * pages are ordered oldest first; an `asOf` request returns at most one item.
-   * Series page sizes default to and are capped at 10,000 points. Transient rate
-   * limits are retried automatically.
+   * instant. Time inputs accept Unix epoch seconds or `Date` values. When
+   * `bucketSeconds` is omitted, resolution is selected automatically for the
+   * requested window and reported on each point as `resolutionSeconds`. An
+   * explicit bucket is used exactly as requested and may produce an empty series
+   * when that resolution is unavailable for the window. Prices are decimal
+   * strings and returned timestamps are Unix epoch milliseconds. Series pages
+   * are ordered oldest first; an `asOf` request returns at most one item. Series
+   * page sizes default to and are capped at 10,000 points. Transient rate limits
+   * are retried automatically.
    *
    * @throws {@link ListPriceHistoryError}
    * Thrown on failure.

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -4,7 +4,6 @@ import type {
   LastTradePriceForAsset,
   Midpoints,
   OrderBook,
-  PriceHistoryPoint,
   Prices,
   Spreads,
 } from '@polymarket/bindings/clob';
@@ -12,6 +11,7 @@ import type {
   LiveVolume,
   MetaHolder,
   OpenInterest,
+  PriceHistoryPoint,
   Resolution,
   Trade,
 } from '@polymarket/bindings/data';
@@ -26,7 +26,6 @@ import {
   type FetchOpenInterestRequest,
   type FetchOrderBookRequest,
   type FetchOrderBooksRequest,
-  type FetchPriceHistoryRequest,
   type FetchPriceRequest,
   type FetchPricesRequest,
   type FetchResolutionsRequest,
@@ -41,14 +40,15 @@ import {
   fetchOrderBook,
   fetchOrderBooks,
   fetchPrice,
-  fetchPriceHistory,
   fetchPrices,
   fetchResolutions,
   fetchSpread,
   fetchSpreads,
   type ListMarketHoldersRequest,
+  type ListPriceHistoryRequest,
   type ListTradesRequest,
   listMarketHolders,
+  listPriceHistory,
   listTrades,
 } from '../actions';
 import type {
@@ -233,19 +233,35 @@ export type DataActions = {
     request: FetchLastTradePricesRequest,
   ): Promise<LastTradePriceForAsset[]>;
   /**
-   * Fetches historical price points for an exchange asset.
+   * Lists historical price observations for an outcome token.
    *
-   * @throws {@link FetchPriceHistoryError}
+   * Select exactly one time form: a relative `interval`, an explicit `start`
+   * with optional `end`, or the latest observation at or before an `asOf`
+   * instant. Time inputs accept Unix epoch seconds or `Date` values. Prices are
+   * decimal strings and returned timestamps are Unix epoch milliseconds. Series
+   * pages are ordered oldest first; an `asOf` request returns at most one item.
+   * Series page sizes default to and are capped at 10,000 points. Transient rate
+   * limits are retried automatically.
+   *
+   * @throws {@link ListPriceHistoryError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const history = await client.fetchPriceHistory({ assetId: '0x0122…0000', interval: '1d' });
+   * const history = client.listPriceHistory({
+   *   tokenId: '17023124228269928849020611259015948850061676830917875073785033885105715180702',
+   *   interval: PriceHistoryInterval.OneDay,
+   *   bucketSeconds: 3600,
+   * });
+   *
+   * for await (const page of history) {
+   *   // page.items: PriceHistoryPoint[]
+   * }
    * ```
    */
-  fetchPriceHistory(
-    request: FetchPriceHistoryRequest,
-  ): Promise<PriceHistoryPoint[]>;
+  listPriceHistory(
+    request: ListPriceHistoryRequest,
+  ): Paginated<PriceHistoryPoint[]>;
   /**
    * Estimates the price level a market order would cross at current book depth.
    *
@@ -364,7 +380,7 @@ export function dataActions(client: BaseClient): DataActions {
     fetchSpreads: fetchSpreads.bind(null, client),
     fetchLastTradePrice: fetchLastTradePrice.bind(null, client),
     fetchLastTradePrices: fetchLastTradePrices.bind(null, client),
-    fetchPriceHistory: fetchPriceHistory.bind(null, client),
+    listPriceHistory: listPriceHistory.bind(null, client),
     estimateMarketPrice: estimateMarketPrice.bind(null, client),
     fetchOpenInterest: fetchOpenInterest.bind(null, client),
     listMarketHolders: listMarketHolders.bind(null, client),
@@ -386,13 +402,14 @@ export {
   FetchOrderBookError,
   FetchOrderBooksError,
   FetchPriceError,
-  FetchPriceHistoryError,
   FetchPricesError,
   FetchResolutionsError,
   FetchSpreadError,
   FetchSpreadsError,
   ListMarketHoldersError,
+  ListPriceHistoryError,
   ListTradesError,
+  PriceHistoryInterval,
   ResolutionMarketType,
   ResolutionReporter,
   ResolutionSource,

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -233,7 +233,7 @@ export type DataActions = {
     request: FetchLastTradePricesRequest,
   ): Promise<LastTradePriceForAsset[]>;
   /**
-   * Lists historical price observations for an outcome token.
+   * Lists historical price observations for an exchange asset.
    *
    * Select exactly one time form: a relative `interval`, an explicit `start`
    * with optional `end`, or the latest observation at or before an `asOf`
@@ -249,7 +249,7 @@ export type DataActions = {
    * @example
    * ```ts
    * const history = client.listPriceHistory({
-   *   tokenId: '17023124228269928849020611259015948850061676830917875073785033885105715180702',
+   *   assetId: '17023124228269928849020611259015948850061676830917875073785033885105715180702',
    *   interval: PriceHistoryInterval.OneDay,
    *   bucketSeconds: 3600,
    * });

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -4,7 +4,6 @@ export type * from '@polymarket/bindings/clob';
 export {
   NotificationType,
   OrderResponseErrorCode,
-  PriceHistoryInterval,
   SignatureType,
 } from '@polymarket/bindings/clob';
 export type * from '@polymarket/bindings/data';

--- a/packages/client/tests/integration/clob.test.ts
+++ b/packages/client/tests/integration/clob.test.ts
@@ -1,5 +1,4 @@
 import { OrderSide, type TokenId } from '@polymarket/bindings';
-import { PriceHistoryInterval } from '@polymarket/bindings/clob';
 import type { PublicClient } from '@polymarket/client';
 import { expectPresent } from '@polymarket/types';
 import { describe, expect, it } from './fixtures';
@@ -158,28 +157,6 @@ describe('CLOB', () => {
           price: expect.any(String),
           side: expect.any(String),
           tokenId,
-        }),
-      );
-    });
-  });
-
-  describe('fetchPriceHistory', () => {
-    it('lists historical price points for a token', async ({
-      publicClient,
-    }) => {
-      const tokenId = await selectLiquidClobTokenId(publicClient);
-
-      const result = await publicClient.fetchPriceHistory({
-        tokenId,
-        interval: PriceHistoryInterval.ONE_DAY,
-        fidelity: 60,
-      });
-
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0]).toEqual(
-        expect.objectContaining({
-          p: expect.any(Number),
-          t: expect.any(Number),
         }),
       );
     });

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -1,5 +1,6 @@
 import {
   createPublicClient,
+  PriceHistoryInterval,
   UnexpectedResponseError,
   UserInputError,
 } from '@polymarket/client';
@@ -194,6 +195,80 @@ describe('Markets', () => {
           holders: expect.any(Array),
           token: expect.any(String),
         }),
+      );
+    });
+  });
+
+  describe('listPriceHistory', () => {
+    it('rejects invalid series windows before requesting them', ({
+      publicClient,
+    }) => {
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+
+      expect(() =>
+        publicClient.listPriceHistory({
+          tokenId,
+          interval: PriceHistoryInterval.OneWeek,
+          bucketSeconds: 60,
+        }),
+      ).toThrow(UserInputError);
+      expect(() =>
+        publicClient.listPriceHistory({
+          tokenId,
+          start: 1_700_000_000,
+          end: 1_701_296_001,
+        }),
+      ).toThrow(UserInputError);
+    });
+
+    it('walks normalized price history pages', async ({ publicClient }) => {
+      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const paginator = publicClient.listPriceHistory({
+        tokenId,
+        interval: PriceHistoryInterval.OneDay,
+        bucketSeconds: 60,
+        pageSize: 2,
+      });
+
+      const firstPage = await paginator.firstPage().then(expectNonEmptyPage);
+      expect(firstPage.hasMore).toBe(true);
+      expect(firstPage.nextCursor).toBeDefined();
+
+      const firstPoint = firstPage.items[0];
+      expect(firstPoint).toEqual(
+        expect.objectContaining({
+          price: expect.any(String),
+          resolutionSeconds: expect.any(Number),
+          timestamp: expect.any(Number),
+        }),
+      );
+      expect(firstPoint.timestamp).toBeGreaterThan(1_000_000_000_000);
+
+      const secondPage = await paginator
+        .from(firstPage.nextCursor)
+        .firstPage()
+        .then(expectNonEmptyPage);
+      const lastFirstTimestamp = expectPresent(
+        firstPage.items.at(-1),
+      ).timestamp;
+      expect(secondPage.items[0].timestamp).toBeGreaterThan(lastFirstTimestamp);
+
+      const requests = fetchSpy.mock.calls
+        .map(([input]) =>
+          input instanceof Request ? input.url : String(input),
+        )
+        .filter((url) => new URL(url).pathname === '/v2/prices-history')
+        .map((url) => new URL(url));
+
+      expect(requests).toHaveLength(2);
+      for (const request of requests) {
+        expect(request.searchParams.get('token_id')).toBe(tokenId);
+        expect(request.searchParams.get('interval')).toBe('1d');
+        expect(request.searchParams.get('bucket_seconds')).toBe('60');
+      }
+      expect(requests[1]?.searchParams.get('cursor')).toBe(
+        firstPage.nextCursor,
       );
     });
   });

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -10,6 +10,7 @@ import { describe, environment, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
+const FIRST_UNSUPPORTED_PRICE_HISTORY_TIMESTAMP_SECONDS = 253_402_300_800;
 const publicClient = createPublicClient({ environment });
 
 const {
@@ -219,6 +220,12 @@ describe('Markets', () => {
           end: 1_701_296_001,
         }),
       ).toThrow(UserInputError);
+      expect(() =>
+        publicClient.listPriceHistory({
+          assetId,
+          asOf: FIRST_UNSUPPORTED_PRICE_HISTORY_TIMESTAMP_SECONDS,
+        }),
+      ).toThrow(UserInputError);
     });
 
     it('walks normalized price history pages', async ({ publicClient }) => {
@@ -227,7 +234,6 @@ describe('Markets', () => {
       const paginator = publicClient.listPriceHistory({
         assetId,
         interval: PriceHistoryInterval.OneDay,
-        bucketSeconds: 60,
         pageSize: 2,
       });
 
@@ -264,7 +270,7 @@ describe('Markets', () => {
         expect(request.searchParams.get('token_id')).toBe(assetId);
         expect(request.searchParams.has('asset_id')).toBe(false);
         expect(request.searchParams.get('interval')).toBe('1d');
-        expect(request.searchParams.get('bucket_seconds')).toBe('60');
+        expect(request.searchParams.has('bucket_seconds')).toBe(false);
       }
       expect(requests[1]?.searchParams.get('cursor')).toBe(
         firstPage.nextCursor,

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -203,18 +203,18 @@ describe('Markets', () => {
     it('rejects invalid series windows before requesting them', ({
       publicClient,
     }) => {
-      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const assetId = expectPresent(market.outcomes.yes.tokenId);
 
       expect(() =>
         publicClient.listPriceHistory({
-          tokenId,
+          assetId,
           interval: PriceHistoryInterval.OneWeek,
           bucketSeconds: 60,
         }),
       ).toThrow(UserInputError);
       expect(() =>
         publicClient.listPriceHistory({
-          tokenId,
+          assetId,
           start: 1_700_000_000,
           end: 1_701_296_001,
         }),
@@ -222,10 +222,10 @@ describe('Markets', () => {
     });
 
     it('walks normalized price history pages', async ({ publicClient }) => {
-      const tokenId = expectPresent(market.outcomes.yes.tokenId);
+      const assetId = expectPresent(market.outcomes.yes.tokenId);
       const fetchSpy = vi.spyOn(globalThis, 'fetch');
       const paginator = publicClient.listPriceHistory({
-        tokenId,
+        assetId,
         interval: PriceHistoryInterval.OneDay,
         bucketSeconds: 60,
         pageSize: 2,
@@ -261,7 +261,8 @@ describe('Markets', () => {
 
       expect(requests).toHaveLength(2);
       for (const request of requests) {
-        expect(request.searchParams.get('token_id')).toBe(tokenId);
+        expect(request.searchParams.get('token_id')).toBe(assetId);
+        expect(request.searchParams.has('asset_id')).toBe(false);
         expect(request.searchParams.get('interval')).toBe('1d');
         expect(request.searchParams.get('bucket_seconds')).toBe('60');
       }

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -232,8 +232,6 @@ describe('Markets', () => {
       });
 
       const firstPage = await paginator.firstPage().then(expectNonEmptyPage);
-      expect(firstPage.hasMore).toBe(true);
-      expect(firstPage.nextCursor).toBeDefined();
 
       const firstPoint = firstPage.items[0];
       expect(firstPoint).toEqual(


### PR DESCRIPTION
## Summary
- replace legacy fetchPriceHistory with cursor-paginated listPriceHistory on the v2 data route
- expose strict interval, range, and as-of requests with normalized decimal prices and millisecond timestamps

## Validation
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- targeted live markets integration suite (14 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API and response shape will break integrators on the old CLOB price-history path; validation and pagination behavior are new contract surface area.
> 
> **Overview**
> **Breaking:** removes CLOB `fetchPriceHistory` and adds cursor-paginated **`listPriceHistory`** on the data **`/v2/prices-history`** route. Callers use `assetId` (sent as `token_id`), async pagination, and a stricter request shape.
> 
> Time selection is **exactly one** of: relative `interval` (including new `1m`), explicit `start`/`end` (≤15 days), or snapshot `asOf`. Optional **`bucketSeconds`** replaces `fidelity`, with per-interval minimums enforced client-side before the network call.
> 
> **`PriceHistoryPoint`** is normalized: millisecond `timestamp`, decimal-string `price`, and `resolutionSeconds`. Types and **`PriceHistoryInterval`** move from `@polymarket/bindings/clob` to **`@polymarket/bindings/data`**; the client exposes `listPriceHistory` on data actions and re-exports `PriceHistoryInterval` from markets actions. SDK direction doc now standardizes **`assetId`** for exchange assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 440544bb1f205b270e56b00ca72b90d23e1304aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->