### PR TITLE
feat(data): migrate holders to v2

### DIFF
--- a/.changeset/data-v2-holders.md
+++ b/.changeset/data-v2-holders.md
@@ -1,0 +1,6 @@
+---
+'@polymarket/bindings': minor
+'@polymarket/client': minor
+---
+
+**Breaking**: migrate `listMarketHolders` to its cursor-paginated `/v2` contract, using condition IDs, normalized holder fields, and optional position economics.

--- a/packages/bindings/src/data/analytics.ts
+++ b/packages/bindings/src/data/analytics.ts
@@ -56,58 +56,106 @@ export type ListPriceHistoryResponse = z.infer<
 >;
 
 export type Holder = {
-  wallet: EvmAddress | null | undefined;
+  wallet: EvmAddress;
   /** Outcome identifier for a CTF token or Polymarket V2 position. */
-  assetId: TokenId | PositionId | null | undefined;
+  assetId: TokenId | PositionId;
   /** @deprecated Use `assetId`. */
-  tokenId: TokenId | PositionId | null | undefined;
-  bio?: string | null;
-  pseudonym?: string | null;
-  amount?: DecimalString | null;
-  displayUsernamePublic?: boolean | null;
-  outcomeIndex?: number | null;
-  name?: string | null;
-  profileImage?: string | null;
-  profileImageOptimized?: string | null;
+  tokenId: TokenId | PositionId;
+  /** Holding in shares: net by default, per-side gross with PnL included. */
+  amount: DecimalString;
+  displayUsernamePublic: boolean;
+  outcomeIndex: number | null;
+  verified: boolean;
+  bio: string | null;
+  pseudonym: string | null;
+  name: string | null;
+  profileImage: string | null;
+  profileImageOptimized: string | null;
+  /** Historical entry price per share, when PnL is included. */
+  avgPrice?: DecimalString | null;
+  /** Fee-exclusive entry cost in USDC, when PnL is included. */
+  entryCostUsdc?: DecimalString | null;
+  /** Current outcome price, when PnL is included. */
+  currentPrice?: DecimalString | null;
+  /** Current holding value in USDC, when PnL is included. */
+  currentValue?: DecimalString | null;
+  /** Realized PnL in USDC, when PnL is included. */
+  realizedPnl?: DecimalString | null;
+  /** Unrealized PnL in USDC, when PnL is included. */
+  unrealizedPnl?: DecimalString | null;
+  /** Total PnL in USDC, when PnL is included. */
+  totalPnl?: DecimalString | null;
 };
+
+const NullableHolderTextSchema = z.preprocess(
+  (value) => (value === '' ? null : value),
+  z.string().nullable(),
+);
 
 export const HolderSchema = z
   .object({
-    proxyWallet: EvmAddressSchema.nullish(),
-    bio: z.string().nullish(),
-    asset: ClobAssetIdSchema.nullish(),
-    pseudonym: z.string().nullish(),
-    amount: DecimalishSchema.nullish(),
-    displayUsernamePublic: z.boolean().nullish(),
-    outcomeIndex: z.number().int().nullish(),
-    name: z.string().nullish(),
-    profileImage: z.string().nullish(),
-    profileImageOptimized: z.string().nullish(),
+    proxy_wallet: EvmAddressSchema,
+    bio: NullableHolderTextSchema,
+    token_id: ClobAssetIdSchema,
+    pseudonym: NullableHolderTextSchema,
+    amount: DecimalishSchema,
+    display_username_public: z.boolean(),
+    outcome_index: z.preprocess(
+      (value) => (value === 999 ? null : value),
+      z.number().int().nullable(),
+    ),
+    name: NullableHolderTextSchema,
+    profile_image: NullableHolderTextSchema,
+    profile_image_optimized: NullableHolderTextSchema,
+    verified: z.boolean(),
+    avg_price: DecimalishSchema.nullish(),
+    entry_cost_usdc: DecimalishSchema.nullish(),
+    current_price: DecimalishSchema.nullish(),
+    current_value: DecimalishSchema.nullish(),
+    realized_pnl: DecimalishSchema.nullish(),
+    unrealized_pnl: DecimalishSchema.nullish(),
+    total_pnl: DecimalishSchema.nullish(),
   })
