### PR TITLE
fix(client): include EIP712Domain types in signing payloads

### DIFF
--- a/.changeset/tidy-domains-sign.md
+++ b/.changeset/tidy-domains-sign.md
@@ -1,0 +1,5 @@
+---
+'@polymarket/client': patch
+---
+
+Include explicit EIP712Domain types in authentication, deposit wallet order and batch, and Perps signing payloads for wallets that require complete typed data.

--- a/packages/client/src/actions/gasless.ts
+++ b/packages/client/src/actions/gasless.ts
@@ -823,13 +823,15 @@ function toDepositWalletCall(call: TransactionCall): DepositWalletCall {
 function createDepositWalletBatchTypedDataPayload(
   request: CreateDepositWalletBatchTypedDataPayloadRequest,
 ): TypedDataPayload {
+  const domain = {
+    chainId: request.chainId,
+    name: DEPOSIT_WALLET_DOMAIN_NAME,
+    verifyingContract: request.wallet,
+    version: DEPOSIT_WALLET_DOMAIN_VERSION,
+  };
+
   return {
-    domain: {
-      chainId: request.chainId,
-      name: DEPOSIT_WALLET_DOMAIN_NAME,
-      verifyingContract: request.wallet,
-      version: DEPOSIT_WALLET_DOMAIN_VERSION,
-    },
+    domain,
     message: {
       calls: request.calls.map((call) => ({
         data: call.data,
@@ -844,6 +846,7 @@ function createDepositWalletBatchTypedDataPayload(
     types: {
       Batch: DEPOSIT_WALLET_BATCH,
       Call: DEPOSIT_WALLET_CALL,
+      EIP712Domain: OxTypedData.extractEip712DomainTypes(domain),
     },
   };
 }

--- a/packages/client/src/actions/orders/typed-data.test.ts
+++ b/packages/client/src/actions/orders/typed-data.test.ts
@@ -1,6 +1,7 @@
 import { OrderSide, OrderType, toTokenId } from '@polymarket/bindings';
 import { SignatureType } from '@polymarket/bindings/clob';
 import type { EvmAddress, EvmSignature, HexString } from '@polymarket/types';
+import { TypedData } from 'ox';
 import { describe, expect, it } from 'vitest';
 import { ExchangeOrderProtocolVersion } from '../../exchange';
 import {
@@ -38,6 +39,19 @@ describe('createOrderTypedDataPayload', () => {
       version: '1',
     });
     expect(payload.primaryType).toBe('TypedDataSign');
+    const { EIP712Domain, ...types } = payload.types;
+    expect(EIP712Domain).toEqual([
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ]);
+    expect(TypedData.getSignPayload(payload)).toBe(
+      TypedData.getSignPayload({
+        ...payload,
+        types,
+      }),
+    );
   });
 
   it('signs non-POLY_1271 orders directly against the app domain', () => {

--- a/packages/client/src/actions/perps.ts
+++ b/packages/client/src/actions/perps.ts
@@ -44,7 +44,7 @@ import {
   type PrivateKey,
   unwrap,
 } from '@polymarket/types';
-import { Address, Secp256k1 } from 'ox';
+import { Address, Secp256k1, TypedData } from 'ox';
 import { z } from 'zod';
 import { MAX_UINT256, perpsDepositCall } from '../abis';
 import type { BaseClient, BaseSecureClient } from '../clients';
@@ -1553,13 +1553,15 @@ type CreatePerpsWithdrawTypedDataPayloadRequest =
 function createPerpsWithdrawTypedDataPayload(
   request: CreatePerpsWithdrawTypedDataPayloadRequest,
 ): TypedDataPayload {
+  const domain = {
+    chainId: request.chainId,
+    name: 'Polymarket',
+    verifyingContract: request.contract,
+    version: '1',
+  };
+
   return {
-    domain: {
-      chainId: request.chainId,
-      name: 'Polymarket',
-      verifyingContract: request.contract,
-      version: '1',
-    },
+    domain,
     message: {
       account: request.account,
       amount: request.amount,
@@ -1571,6 +1573,7 @@ function createPerpsWithdrawTypedDataPayload(
     },
     primaryType: 'Withdraw',
     types: {
+      EIP712Domain: TypedData.extractEip712DomainTypes(domain),
       Withdraw: [
         { name: 'account', type: 'address' },
         { name: 'token', type: 'address' },
@@ -1592,12 +1595,14 @@ type CreatePerpsCreateProxyTypedDataPayloadRequest =
 function createPerpsCreateProxyTypedDataPayload(
   request: CreatePerpsCreateProxyTypedDataPayloadRequest,
 ): TypedDataPayload {
+  const domain = {
+    chainId: request.chainId,
+    name: 'Polymarket',
+    version: '1',
+  };
+
   return {
-    domain: {
-      chainId: request.chainId,
-      name: 'Polymarket',
-      version: '1',
-    },
+    domain,
     message: {
       addr: request.proxy,
       exp: request.expiresAt,
@@ -1612,6 +1617,7 @@ function createPerpsCreateProxyTypedDataPayload(
         { name: 'salt', type: 'uint64' },
         { name: 'ts', type: 'uint64' },
       ],
+      EIP712Domain: TypedData.extractEip712DomainTypes(domain),
     },
   };
 }

--- a/packages/client/src/authentication.ts
+++ b/packages/client/src/authentication.ts
@@ -1,4 +1,5 @@
 import type { EvmAddress } from '@polymarket/types';
+import { TypedData } from 'ox';
 import type { TypedDataPayload } from './types';
 
 /** @internal */
@@ -13,12 +14,14 @@ export type CreateApiKeyAuthTypedDataPayloadRequest = {
 export function createApiKeyAuthTypedDataPayload(
   request: CreateApiKeyAuthTypedDataPayloadRequest,
 ): TypedDataPayload {
+  const domain = {
+    chainId: request.chainId,
+    name: 'ClobAuthDomain',
+    version: '1',
+  };
+
   return {
-    domain: {
-      chainId: request.chainId,
-      name: 'ClobAuthDomain',
-      version: '1',
-    },
+    domain,
     message: {
       address: request.address,
       message: 'This message attests that I control the given wallet',
@@ -27,6 +30,7 @@ export function createApiKeyAuthTypedDataPayload(
     },
     primaryType: 'ClobAuth',
     types: {
+      EIP712Domain: TypedData.extractEip712DomainTypes(domain),
       ClobAuth: [
         { name: 'address', type: 'address' },
         { name: 'timestamp', type: 'string' },

--- a/packages/client/src/exchange.ts
+++ b/packages/client/src/exchange.ts
@@ -139,6 +139,7 @@ export function createExchangeOrderTypedDataPayload(
     },
     primaryType: 'TypedDataSign',
     types: {
+      EIP712Domain: EIP712_DOMAIN,
       Order: ORDER_STRUCTURE,
       TypedDataSign: TYPED_DATA_SIGN_STRUCTURE,
     },

--- a/packages/client/src/viem.test.ts
+++ b/packages/client/src/viem.test.ts
@@ -1,5 +1,8 @@
+import { Wallet } from 'ethers-v5';
 import { describe, expect, it } from 'vitest';
+import { createApiKeyAuthTypedDataPayload } from './authentication';
 import { UserInputError } from './errors';
+import { signerFrom } from './ethers-v5';
 import { privateKey } from './viem';
 
 const TEST_PRIVATE_KEY =
@@ -32,6 +35,32 @@ describe('viem', () => {
           },
         }),
       ).resolves.toMatch(/^0x[0-9a-f]+$/i);
+    });
+
+    it('signs explicit authentication domains consistently across wallet adapters', async () => {
+      const signer = privateKey(TEST_PRIVATE_KEY);
+      const payload = createApiKeyAuthTypedDataPayload({
+        address: await signer.getAddress(),
+        chainId: 137,
+        timestamp: 1_739_491_200,
+      });
+
+      const { EIP712Domain, ...types } = payload.types;
+      expect(EIP712Domain).toEqual([
+        { name: 'name', type: 'string' },
+        { name: 'version', type: 'string' },
+        { name: 'chainId', type: 'uint256' },
+      ]);
+      const signature = await signer.signTypedData(payload);
+      await expect(
+        signer.signTypedData({
+          ...payload,
+          types,
+        }),
+      ).resolves.toBe(signature);
+      await expect(
+        signerFrom(new Wallet(TEST_PRIVATE_KEY)).signTypedData(payload),
+      ).resolves.toBe(signature);
     });
 
     it('rejects invalid private keys', () => {

--- a/packages/client/src/websockets/perps/actions/trading.test.ts
+++ b/packages/client/src/websockets/perps/actions/trading.test.ts
@@ -1,5 +1,6 @@
 import { OrderSide } from '@polymarket/bindings';
 import { PerpsTimeInForce } from '@polymarket/bindings/perps';
+import { TypedData } from 'ox';
 import { describe, expect, it } from 'vitest';
 import { createPerpsOpTypedDataPayload } from '../signing';
 import {
@@ -31,6 +32,18 @@ describe('Perps trading actions', () => {
             salt: 1n,
             ts: 1_739_491_200_000n,
           });
+          const { EIP712Domain, ...types } = payload.types;
+          expect(EIP712Domain).toEqual([
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+          ]);
+          expect(TypedData.getSignPayload(payload)).toBe(
+            TypedData.getSignPayload({
+              ...payload,
+              types,
+            }),
+          );
           expect(toPerpsCommandBodyOp(request.op)).toEqual({
             args: [
               {

--- a/packages/client/src/websockets/perps/signing.ts
+++ b/packages/client/src/websockets/perps/signing.ts
@@ -60,12 +60,14 @@ export function signPerpsOp(request: SignPerpsOpRequest): EvmSignature {
 export function createPerpsOpTypedDataPayload(
   request: CreatePerpsOpTypedDataPayloadRequest,
 ): TypedDataPayload {
+  const domain = {
+    chainId: request.chainId,
+    name: 'Polymarket',
+    version: '1',
+  };
+
   return {
-    domain: {
-      chainId: request.chainId,
-      name: 'Polymarket',
-      version: '1',
-    },
+    domain,
     message: {
       data: Hash.keccak256(encode(compactSignableValue(request.op)), {
         as: 'Hex',
@@ -75,6 +77,7 @@ export function createPerpsOpTypedDataPayload(
     },
     primaryType: 'Op',
     types: {
+      EIP712Domain: TypedData.extractEip712DomainTypes(domain),
       Op: [
         { name: 'data', type: 'bytes32' },
         { name: 'salt', type: 'uint64' },


### PR DESCRIPTION
Include `types.EIP712Domain` in ClobAuth, POLY_1271 TypedDataSign, Batch, Withdraw, CreateProxy, and Op payloads so wallets receive complete typed data. Derive fields from each domain or reuse the existing exchange schema. Includes a patch changeset and regression coverage for unchanged hashes and viem/ethers v5 signatures.

Validated: `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` (558 tests), and changeset status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and multiple signing flows; behavior is intended to be hash-equivalent but any wallet or adapter mismatch could block signing until verified in production wallets.
> 
> **Overview**
> Adds explicit **`types.EIP712Domain`** to EIP-712 signing payloads across the client so wallets that require full typed-data schemas accept them without changing digests.
> 
> **Clob API auth** (`createApiKeyAuthTypedDataPayload`), **deposit wallet batch** gasless signing, **POLY_1271** exchange `TypedDataSign` orders, and **Perps** withdraw, create-proxy, and websocket **Op** payloads now include domain field definitions—mostly via `TypedData.extractEip712DomainTypes(domain)`, with the exchange path reusing the existing `EIP712_DOMAIN` constant.
> 
> Regression tests assert the expected `EIP712Domain` shape, unchanged `TypedData.getSignPayload` hashes when the entry is omitted vs included, and matching signatures between viem and ethers v5 for auth. Ships as a **patch** changeset for `@polymarket/client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43409a7200892d25e47a014e5114f1fcda9637be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->