-  .transform(({ asset, proxyWallet, ...rest }) => ({
-    ...rest,
-    wallet: proxyWallet,
-    assetId: asset,
-    tokenId: asset,
+  .transform((holder) => ({
+    wallet: holder.proxy_wallet,
+    assetId: holder.token_id,
+    tokenId: holder.token_id,
+    amount: holder.amount,
+    displayUsernamePublic: holder.display_username_public,
+    outcomeIndex: holder.outcome_index,
+    verified: holder.verified,
+    bio: holder.bio,
+    pseudonym: holder.pseudonym,
+    name: holder.name,
+    profileImage: holder.profile_image,
+    profileImageOptimized: holder.profile_image_optimized,
+    avgPrice: holder.avg_price,
+    entryCostUsdc: holder.entry_cost_usdc,
+    currentPrice: holder.current_price,
+    currentValue: holder.current_value,
+    realizedPnl: holder.realized_pnl,
+    unrealizedPnl: holder.unrealized_pnl,
+    totalPnl: holder.total_pnl,
   })) satisfies z.ZodType<Holder>;
 
 export type MetaHolder = {
   /** Outcome identifier for a CTF token or Polymarket V2 position. */
-  assetId: TokenId | PositionId | null | undefined;
+  assetId: TokenId | PositionId;
   /** @deprecated Use `assetId`. */
-  token: TokenId | PositionId | null | undefined;
-  holders?: Holder[] | null;
+  token: TokenId | PositionId;
+  /** Holders for this outcome, ordered by amount descending. */
+  holders: Holder[];
 };
 
 export const MetaHolderSchema = z
   .object({
-    token: ClobAssetIdSchema.nullish(),
-    holders: z.array(HolderSchema).nullish(),
+    token_id: ClobAssetIdSchema,
+    holders: z.array(HolderSchema),
   })
-  .transform(({ token, ...rest }) => ({
-    ...rest,
-    assetId: token,
-    token,
+  .transform(({ holders, token_id }) => ({
+    assetId: token_id,
+    token: token_id,
+    holders,
   })) satisfies z.ZodType<MetaHolder>;
 
 export type OpenInterest = {
@@ -161,7 +209,7 @@ export const LiveVolumeSchema = z
     takerVolumeTotal: taker_volume_total,
   })) satisfies z.ZodType<LiveVolume>;
 
-export const ListMarketHoldersResponseSchema = z.array(MetaHolderSchema);
+export const ListMarketHoldersResponseSchema = dataPageSchema(MetaHolderSchema);
 export const FetchOpenInterestResponseSchema = dataEnvelopeSchema(
   z.array(OpenInterestSchema),
 );

--- a/packages/client/src/actions/markets.test-d.ts
+++ b/packages/client/src/actions/markets.test-d.ts
@@ -1,4 +1,5 @@
 import {
+  type MetaHolder,
   PriceHistoryInterval,
   type PriceHistoryPoint,
 } from '@polymarket/bindings/data';
@@ -6,7 +7,11 @@ import type { Market } from '@polymarket/bindings/gamma';
 import { describe, expectTypeOf, it } from 'vitest';
 import type { DataActions } from '../decorators';
 import type { Paginated } from '../pagination';
-import type { ListPriceHistoryRequest, listPriceHistory } from './markets';
+import type {
+  ListPriceHistoryRequest,
+  listMarketHolders,
+  listPriceHistory,
+} from './markets';
 
 describe('price history request types', () => {
   it('accepts exactly one time selection', () => {
@@ -49,6 +54,14 @@ describe('price history request types', () => {
   });
 });
 
+describe('market holders request types', () => {
+  it('returns normalized pagination', () => {
+    expectTypeOf<ReturnType<typeof listMarketHolders>>().toEqualTypeOf<
+      Paginated<MetaHolder[]>
+    >();
+  });
+});
+
 function listMarketPriceHistory(actions: DataActions, market: Market) {
   const tokenId = market.outcomes.yes.tokenId;
 
@@ -63,3 +76,15 @@ function listMarketPriceHistory(actions: DataActions, market: Market) {
 }
 
 void listMarketPriceHistory;
+
+function listMarketHoldersForMarket(actions: DataActions, market: Market) {
+  if (market.conditionId === null) return;
+
+  expectTypeOf(
+    actions.listMarketHolders({
+      conditionIds: [market.conditionId],
+    }),
+  ).toEqualTypeOf<Paginated<MetaHolder[]>>();
+}
+
+void listMarketHoldersForMarket;

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -450,7 +450,8 @@ export const ListMarketHoldersError = makeErrorGuard(
  * `conditionIds` accepts up to 20 distinct market condition IDs. `pageSize`
  * defaults to 100 (max 1000) and applies separately to each outcome. Merge
  * matching `assetId` groups across pages rather than relying on array position.
- * `minBalance` is measured in shares and defaults to `0`.
+ * `minBalance` uses display shares and defaults to `0`; `1` means one share,
+ * equivalent to 1,000,000 base units.
  * Amounts are net holdings by default. `includePnl` switches to per-outcome
  * gross holdings and adds position economics; it requires one condition ID and
  * a page size of at most 100. Transient rate limits are retried automatically.

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -49,7 +49,6 @@ import {
   EpochSecondsLikeSchema,
   snakeCase,
   toDataSearchParams,
-  toLegacyDataSearchParams,
   toSearchParams,
 } from './params';
 
@@ -126,15 +125,6 @@ export type FetchMarketTagsRequest = z.input<
   typeof FetchMarketTagsRequestSchema
 >;
 
-const ListMarketHoldersRequestSchema = z.object({
-  limit: z.number().int().optional(),
-  market: z.array(z.string()),
-  minBalance: z.number().int().optional(),
-});
-
-export type ListMarketHoldersRequest = z.input<
-  typeof ListMarketHoldersRequestSchema
->;
 type ListMarketsParams = z.output<typeof ListMarketsRequestSchema>;
 
 export type ListMarketsError =
@@ -409,6 +399,37 @@ export async function fetchMarketTags(
   );
 }
 
+const ListMarketHoldersRequestSchema = z
+  .object({
+    conditionIds: distinctIdList(CanonicalMarketConditionIdSchema, 20),
+    cursor: PaginationCursorSchema.optional(),
+    includePnl: z.boolean().optional(),
+    minBalance: z.number().nonnegative().optional(),
+    pageSize: PageSizeSchema.max(1000).default(100),
+  })
+  .superRefine(({ conditionIds, includePnl, pageSize }, context) => {
+    if (!includePnl) return;
+
+    if (conditionIds.length !== 1) {
+      context.addIssue({
+        code: 'custom',
+        message: 'includePnl requires exactly one conditionId',
+        path: ['conditionIds'],
+      });
+    }
+
+    if (pageSize > 100) {
+      context.addIssue({
+        code: 'custom',
+        message: 'includePnl supports pageSize at most 100',
+        path: ['pageSize'],
+      });
+    }
+  });
+
+export type ListMarketHoldersRequest = z.input<
+  typeof ListMarketHoldersRequestSchema
+>;
 export type ListMarketHoldersError =
   | RateLimitError
   | RequestRejectedError
@@ -424,7 +445,14 @@ export const ListMarketHoldersError = makeErrorGuard(
 );
 
 /**
- * Lists the top holders for one or more markets.
+ * Lists top holders grouped by outcome for one or more markets.
+ *
+ * `conditionIds` accepts up to 20 distinct market condition IDs. `pageSize`
+ * defaults to 100 (max 1000) and applies separately to each outcome. Merge
+ * matching `assetId` groups across pages rather than relying on array position.
+ * Amounts are net holdings by default. `includePnl` switches to per-outcome
+ * gross holdings and adds position economics; it requires one condition ID and
+ * a page size of at most 100. Transient rate limits are retried automatically.
  *
  * @remarks
  * This is a low-level function. Most SDK consumers should prefer the client instance API.
@@ -434,26 +462,37 @@ export const ListMarketHoldersError = makeErrorGuard(
  *
  * @example
  * ```ts
- * const holders = await listMarketHolders(client, {
- *   market: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
- *   limit: 5,
+ * const result = listMarketHolders(client, {
+ *   conditionIds: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
+ *   pageSize: 5,
  * });
  *
- * // holders: MetaHolder[]
+ * for await (const page of result) {
+ *   // page.items: MetaHolder[]
+ * }
  * ```
  */
-export async function listMarketHolders(
+export function listMarketHolders(
   client: BaseClient,
   request: ListMarketHoldersRequest,
-): Promise<MetaHolder[]> {
-  const params = parseUserInput(request, ListMarketHoldersRequestSchema);
+): Paginated<MetaHolder[]> {
+  const { conditionIds, cursor, includePnl, minBalance, pageSize } =
+    parseUserInput(request, ListMarketHoldersRequestSchema);
 
-  return unwrap(
-    client.data
-      .get('/holders', {
-        params: toLegacyDataSearchParams(params),
-      })
-      .andThen(validateWith(ListMarketHoldersResponseSchema)),
+  return paginate(
+    (cursor) =>
+      withRateLimitRetry(() =>
+        client.data.get('/v2/holders', {
+          params: toDataSearchParams({
+            condition: conditionIds,
+            limit: pageSize,
+            cursor,
+            includePnl,
+            minBalance,
+          }),
+        }),
+      ).andThen(validateWith(ListMarketHoldersResponseSchema)),
+    cursor,
   );
 }
 

--- a/packages/client/src/actions/markets.ts
+++ b/packages/client/src/actions/markets.ts
@@ -450,6 +450,7 @@ export const ListMarketHoldersError = makeErrorGuard(
  * `conditionIds` accepts up to 20 distinct market condition IDs. `pageSize`
  * defaults to 100 (max 1000) and applies separately to each outcome. Merge
  * matching `assetId` groups across pages rather than relying on array position.
+ * `minBalance` is measured in shares and defaults to `0`.
  * Amounts are net holdings by default. `includePnl` switches to per-outcome
  * gross holdings and adds position economics; it requires one condition ID and
  * a page size of at most 100. Transient rate limits are retried automatically.

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -304,20 +304,31 @@ export type DataActions = {
     request?: FetchOpenInterestRequest,
   ): Promise<OpenInterest[]>;
   /**
-   * Lists the top holders for one or more markets.
+   * Lists top holders grouped by outcome for one or more markets.
+   *
+   * `conditionIds` accepts up to 20 distinct market condition IDs. `pageSize`
+   * defaults to 100 (max 1000) and applies separately to each outcome. Merge
+   * matching `assetId` groups across pages rather than relying on array position.
+   * Amounts are net holdings by default. `includePnl` switches to per-outcome
+   * gross holdings and adds position economics; it requires one condition ID and
+   * a page size of at most 100. Transient rate limits are retried automatically.
    *
    * @throws {@link ListMarketHoldersError}
    * Thrown on failure.
    *
    * @example
    * ```ts
-   * const holders = await client.listMarketHolders({
-   *   market: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
-   *   limit: 5,
+   * const result = client.listMarketHolders({
+   *   conditionIds: ['0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093'],
+   *   pageSize: 5,
    * });
+   *
+   * for await (const page of result) {
+   *   // page.items: MetaHolder[]
+   * }
    * ```
    */
-  listMarketHolders(request: ListMarketHoldersRequest): Promise<MetaHolder[]>;
+  listMarketHolders(request: ListMarketHoldersRequest): Paginated<MetaHolder[]>;
   /**
    * Lists trades for a wallet, market, or event — or the global recent-trades
    * feed when no filter is given.

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -309,6 +309,7 @@ export type DataActions = {
    * `conditionIds` accepts up to 20 distinct market condition IDs. `pageSize`
    * defaults to 100 (max 1000) and applies separately to each outcome. Merge
    * matching `assetId` groups across pages rather than relying on array position.
+   * `minBalance` is measured in shares and defaults to `0`.
    * Amounts are net holdings by default. `includePnl` switches to per-outcome
    * gross holdings and adds position economics; it requires one condition ID and
    * a page size of at most 100. Transient rate limits are retried automatically.

--- a/packages/client/src/decorators/data.ts
+++ b/packages/client/src/decorators/data.ts
@@ -309,7 +309,8 @@ export type DataActions = {
    * `conditionIds` accepts up to 20 distinct market condition IDs. `pageSize`
    * defaults to 100 (max 1000) and applies separately to each outcome. Merge
    * matching `assetId` groups across pages rather than relying on array position.
-   * `minBalance` is measured in shares and defaults to `0`.
+   * `minBalance` uses display shares and defaults to `0`; `1` means one share,
+   * equivalent to 1,000,000 base units.
    * Amounts are net holdings by default. `includePnl` switches to per-outcome
    * gross holdings and adds position economics; it requires one condition ID and
    * a page size of at most 100. Transient rate limits are retried automatically.

--- a/packages/client/tests/integration/data-pagination.test.ts
+++ b/packages/client/tests/integration/data-pagination.test.ts
@@ -1,11 +1,5 @@
 import { OrderSide } from '@polymarket/bindings';
-import { dataEnvelopeSchema } from '@polymarket/bindings/data';
-import { unwrap } from '@polymarket/types';
-import { z } from 'zod';
 import { describe, expect, it } from './fixtures';
-
-// A wallet shape that is valid but cannot correspond to a real account.
-const UNKNOWN_WALLET = '0x00000000000000000000000000000000000000aa';
 
 describe('Data pagination', () => {
   it('walks consecutive pages with for await and re-sends filters', async ({
@@ -64,42 +58,5 @@ describe('Data pagination', () => {
     expect(firstOfSecond?.timestamp).toBeLessThanOrEqual(
       lastOfFirst?.timestamp ?? 0,
     );
-  });
-});
-
-/**
- * Envelope-level coverage for v2 surfaces that have no public action yet.
- * Each block below folds into its action's integration test as the
- * corresponding endpoint lands in the SDK.
- */
-describe('Data envelope', () => {
-  it('unwraps a single-object envelope to the payload', async ({
-    publicClient,
-  }) => {
-    const response = await unwrap(publicClient.data.get('v2/oi'));
-
-    const markets = dataEnvelopeSchema(
-      z.array(
-        z.object({ condition_id: z.string(), value: z.number() }).loose(),
-      ),
-    ).parse(await response.json());
-
-    expect(markets.length).toBeGreaterThan(0);
-  });
-
-  it('keeps a null answer parsed rather than failing validation', async ({
-    publicClient,
-  }) => {
-    const response = await unwrap(
-      publicClient.data.get('v2/user-stats', {
-        params: new URLSearchParams({ user: UNKNOWN_WALLET }),
-      }),
-    );
-
-    const stats = dataEnvelopeSchema(
-      z.object({ trades: z.number().int() }).loose().nullable(),
-    ).parse(await response.json());
-
-    expect(stats).toBeNull();
   });
 });

--- a/packages/client/tests/integration/markets.test.ts
+++ b/packages/client/tests/integration/markets.test.ts
@@ -10,6 +10,10 @@ import { describe, environment, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
+const HOLDERS_CONDITION_ID =
+  '0xe546672750517f62c45a5a00067481981e62b9c20fa8220203232c9dc8fd2093';
+const OTHER_CONDITION_ID =
+  '0x0000000000000000000000000000000000000000000000000000000000000000';
 const publicClient = createPublicClient({ environment });
 
 const {
@@ -183,19 +187,85 @@ describe('Markets', () => {
   });
 
   describe('listMarketHolders', () => {
-    it('lists top holders for a market', async ({ publicClient }) => {
-      const result = await publicClient.listMarketHolders({
-        market: [positionConditionId],
-        limit: 1,
+    it('walks normalized holder pages with position economics', async ({
+      publicClient,
+    }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+      const paginator = publicClient.listMarketHolders({
+        conditionIds: [HOLDERS_CONDITION_ID],
+        includePnl: true,
+        minBalance: 0,
+        pageSize: 1,
       });
+      const firstPage = await paginator.firstPage().then(expectNonEmptyPage);
+      const firstGroup = firstPage.items[0];
+      const firstHolder = expectPresent(firstGroup.holders[0]);
 
-      expect(result.length).toBeGreaterThan(0);
-      expect(result[0]).toEqual(
+      expect(firstGroup).toEqual(
         expect.objectContaining({
+          assetId: expect.any(String),
           holders: expect.any(Array),
           token: expect.any(String),
         }),
       );
+      expect(firstHolder).toEqual(
+        expect.objectContaining({
+          amount: expect.any(String),
+          assetId: firstGroup.assetId,
+          avgPrice: expect.any(String),
+          currentPrice: expect.any(String),
+          currentValue: expect.any(String),
+          entryCostUsdc: expect.any(String),
+          realizedPnl: expect.any(String),
+          totalPnl: expect.any(String),
+          unrealizedPnl: expect.any(String),
+          verified: expect.any(Boolean),
+          wallet: expect.any(String),
+        }),
+      );
+
+      await paginator
+        .from(firstPage.nextCursor)
+        .firstPage()
+        .then(expectNonEmptyPage);
+
+      const requests = fetchSpy.mock.calls
+        .map(([input]) =>
+          input instanceof Request ? input.url : String(input),
+        )
+        .filter((url) => new URL(url).pathname === '/v2/holders')
+        .map((url) => new URL(url).searchParams);
+
+      expect(requests).toHaveLength(2);
+      for (const request of requests) {
+        expect(request.get('condition')).toBe(HOLDERS_CONDITION_ID);
+        expect(request.get('include_pnl')).toBe('true');
+        expect(request.get('limit')).toBe('1');
+        expect(request.get('min_balance')).toBe('0');
+        expect(request.has('market')).toBe(false);
+      }
+      expect(requests[0]?.has('cursor')).toBe(false);
+      expect(requests[1]?.get('cursor')).toBe(firstPage.nextCursor);
+    });
+
+    it('rejects invalid PnL requests before transport', ({ publicClient }) => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      expect(() =>
+        publicClient.listMarketHolders({
+          conditionIds: [HOLDERS_CONDITION_ID, OTHER_CONDITION_ID],
+          includePnl: true,
+        }),
+      ).toThrow(UserInputError);
+      expect(() =>
+        publicClient.listMarketHolders({
+          conditionIds: [HOLDERS_CONDITION_ID],
+          includePnl: true,
+          pageSize: 101,
+        }),
+      ).toThrow(UserInputError);
+
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/client/tests/integration/portfolio.test.ts
+++ b/packages/client/tests/integration/portfolio.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from './fixtures';
 import { expectNonEmptyPage, expectPageWindow } from './helpers';
 
 const TEST_USER = '0x7c3db723f1d4d8cb9c550095203b686cb11e5c6b';
+const UNKNOWN_WALLET = '0x00000000000000000000000000000000000000aa';
 const TEST_CONDITION_ID =
   '0x7ad403c3508f8e3912940fd1a913f227591145ca0614074208e0b962d5fcc422';
 
@@ -263,6 +264,14 @@ describe('Portfolio', () => {
           tradeCount: expect.any(Number),
         }),
       );
+    });
+
+    it('keeps an unknown user as null', async ({ publicClient }) => {
+      const result = await publicClient.fetchUserStats({
+        user: UNKNOWN_WALLET,
+      });
+
+      expect(result).toBeNull();
     });
 
     it('defaults secure clients to the authenticated wallet', async ({


### PR DESCRIPTION
## Summary
- migrate `listMarketHolders` to `/v2/holders` with normalized cursor pagination and PnL-mode validation
- normalize holder identifiers, decimals, and wire sentinels in bindings
- update existing Data API integration tests to use public SDK actions
- stack on #348

## Validation
- `pnpm -r --sort --if-present run build`; `pnpm lint`; `pnpm typecheck`
- affected live integration tests: 30 passed, 6 credential-gated skips